### PR TITLE
Render text input field according to what is set to app state

### DIFF
--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -34,7 +34,8 @@
               [[:div.editor-form__checkbox-wrapper
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"
-                                                :id (str id "_mandatory_choice")}]
+                                                :id (str id "_mandatory_choice")
+                                                :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :required])}]
                  [:label.editor-form__checkbox-label {:for (str id "_mandatory_choice")} "Pakollinen tieto"]]
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -8,6 +8,24 @@
     [:div.language
      [:div (clojure.string/upper-case (name lang))]]))
 
+(def ^:private checkbox-metadata
+  {:required {:id-suffix "_required"
+              :label "Pakollinen tieto"}
+   :multiple-answers {:id-suffix "_multiple_choices"
+                      :label "Vastaaja voi lisätä useita vastauksia"}})
+
+(defn ^:private render-checkbox
+  [path initial-content metadata-kwd]
+  (let [metadata (get checkbox-metadata metadata-kwd)
+        id (str (gensym) (:id-suffix metadata))
+        label (:label metadata)]
+    [:div.editor-form__checkbox-container
+     [:input.editor-form__checkbox {:type "checkbox"
+                                    :id id
+                                    :checked (true? (get initial-content metadata-kwd))
+                                    :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path metadata-kwd])}]
+     [:label.editor-form__checkbox-label {:for id} label]]))
+
 (defn render-text-field [initial-content path]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path])]
@@ -31,20 +49,8 @@
                [:span.editor-form__size-button.editor-form__size-button--not-selected "L"]]]])
           (into
             [[:div.editor-form__checkbox-wrapper
-              (let [id (str (gensym))]
-                [:div.editor-form__checkbox-container
-                 [:input.editor-form__checkbox {:type "checkbox"
-                                                :id (str id "_mandatory_choice")
-                                                :checked (:required initial-content)
-                                                :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :required])}]
-                 [:label.editor-form__checkbox-label {:for (str id "_mandatory_choice")} "Pakollinen tieto"]])
-              (let [id (str (gensym))]
-                [:div.editor-form__checkbox-container
-                 [:input.editor-form__checkbox {:type "checkbox"
-                                                :id (str id "_multiple_choices")
-                                                :checked (:multiple-answers initial-content)
-                                                :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :multiple-answers])}]
-                 [:label.editor-form__checkbox-label {:for (str id "_multiple_choices")} "Vastaaja voi lisätä useita vastauksia"]])]])))))
+              (render-checkbox path initial-content :required)
+              (render-checkbox path initial-content :multiple-answers)]])))))
 
 (defn render-link-info [{:keys [params] :as content} path]
   (let [languages (subscribe [:editor/languages])

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -8,7 +8,7 @@
     [:div.language
      [:div (clojure.string/upper-case (name lang))]]))
 
-(defn text-field [initial-content path]
+(defn render-text-field [initial-content path]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path])]
     (fn [initial-content path]

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -34,11 +34,11 @@
               [[:div.editor-form__checkbox-wrapper
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"
-                                         :id (str id "_mandatory_choice")}]
+                                                :id (str id "_mandatory_choice")}]
                  [:label.editor-form__checkbox-label {:for (str id "_mandatory_choice")} "Pakollinen tieto"]]
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"
-                                         :id (str id "_multiple_choices")}]
+                                                :id (str id "_multiple_choices")}]
                  [:label.editor-form__checkbox-label {:for (str id "_multiple_choices")} "Vastaaja voi lisätä useita vastauksia"]]]]))))))
 
 (defn link-info [{:keys [params] :as content} path]

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -30,20 +30,21 @@
                [:span.editor-form__size-button.editor-form__size-button--selected "M"]
                [:span.editor-form__size-button.editor-form__size-button--not-selected "L"]]]])
           (into
-            (let [id (str (gensym))]
-              [[:div.editor-form__checkbox-wrapper
+            [[:div.editor-form__checkbox-wrapper
+              (let [id (str (gensym))]
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"
                                                 :id (str id "_mandatory_choice")
                                                 :checked (:required initial-content)
                                                 :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :required])}]
-                 [:label.editor-form__checkbox-label {:for (str id "_mandatory_choice")} "Pakollinen tieto"]]
+                 [:label.editor-form__checkbox-label {:for (str id "_mandatory_choice")} "Pakollinen tieto"]])
+              (let [id (str (gensym))]
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"
                                                 :id (str id "_multiple_choices")
                                                 :checked (:multiple-answers initial-content)
                                                 :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :multiple-answers])}]
-                 [:label.editor-form__checkbox-label {:for (str id "_multiple_choices")} "Vastaaja voi lisätä useita vastauksia"]]]]))))))
+                 [:label.editor-form__checkbox-label {:for (str id "_multiple_choices")} "Vastaaja voi lisätä useita vastauksia"]])]])))))
 
 (defn render-link-info [{:keys [params] :as content} path]
   (let [languages (subscribe [:editor/languages])

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -11,7 +11,7 @@
 (def ^:private checkbox-metadata
   {:required {:id-suffix "_required"
               :label "Pakollinen tieto"}
-   :multiple-answers {:id-suffix "_multiple_choices"
+   :multiple-answers {:id-suffix "_multiple_answers"
                       :label "Vastaaja voi lisätä useita vastauksia"}})
 
 (defn ^:private render-checkbox

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -39,7 +39,8 @@
                  [:label.editor-form__checkbox-label {:for (str id "_mandatory_choice")} "Pakollinen tieto"]]
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"
-                                                :id (str id "_multiple_choices")}]
+                                                :id (str id "_multiple_choices")
+                                                :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :multiple-answers])}]
                  [:label.editor-form__checkbox-label {:for (str id "_multiple_choices")} "Vastaaja voi lisätä useita vastauksia"]]]]))))))
 
 (defn link-info [{:keys [params] :as content} path]

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -41,6 +41,7 @@
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"
                                                 :id (str id "_multiple_choices")
+                                                :checked (:multiple-answers initial-content)
                                                 :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :multiple-answers])}]
                  [:label.editor-form__checkbox-label {:for (str id "_multiple_choices")} "Vastaaja voi lisätä useita vastauksia"]]]]))))))
 

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -45,7 +45,7 @@
                                                 :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :multiple-answers])}]
                  [:label.editor-form__checkbox-label {:for (str id "_multiple_choices")} "Vastaaja voi lisätä useita vastauksia"]]]]))))))
 
-(defn link-info [{:keys [params] :as content} path]
+(defn render-link-info [{:keys [params] :as content} path]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path])]
     (fn [{:keys [params] :as content} path]

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -8,10 +8,10 @@
     [:div.language
      [:div (clojure.string/upper-case (name lang))]]))
 
-(defn text-field [path]
+(defn text-field [initial-content path]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path])]
-    (fn [path]
+    (fn [initial-content path]
       (-> [:div.editor-form__component-wrapper
            [:header.editor-form__component-header "Tekstikenttä"]]
           (into
@@ -35,6 +35,7 @@
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox {:type "checkbox"
                                                 :id (str id "_mandatory_choice")
+                                                :checked (:required initial-content)
                                                 :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path :required])}]
                  [:label.editor-form__checkbox-label {:for (str id "_mandatory_choice")} "Pakollinen tieto"]]
                 [:div.editor-form__checkbox-container

--- a/src/cljs/lomake_editori/editor/component.cljs
+++ b/src/cljs/lomake_editori/editor/component.cljs
@@ -65,7 +65,7 @@
                     :placeholder "Otsikko"}]
            [language lang]])))))
 
-(defn info [{:keys [params] :as content} path]
+(defn render-info [{:keys [params] :as content} path]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path :text])]
     (fn [{:keys [params] :as content} path]

--- a/src/cljs/lomake_editori/editor/core.cljs
+++ b/src/cljs/lomake_editori/editor/core.cljs
@@ -41,7 +41,7 @@
          (conj wrapper-element [ec/add-component (conj path :children (count (:children content)))]))
 
        [{:fieldClass "formField"}]
-       [ec/text-field path]
+       [ec/text-field content path]
 
        [{:fieldClass "infoElement"
          :fieldType  "link"}]

--- a/src/cljs/lomake_editori/editor/core.cljs
+++ b/src/cljs/lomake_editori/editor/core.cljs
@@ -48,7 +48,7 @@
        [ec/render-link-info content path]
 
        [{:fieldClass "infoElement"}]
-       [ec/info content path]
+       [ec/render-info content path]
 
        :else (do
                (error content)

--- a/src/cljs/lomake_editori/editor/core.cljs
+++ b/src/cljs/lomake_editori/editor/core.cljs
@@ -41,7 +41,7 @@
          (conj wrapper-element [ec/add-component (conj path :children (count (:children content)))]))
 
        [{:fieldClass "formField"}]
-       [ec/text-field content path]
+       [ec/render-text-field content path]
 
        [{:fieldClass "infoElement"
          :fieldType  "link"}]

--- a/src/cljs/lomake_editori/editor/core.cljs
+++ b/src/cljs/lomake_editori/editor/core.cljs
@@ -45,7 +45,7 @@
 
        [{:fieldClass "infoElement"
          :fieldType  "link"}]
-       [ec/link-info content path]
+       [ec/render-link-info content path]
 
        [{:fieldClass "infoElement"}]
        [ec/info content path]


### PR DESCRIPTION
This feature makes text input fields to be rendered as they're defined in the app state (when rendering existing input fields). This includes: initial value of the input field, checking or unchecking of the required and multiple answers checkboxes.

Also, when user changes these values, they're stored to the internal app state.