### PR TITLE
Open an edit view to a form using a direct URL

### DIFF
--- a/src/cljs/lomake_editori/core.cljs
+++ b/src/cljs/lomake_editori/core.cljs
@@ -19,5 +19,4 @@
 (defn ^:export init []
   (routes/app-routes)
   (re-frame/dispatch-sync [:initialize-db])
-  (re-frame/dispatch [:fetch-initial-data])
   (mount-root))

--- a/src/cljs/lomake_editori/handlers.cljs
+++ b/src/cljs/lomake_editori/handlers.cljs
@@ -10,7 +10,7 @@
 
 (def formatter (f/formatter "EEEE dd.MM.yyyy HH:mm"))
 
-(defn http [method path handler-or-dispatch & {:keys [override-args]}]
+(defn http [method path handler-or-dispatch & {:keys [override-args handler-args]}]
   (let [f (case method
             :get    GET
             :post   POST
@@ -41,8 +41,8 @@
                                                               [:delete] "Tiedot poistettu"
                                                               :else nil)}])
                                   (match [handler-or-dispatch]
-                                         [(dispatch-keyword :guard keyword?)] (dispatch [dispatch-keyword response])
-                                         :else (dispatch [:state-update (fn [db] (handler-or-dispatch db response))])))}
+                                         [(dispatch-keyword :guard keyword?)] (dispatch [dispatch-keyword response handler-args])
+                                         :else (dispatch [:state-update (fn [db] (handler-or-dispatch db response handler-args))])))}
               override-args))))
 
 (defn post [path params handler-or-dispatch]

--- a/src/cljs/lomake_editori/handlers.cljs
+++ b/src/cljs/lomake_editori/handlers.cljs
@@ -10,7 +10,7 @@
 
 (def formatter (f/formatter "EEEE dd.MM.yyyy HH:mm"))
 
-(defn http [method path handler-or-dispatch & [override-args]]
+(defn http [method path handler-or-dispatch & {:keys [override-args]}]
   (let [f (case method
             :get    GET
             :post   POST
@@ -46,7 +46,7 @@
               override-args))))
 
 (defn post [path params handler-or-dispatch]
-  (http :post path handler-or-dispatch {:params params}))
+  (http :post path handler-or-dispatch :override-args {:params params}))
 
 (register-handler
  :initialize-db

--- a/src/cljs/lomake_editori/handlers.cljs
+++ b/src/cljs/lomake_editori/handlers.cljs
@@ -76,12 +76,6 @@
     (assoc db :error-message "Lomakelistan hakeminen epäonnistui")))
 
 (register-handler
-  :fetch-initial-data
-  (fn [db _]
-    (dispatch [:editor/refresh-forms])
-    db))
-
-(register-handler
  :set-active-panel
  (fn [db [_ active-panel]]
    (assoc db :active-panel active-panel)))

--- a/src/cljs/lomake_editori/routes.cljs
+++ b/src/cljs/lomake_editori/routes.cljs
@@ -30,6 +30,10 @@
     (dispatch [:set-active-panel :editor])
     (dispatch [:editor/refresh-forms]))
 
+  (defroute #"/editor/forms/(\d+)" [id]
+    (dispatch [:set-active-panel :editor])
+    (dispatch [:editor/refresh-forms (js/parseInt id)]))
+
   (defroute "/application" []
     (dispatch [:set-active-panel :application]))
 


### PR DESCRIPTION
User can now open an edit view to a specific form using a direct URL. The URL is like `/lomake-editori/#/editor/forms/:id` where `:id` is the ID of the form that should be shown to the user.