### PR TITLE
Functionality to add arbitrary form elements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -90,7 +90,7 @@
   :main lomake-editori.system
 
   :cljsbuild {:builds [{:id "dev"
-                        :source-paths ["src/cljs"]
+                        :source-paths ["src/cljs" "src/cljc"]
                         :figwheel {:on-jsload "lomake-editori.core/mount-root"}
                         :compiler {:main lomake-editori.core
                                    :output-to "resources/public/js/compiled/app.js"
@@ -101,7 +101,7 @@
                                    :source-map-timestamp true}}
 
                        {:id "test"
-                        :source-paths ["src/cljs" "test/cljs"]
+                        :source-paths ["src/cljs" "test/cljs" "src/cljc"]
                         :compiler {:output-to "resources/public/js/test/test.js"
                                    :output-dir "resources/public/js/test/out"
                                    :asset-path "js/test/out"
@@ -111,7 +111,7 @@
                                    :optimizations :none}}
 
                        {:id "min"
-                        :source-paths ["src/cljs"]
+                        :source-paths ["src/cljs" "src/cljc"]
                         :compiler {:main lomake-editori.core
                                    :output-to "resources/public/js/compiled/app.js"
                                    :optimizations :advanced

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [cljs-ajax "0.5.4"]
 
                  ;clojure/clojurescript
-                 [prismatic/schema "1.0.5"]
+                 [prismatic/schema "1.1.1"]
                  [com.taoensso/timbre "4.3.1"]
                  [org.clojure/core.async "0.2.374"]
                  [org.clojure/core.match "0.3.0-alpha4"]

--- a/spec/lomake_editori/soresu/component_spec.clj
+++ b/spec/lomake_editori/soresu/component_spec.clj
@@ -6,8 +6,21 @@
 
 (soresu/create-form-schema [] [] [])
 
+(s/defschema TemporaryWrapperElementSchema
+  {:fieldClass                (s/eq "wrapperElement")
+   :id                        s/Str
+   :fieldType                 (s/eq "fieldset")
+   :children                  [s/Any]
+   (s/optional-key :params)   s/Any
+   (s/optional-key :label)    soresu/LocalizedString
+   (s/optional-key :helpText) soresu/LocalizedString})
+
 (describe "text-field"
   (it "should be validated with soresu-form schema"
     (should (s/validate soresu/FormField (component/text-field)))))
+
+(describe "form-section"
+  (it "should be validated with soresu-form schema"
+    (should (s/validate TemporaryWrapperElementSchema (component/form-section)))))
 
 (run-specs)

--- a/spec/lomake_editori/soresu/component_spec.clj
+++ b/spec/lomake_editori/soresu/component_spec.clj
@@ -6,21 +6,12 @@
 
 (soresu/create-form-schema [] [] [])
 
-(s/defschema TemporaryWrapperElementSchema
-  {:fieldClass                (s/eq "wrapperElement")
-   :id                        s/Str
-   :fieldType                 (s/eq "fieldset")
-   :children                  [s/Any]
-   (s/optional-key :params)   s/Any
-   (s/optional-key :label)    soresu/LocalizedString
-   (s/optional-key :helpText) soresu/LocalizedString})
-
 (describe "text-field"
   (it "should be validated with soresu-form schema"
     (should (s/validate soresu/FormField (component/text-field)))))
 
 (describe "form-section"
   (it "should be validated with soresu-form schema"
-    (should (s/validate TemporaryWrapperElementSchema (component/form-section)))))
+    (should (s/validate soresu/WrapperElement (component/form-section)))))
 
 (run-specs)

--- a/src/cljc/lomake_editori/soresu/component.cljc
+++ b/src/cljc/lomake_editori/soresu/component.cljc
@@ -15,4 +15,5 @@
   {:fieldClass "wrapperElement"
    :fieldType  "fieldset"
    :id         (str (gensym))
+   :label      "Osion nimi"
    :children   []})

--- a/src/cljc/lomake_editori/soresu/component.cljc
+++ b/src/cljc/lomake_editori/soresu/component.cljc
@@ -4,7 +4,7 @@
   []
   {:fieldClass "formField"
    :label      {:fi "Tekstikenttä", :sv "Textfält"}
-   :id         (str gensym)
+   :id         (str (gensym))
    :required   true
    :fieldType  "textField"
    :helpText   {:fi "Aputeksti"
@@ -14,5 +14,5 @@
   []
   {:fieldClass "wrapperElement"
    :fieldType  "fieldset"
-   :id         (str gensym)
+   :id         (str (gensym))
    :children   []})

--- a/src/cljc/lomake_editori/soresu/component.cljc
+++ b/src/cljc/lomake_editori/soresu/component.cljc
@@ -9,3 +9,10 @@
    :fieldType  "textField"
    :helpText   {:fi "Aputeksti"
                 :sv "Hjälptext"}})
+
+(defn form-section
+  []
+  {:fieldClass "wrapperElement"
+   :fieldType  "fieldset"
+   :id         "form-section"
+   :children   []})

--- a/src/cljc/lomake_editori/soresu/component.cljc
+++ b/src/cljc/lomake_editori/soresu/component.cljc
@@ -15,5 +15,5 @@
   {:fieldClass "wrapperElement"
    :fieldType  "fieldset"
    :id         (str (gensym))
-   :label      "Osion nimi"
+   :label      {:fi "Osion nimi" :sv "Avsnitt namn"}
    :children   []})

--- a/src/cljc/lomake_editori/soresu/component.cljc
+++ b/src/cljc/lomake_editori/soresu/component.cljc
@@ -4,7 +4,7 @@
   []
   {:fieldClass "formField"
    :label      {:fi "Tekstikenttä", :sv "Textfält"}
-   :id         "applicant-surname"
+   :id         (str gensym)
    :required   true
    :fieldType  "textField"
    :helpText   {:fi "Aputeksti"
@@ -14,5 +14,5 @@
   []
   {:fieldClass "wrapperElement"
    :fieldType  "fieldset"
-   :id         "form-section"
+   :id         (str gensym)
    :children   []})

--- a/src/cljs/lomake_editori/editor/core.cljs
+++ b/src/cljs/lomake_editori/editor/core.cljs
@@ -89,7 +89,7 @@
 
 (def toolbar-elements
   (let [dummy [:div "ei vielä toteutettu.."]]
-    {"Lomakeosio"                dummy
+    {"Lomakeosio"                component/form-section
      "Tekstikenttä"              component/text-field
      "Tekstialue"                dummy
      "Lista, monta valittavissa" dummy

--- a/src/cljs/lomake_editori/editor/core.cljs
+++ b/src/cljs/lomake_editori/editor/core.cljs
@@ -90,16 +90,16 @@
 (def toolbar-elements
   (let [dummy [:div "ei vielä toteutettu.."]]
     {"Lomakeosio"                component/form-section
-     "Tekstikenttä"              component/text-field
-     "Tekstialue"                dummy
-     "Lista, monta valittavissa" dummy
-     "Lista, yksi valittavissa"  dummy
-     "Pudotusvalikko"            dummy
-     "Vierekkäiset kentät"       dummy
-     "Liitetiedosto"             dummy
-     "Ohjeteksti"                info
-     "Linkki"                    link-info
-     "Väliotsikko"               dummy}))
+     "Tekstikenttä"              component/text-field}))
+     ;"Tekstialue"                dummy
+     ;"Lista, monta valittavissa" dummy
+     ;"Lista, yksi valittavissa"  dummy
+     ;"Pudotusvalikko"            dummy
+     ;"Vierekkäiset kentät"       dummy
+     ;"Liitetiedosto"             dummy
+     ;"Ohjeteksti"                info
+     ;"Linkki"                    link-info
+     ;"Väliotsikko"               dummy
 
 (defn component-toolbar [path]
   (fn [path]

--- a/src/cljs/lomake_editori/editor/core.cljs
+++ b/src/cljs/lomake_editori/editor/core.cljs
@@ -166,7 +166,7 @@
 
 (defn editor []
   (let [form    (subscribe [:editor/selected-form])
-        content (reaction (take 3 (:content @form)))]
+        content (reaction (:content @form))]
     (fn []
       [:section.form
        (conj

--- a/src/cljs/lomake_editori/editor/core.cljs
+++ b/src/cljs/lomake_editori/editor/core.cljs
@@ -146,7 +146,7 @@
          :children   children}]
        (let [wrapper-element (->> (for [[index child] (zipmap (range) children)]
                                     [soresu->reagent child (conj path :children index)])
-                                  (into [:section.wrapper (when-let [n (-> content :params :name)]
+                                  (into [:section.wrapper (when-let [n (-> content :label)]
                                                             [:h1 n])]))]
          (conj wrapper-element [add-component (conj path :children (count (:children content)))]))
 

--- a/src/cljs/lomake_editori/editor/handlers.cljs
+++ b/src/cljs/lomake_editori/editor/handlers.cljs
@@ -68,7 +68,7 @@
 (register-handler
   :generate-component
   (fn [db [_ generate-fn path]]
-    (let [form-id      (-> db :editor :selected-form :id)
+    (let [form-id  (get-in db [:editor :selected-form :id])
           path-vec     (if
                          (coll? path)
                          path

--- a/src/cljs/lomake_editori/editor/handlers.cljs
+++ b/src/cljs/lomake_editori/editor/handlers.cljs
@@ -73,9 +73,12 @@
                          (coll? path)
                          path
                          [path])
-          element-path (into []
-                         (concat [:editor :forms form-id :content] path-vec))]
-      (assoc-in db element-path (generate-fn)))))
+          new-form (-> db
+                     (get-in [:editor :forms form-id :content])
+                     (assoc-in path-vec (generate-fn)))]
+      (-> db
+        (assoc-in [:editor :selected-form :content] new-form)
+        (assoc-in [:editor :forms form-id :content] new-form)))))
 
 (register-handler
   :editor/handle-user-info

--- a/src/cljs/lomake_editori/editor/handlers.cljs
+++ b/src/cljs/lomake_editori/editor/handlers.cljs
@@ -69,10 +69,10 @@
   :generate-component
   (fn [db [_ generate-fn path]]
     (let [form-id  (get-in db [:editor :selected-form :id])
-          path-vec     (if
-                         (coll? path)
-                         path
-                         [path])
+          path-vec (if
+                     (coll? path)
+                     path
+                     [path])
           new-form (-> db
                      (get-in [:editor :forms form-id :content])
                      (assoc-in path-vec (generate-fn)))]


### PR DESCRIPTION
This branch adds functionality to insert arbitrary form elements. New form elements can be added to the end of an element group or to the end of the form itself.

It shouldn't be possible to add elements into the middle of the form. Instead, there'll be a drag'n'drop feature in the future to make it possible to add elements to the middle of the form.