### PR TITLE
Remove form element when user clicks the remove link

### DIFF
--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -176,15 +176,29 @@ form > .editor-form__component-wrapper {
   margin-bottom: 10px;
 }
 
-.editor-form__component-header {
+.editor-form__header-wrapper {
+  width: 100%;
   background-color: @element-header-background;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+}
+
+.editor-form__component-header {
   color: @blue-text-color;
   font-size: 16px;
   font-weight: normal;
   text-transform: uppercase;
   margin: 0px;
   padding: 10px 11px 8px 11px;
-  width: 100%;
+}
+
+.editor-form__component-header-link {
+  color: @blue-text-color;
+  text-decoration: underline;
+  margin: 0px;
+  padding: 10px 11px 8px 11px;
+  font-size: 14px;
 }
 
 .editor-form__checkbox-label {

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -34,7 +34,9 @@
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :size]))]
     (fn [initial-content path]
       [:div.editor-form__component-wrapper
-       [:header.editor-form__component-header "Tekstikenttä"]
+       [:div.editor-form__header-wrapper
+        [:header.editor-form__component-header "Tekstikenttä"]
+        [:a.editor-form__component-header-link "Poista"]]
        [:div.editor-form__text-field-wrapper
         [:header.editor-form__component-item-header "Otsikko"]
         (doall
@@ -157,7 +159,9 @@
         value     (subscribe [:editor/get-component-value path])]
     (fn []
       (-> [:div.editor-form__component-wrapper
-           [:header.editor-form__component-header "Lomakeosio"]]
+           [:div.editor-form__header-wrapper
+            [:header.editor-form__component-header "Lomakeosio"]
+            [:a.editor-form__component-header-link "Poista"]]]
           (into
             [[:div.editor-form__text-field-wrapper
               [:header.editor-form__component-item-header "Osion nimi"]

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -24,6 +24,12 @@
                                     :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path metadata-kwd])}]
      [:label.editor-form__checkbox-label {:for id} label]]))
 
+(defn- render-component-header
+  [label]
+  [:div.editor-form__header-wrapper
+   [:header.editor-form__component-header label]
+   [:a.editor-form__component-header-link "Poista"]])
+
 (defn render-text-field [initial-content path]
   (let [languages        (subscribe [:editor/languages])
         value            (subscribe [:editor/get-component-value path])
@@ -34,9 +40,7 @@
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :size]))]
     (fn [initial-content path]
       [:div.editor-form__component-wrapper
-       [:div.editor-form__header-wrapper
-        [:header.editor-form__component-header "Tekstikenttä"]
-        [:a.editor-form__component-header-link "Poista"]]
+       (render-component-header "Tekstikenttä")
        [:div.editor-form__text-field-wrapper
         [:header.editor-form__component-item-header "Otsikko"]
         (doall
@@ -159,9 +163,7 @@
         value     (subscribe [:editor/get-component-value path])]
     (fn []
       (-> [:div.editor-form__component-wrapper
-           [:div.editor-form__header-wrapper
-            [:header.editor-form__component-header "Lomakeosio"]
-            [:a.editor-form__component-header-link "Poista"]]]
+           (render-component-header "Lomakeosio")]
           (into
             [[:div.editor-form__text-field-wrapper
               [:header.editor-form__component-item-header "Osion nimi"]

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -25,10 +25,12 @@
      [:label.editor-form__checkbox-label {:for id} label]]))
 
 (defn- render-component-header
-  [label]
+  [label path]
   [:div.editor-form__header-wrapper
    [:header.editor-form__component-header label]
-   [:a.editor-form__component-header-link "Poista"]])
+   [:a.editor-form__component-header-link
+    {:on-click #(dispatch [:remove-component path])}
+    "Poista"]])
 
 (defn render-text-field [initial-content path]
   (let [languages        (subscribe [:editor/languages])
@@ -40,7 +42,7 @@
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :size]))]
     (fn [initial-content path]
       [:div.editor-form__component-wrapper
-       (render-component-header "Tekstikenttä")
+       (render-component-header "Tekstikenttä" path)
        [:div.editor-form__text-field-wrapper
         [:header.editor-form__component-item-header "Otsikko"]
         (doall
@@ -163,7 +165,7 @@
         value     (subscribe [:editor/get-component-value path])]
     (fn []
       (-> [:div.editor-form__component-wrapper
-           (render-component-header "Lomakeosio")]
+           (render-component-header "Lomakeosio" path)]
           (into
             [[:div.editor-form__text-field-wrapper
               [:header.editor-form__component-item-header "Osion nimi"]

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -65,6 +65,21 @@
 
 (register-handler :generate-component generate-component)
 
+(defn remove-component
+  [db [_ path]]
+  (let [form-id      (get-in db [:editor :selected-form-id])
+        remove-index (last path)
+        path-vec     (-> [:editor :forms form-id :content [path]]
+                         flatten
+                         butlast)]
+    (->> (get-in db path-vec)
+         (keep-indexed (fn [index element]
+                         (when-not (= index remove-index) element)))
+         (into [])
+         (assoc-in db path-vec))))
+
+(register-handler :remove-component remove-component)
+
 (register-handler
   :editor/handle-user-info
   (fn [db [_ user-info-response]]

--- a/test/cljs/unit/ataru/virkailija/editor/handlers_test.cljs
+++ b/test/cljs/unit/ataru/virkailija/editor/handlers_test.cljs
@@ -31,3 +31,27 @@
       2 (count new-children)
       {:child :component} (first new-children)
       {:fake :component} (second new-children))))
+
+(deftest remove-component-removes-from-root-level
+  (let [form-id 1234
+        initial-form {:id form-id
+                      :content [{:first :component} {:second :another-component}]}
+        new-content (-> {:editor {:selected-form-id form-id
+                                  :forms {form-id initial-form}}}
+                        (h/remove-component [:remove-component [0]])
+                        (get-in [:editor :forms form-id :content]))]
+    (are [expected actual] (= expected actual)
+      1 (count new-content)
+      {:second :another-component} (first new-content))))
+
+(deftest remove-component-removes-from-child
+  (let [form-id 1234
+        initial-form {:id form-id
+                      :content [{:children [{:first :component} {:second :another-component}]}]}
+        new-children (-> {:editor {:selected-form-id form-id
+                                   :forms {form-id initial-form}}}
+                         (h/remove-component [:remove-component [0 :children 1]])
+                         (get-in [:editor :forms form-id :content 0 :children]))]
+    (are [expected actual] (= expected actual)
+      1 (count new-children)
+      {:first :component} (first new-children))))


### PR DESCRIPTION
When user clicks remove link on a form element (a text field, wrapper element or whatnot), then the element is removed.