### PR TITLE
Set logging timestamp to ISO8601 in UTC

### DIFF
--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=INFO, ApplicationLog
 
 log4j.appender.ApplicationLog=org.apache.log4j.ConsoleAppender
-log4j.appender.ApplicationLog.layout=org.apache.log4j.PatternLayout
-log4j.appender.ApplicationLog.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c: %m%n
+log4j.appender.ApplicationLog.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.ApplicationLog.layout.ConversionPattern=%d{yyyy-MM-dd'T'HH:mm:ss.SSSX}{GMT} %-5p [%t] %c: %m%n


### PR DESCRIPTION
Change application log timestamp to unified format to make life easier for the log crawler.