### PR TITLE
Proper schema validation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [re-com "0.8.0"]    ; reusable re-frame components
                  [secretary "1.2.3"] ; routing
                  [com.andrewmcveigh/cljs-time "0.4.0"]
-                 [oph/soresu "0.1.1-SNAPSHOT"]
+                 [oph/soresu "0.1.2-SNAPSHOT"]
                  [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
                  [cljs-ajax "0.5.4"]
 

--- a/spec/ataru/fixtures/form.clj
+++ b/spec/ataru/fixtures/form.clj
@@ -1,7 +1,21 @@
 (ns ataru.fixtures.form)
 
 (def form-with-content
-  {:name "Test fixture"
-   :modified-by "speclj"
-   :content []})
-
+  {:name        "Test fixture!"
+   :modified-by "DEVELOPER"
+   :content
+   [{:fieldClass "formField"
+     :label      {:fi "tekstiä" :sv ""}
+     :id         "G__19"
+     :required   false
+     :fieldType  "textField"}
+    {:fieldClass "wrapperElement"
+     :fieldType  "fieldset"
+     :id         "G__31"
+     :label      {:fi "Osion nimi" :sv "Avsnitt namn"}
+     :children
+     [{:fieldClass "formField"
+       :label      {:fi "" :sv ""}
+       :id         "G__32"
+       :required   false
+       :fieldType  "textField"}]}]})

--- a/spec/ataru/soresu/component_spec.clj
+++ b/spec/ataru/soresu/component_spec.clj
@@ -17,8 +17,6 @@
 (describe "fixture"
   (it "must validate"
       (should-be-nil
-        (s/check ataru-schema/FormWithContent fixtures/form-with-content)
-
-        )))
+        (s/check ataru-schema/FormWithContent fixtures/form-with-content))))
 
 (run-specs)

--- a/spec/ataru/soresu/component_spec.clj
+++ b/spec/ataru/soresu/component_spec.clj
@@ -1,9 +1,10 @@
 (ns ataru.soresu.component-spec
-  (:require [oph.soresu.form.schema :as soresu]
-            [ataru.schema.clj-schema]
+  (:require [ataru.fixtures.form :as fixtures]
+            [ataru.schema.clj-schema :as ataru-schema]
             [ataru.virkailija.soresu.component :as component]
             [schema.core :as s]
-            [speclj.core :refer :all]))
+            [speclj.core :refer :all]
+            [oph.soresu.form.schema :as soresu]))
 
 (describe "text-field"
   (it "should be validated with soresu-form schema"
@@ -12,5 +13,12 @@
 (describe "form-section"
   (it "should be validated with ataru-form schema"
     (should-be-nil (s/check soresu/WrapperElement (component/form-section)))))
+
+(describe "fixture"
+  (it "must validate"
+      (should-be-nil
+        (s/check ataru-schema/FormWithContent fixtures/form-with-content)
+
+        )))
 
 (run-specs)

--- a/src/clj/ataru/schema/clj_schema.clj
+++ b/src/clj/ataru/schema/clj_schema.clj
@@ -51,6 +51,15 @@
 
 (s/defschema Form schema/Form)
 
+(intern 'oph.soresu.form.schema
+        'FormField
+        (st/assoc soresu/WrapperElement
+                  :children
+                  [(s/conditional #(= "wrapperElement" (:fieldClass %))
+                                  (s/recursive #'soresu/WrapperElement)
+                                  :else
+                                  soresu/BasicElement)]))
+
 (s/defschema FormWithContent
   (merge Form
          {:content [(s/if (comp some? :children) soresu/WrapperElement soresu/FormField)]}))

--- a/src/clj/ataru/schema/clj_schema.clj
+++ b/src/clj/ataru/schema/clj_schema.clj
@@ -2,7 +2,13 @@
   (:require [ataru.schema :as schema]
             [schema.core :as s]
             [schema-tools.core :as st]
-            [oph.soresu.form.schema :as soresu]))
+            [oph.soresu.form.schema :as soresu]
+            [clojure.string :as str]))
+
+(s/defschema OptionalLocalizedString
+  {:fi                  s/Str
+   (s/optional-key :sv) s/Str
+   (s/optional-key :en) s/Str})
 
 ;        __.,,------.._
 ;     ,'"   _      _   "`.
@@ -28,11 +34,17 @@
 ; it overwrites some of soresus schemas with little changes
 ((memoize
    (fn []
+
      (intern 'oph.soresu.form.schema
              'LocalizedString
-             {:fi           s/Str
-              (s/optional-key :sv) s/Str
-              (s/optional-key :en) s/Str})
+             OptionalLocalizedString)
+
+     (intern 'oph.soresu.form.schema
+             'Option
+             (st/assoc
+               soresu/Option
+               (s/optional-key :label) OptionalLocalizedString))
+
      nil)))
 
 (soresu/create-form-schema [] [] [])

--- a/src/clj/ataru/schema/clj_schema.clj
+++ b/src/clj/ataru/schema/clj_schema.clj
@@ -4,12 +4,6 @@
             [schema-tools.core :as st]
             [oph.soresu.form.schema :as soresu]))
 
-(soresu/create-form-schema [] [] [])
-
-(s/defschema OptionalHelpText
-  {(s/optional-key :helpText) soresu/LocalizedString})
-
-
 ;        __.,,------.._
 ;     ,'"   _      _   "`.
 ;    /.__, ._  -=- _ "`    Y
@@ -34,31 +28,16 @@
 ; it overwrites some of soresus schemas with little changes
 ((memoize
    (fn []
-
      (intern 'oph.soresu.form.schema
              'LocalizedString
              {:fi           s/Str
               (s/optional-key :sv) s/Str
               (s/optional-key :en) s/Str})
-
-     (intern 'oph.soresu.form.schema
-             'FormField
-             (-> soresu/FormField
-                 (st/dissoc :helpText)
-                 (st/merge OptionalHelpText)))
-
      nil)))
 
-(s/defschema Form schema/Form)
+(soresu/create-form-schema [] [] [])
 
-(intern 'oph.soresu.form.schema
-        'FormField
-        (st/assoc soresu/WrapperElement
-                  :children
-                  [(s/conditional #(= "wrapperElement" (:fieldClass %))
-                                  (s/recursive #'soresu/WrapperElement)
-                                  :else
-                                  soresu/BasicElement)]))
+(s/defschema Form schema/Form)
 
 (s/defschema FormWithContent
   (merge Form

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -80,12 +80,12 @@
                      {:forms (form-store/get-forms)}))
                  (api/GET "/forms/content/:id" []
                    :path-params [id :- Long]
-                   :return s/Any
+                   :return ataru-schema/FormWithContent
                    :summary "Get content for form"
                    (trying #(form-store/fetch-form id)))
                  (api/POST "/form" {session :session}
                    :summary "Persist changed form."
-                   :body [form s/Any] ;;TODO use a schema which works with the current editor output JSON
+                   :body [form ataru-schema/FormWithContent]
                    (trying #(form-store/upsert-form
                               (assoc form :modified-by (-> session :identity :username))))))))
 

--- a/src/cljs/ataru/hakija/form_view.cljs
+++ b/src/cljs/ataru/hakija/form_view.cljs
@@ -13,7 +13,7 @@
 (defn text-field [content]
   [:div.application__form-field
    [:label.application_form-field-label (-> content :label :fi)]
-   [:input.application__form-text-input {:type "text" :class (text-field-size->class (-> content :size))}]])
+   [:input.application__form-text-input {:type "text" :class (text-field-size->class (-> content :params :size))}]])
 
 (declare render-field)
 

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -27,11 +27,11 @@
 (defn render-text-field [initial-content path]
   (let [languages        (subscribe [:editor/languages])
         value            (subscribe [:editor/get-component-value path])
-        size             (subscribe [:editor/get-component-value path :size])
+        size             (subscribe [:editor/get-component-value path :params :size])
         radio-group-id   (str "form-size-" (gensym))
         radio-buttons    ["S" "M" "L"]
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
-        size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :size]))]
+        size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
     (fn [initial-content path]
       [:div.editor-form__component-wrapper
        [:header.editor-form__component-header "Tekstikenttä"]


### PR DESCRIPTION
- Most schema changes are in soresu-lib, less hacking in ataru
- Move FormField :size under [:params :size] in order to validate schema.
