### PR TITLE
Log uncaught client errors of Hakija app to server log

### DIFF
--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -4,6 +4,7 @@
             [compojure.core :refer [routes defroutes wrap-routes context GET]]
             [schema.core :as s]
             [ataru.schema.clj-schema :as ataru-schema]
+            [ataru.util.client-error :as client-error]
             [compojure.api.sweet :as api]
             [ring.util.http-response :refer [ok not-found]]
             [compojure.route :as route]
@@ -25,6 +26,10 @@
     (info "Stored application with id:" stored-app-id)
     (ok {})))
 
+(defn- handle-client-error [error-details]
+  (client-error/log-client-error error-details)
+  (ok {}))
+
 (def api-routes
   (api/api
     {:swagger {:spec "/hakemus/swagger.json"
@@ -42,7 +47,11 @@
                  (api/POST "/application" []
                            :summary "Submit application"
                            :body [application ataru-schema/Application]
-                           (handle-application application)))))
+                           (handle-application application))
+                 (api/POST "/client-error" []
+                           :summary "Log client-side errors to server log"
+                           :body [error-details client-error/ClientError]
+                           (handle-client-error error-details)))))
 
 (def hakija-routes
   (-> (routes

--- a/src/clj/ataru/util/client_error.clj
+++ b/src/clj/ataru/util/client_error.clj
@@ -1,0 +1,15 @@
+(ns ataru.util.client-error
+  (:require [taoensso.timbre :refer [error]]
+            [schema.core :as s]))
+
+(s/defschema ClientError {:error-message s/Str
+                          :url s/Str
+                          :line s/Int
+                          :col s/Int
+                          :user-agent s/Str
+                          :stack s/Str})
+
+
+(defn log-client-error [error-details]
+  (error "Error from client browser:")
+  (error error-details))

--- a/src/clj/ataru/util/client_error.clj
+++ b/src/clj/ataru/util/client_error.clj
@@ -12,4 +12,8 @@
 
 (defn log-client-error [error-details]
   (error "Error from client browser:")
-  (error error-details))
+  (error (:error-message error-details))
+  (error (:url error-details))
+  (error "line:" (:line error-details) "column:" (:col error-details))
+  (error "user-agent:" (:user-agent error-details))
+  (error "stack trace:" (:stack error-details)))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -5,6 +5,7 @@
             [ataru.virkailija.authentication.auth-middleware :as auth-middleware]
             [ataru.virkailija.authentication.auth-routes :refer [auth-routes]]
             [ataru.forms.form-store :as form-store]
+            [ataru.util.client-error :as client-error]
             [compojure.api.sweet :as api]
             [compojure.core :refer [GET POST PUT defroutes context routes wrap-routes]]
             [compojure.response :refer [Renderable]]
@@ -87,7 +88,12 @@
                    :summary "Persist changed form."
                    :body [form ataru-schema/FormWithContent]
                    (trying #(form-store/upsert-form
-                              (assoc form :modified-by (-> session :identity :username))))))))
+                             (assoc form :modified-by (-> session :identity :username)))))
+                 (api/POST "/client-error" []
+                           :summary "Log client-side errors to server log"
+                           :body [error-details client-error/ClientError]
+                           (client-error/log-client-error error-details)
+                           (ok {})))))
 
 (defroutes resource-routes
   (route/resources "/"))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -68,7 +68,7 @@
         (fn [error-msg url line col error-obj]
           (let [user-agent (-> js/window .-navigator .-userAgent)
                 stack-string (.-stack error-obj)
-                error-details {:error-message "error-msg"
+                error-details {:error-message error-msg
                                :url url
                                :line line
                                :col col

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -58,3 +58,25 @@
       (js/setInterval
         #(dispatch [:state-update dispatcher])
         200))))
+
+
+(defn set-global-error-handler!
+  "Sets the global error handler. Prints stack trace of uncaught
+   error"
+  [send-to-server-fn]
+  (set! (.-onerror js/window)
+        (fn [error-msg url line col error-obj]
+          (let [user-agent (-> js/window .-navigator .-userAgent)
+                stack-string (.-stack error-obj)
+                error-details {:error-message "error-msg"
+                               :url url
+                               :line line
+                               :col col
+                               :user-agent user-agent
+                               :stack stack-string}]
+            (send-to-server-fn error-details)
+            (when js/console
+              (.log js/console error-msg)
+              (.log js/console url)
+              (.log js/console (str "line: " line " col: " col))
+              (.log js/console (.-stack error-obj)))))))

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -70,6 +70,10 @@
   default-error-handler)
 
 (register-handler
+ :application/default-http-ok-handler
+ (fn [db _] db))
+
+(register-handler
   :state-update
   (fn [db [_ f]]
     (or (f db)

--- a/src/cljs/ataru/hakija/core.cljs
+++ b/src/cljs/ataru/hakija/core.cljs
@@ -2,6 +2,8 @@
   (:require [reagent.core :as reagent]
             [re-frame.core :as re-frame]
             [taoensso.timbre :refer-macros [spy info]]
+            [ataru.cljs-util :refer [set-global-error-handler!]]
+            [ataru.hakija.hakija-ajax :refer [post]]
             [ataru.hakija.form-view :refer [form-view]]
             [ataru.hakija.application-handlers] ;; required although no explicit dependency
             [ataru.hakija.subs] ;; required although no explicit dependency
@@ -17,6 +19,7 @@
                   (.getElementById js/document "app")))
 
 (defn ^:export init []
+  (set-global-error-handler! #(post "/hakemus/api/client-error" %))
   (mount-root)
   (re-frame/dispatch-sync [:application/initialize-db])
   (re-frame/dispatch [:application/get-form (form-id-from-url)]))

--- a/src/cljs/ataru/hakija/hakija_ajax.cljs
+++ b/src/cljs/ataru/hakija/hakija_ajax.cljs
@@ -7,12 +7,12 @@
 
 (defn- params [handler-kw error-handler-kw]
   (merge
-    {:handler (fn [response] (dispatch [handler-kw response]))
+    {:handler (fn [response] (dispatch [(or handler-kw :application/default-http-ok-handler) response]))
      :error-handler (fn [response] (dispatch [(or error-handler-kw :application/default-handle-error) response]))}
     json-params))
 
-(defn get [path handler-kw & [error-handler-kw]]
+(defn get [path & [handler-kw error-handler-kw]]
   (GET path (params handler-kw error-handler-kw)))
 
-(defn post [path post-data handler-kw & [error-handler-kw]]
+(defn post [path post-data & [handler-kw error-handler-kw]]
   (POST path (merge {:params post-data} (params handler-kw error-handler-kw))))

--- a/src/cljs/ataru/virkailija/core.cljs
+++ b/src/cljs/ataru/virkailija/core.cljs
@@ -3,6 +3,8 @@
               [re-frame.core :as re-frame]
               [ataru.virkailija.handlers]
               [ataru.virkailija.subs]
+              [ataru.cljs-util :refer [set-global-error-handler!]]
+              [ataru.virkailija.virkailija-ajax :refer [post]]
               [ataru.virkailija.routes :as routes]
               [ataru.virkailija.views :as views]
               [ataru.virkailija.config :as config]
@@ -19,6 +21,7 @@
                   (.getElementById js/document "app")))
 
 (defn ^:export init []
+  (set-global-error-handler! #(post "/lomake-editori/api/client-error" %))
   (routes/app-routes)
   (re-frame/dispatch-sync [:initialize-db])
   (re-frame/dispatch [:editor/get-user-info])


### PR DESCRIPTION
You can test this with e.g.:

src/cljs/ataru/hakija/application_handlers.cljs
 
 (defn set-application-field [db [_ key value]]
+  (throw (js/Error. "Oops"))
   (assoc-in db [:application :answers key] value))
