### PR TITLE
Fade out effect to components

### DIFF
--- a/src/cljc/ataru/virkailija/editor/component_macros.cljc
+++ b/src/cljc/ataru/virkailija/editor/component_macros.cljc
@@ -1,0 +1,13 @@
+(ns ataru.virkailija.editor.component-macros)
+
+(defmacro component-with-fade-effects
+  [bindings & body]
+  `(let [component# (do ~@body)
+         status-path# [:params :status]
+         fade-out-class# "animated fadeOutUp"]
+     (if
+       (= "fading-out" (get-in ~(first bindings) status-path#))
+       (let [element# (first component#)
+             content# (subvec component# 1)]
+         (into [element# {:class fade-out-class#}] content#))
+       component#)))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -1,5 +1,6 @@
 (ns ataru.virkailija.editor.component
-  (:require [ataru.virkailija.soresu.component :as component]
+  (:require [ataru.virkailija.editor.component-macros :refer-macros [component-with-fade-effects]]
+            [ataru.virkailija.soresu.component :as component]
             [reagent.core :as r]
             [cljs.core.match :refer-macros [match]]
             [re-frame.core :refer [subscribe dispatch]]))
@@ -52,10 +53,8 @@
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
     (fn [initial-content path & {:keys [header-label size-label]}]
+      (component-with-fade-effects [initial-content]
       [:div.editor-form__component-wrapper
-       (when
-         (= "fading-out" (get-in initial-content [:params :status]))
-         {:class "animated fadeOutUp"})
        [text-header header-label path]
        [:div.editor-form__text-field-wrapper
         [:header.editor-form__component-item-header "Otsikko"]
@@ -89,7 +88,7 @@
                                   :else nil)}
                     btn-name]]))]]
        [:div.editor-form__checkbox-wrapper
-        (render-checkbox path initial-content :required)]])))
+        (render-checkbox path initial-content :required)]]))))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän leveys"])
@@ -133,10 +132,8 @@
   (let [languages  (subscribe [:editor/languages])
         value      (subscribe [:editor/get-component-value path])]
     (fn [content path children]
+      (component-with-fade-effects [content]
       [:div.editor-form__section_wrapper
-       (when
-         (= "fading-out" (get-in content [:params :status]))
-         {:class "animated fadeOutUp"})
        [:div.editor-form__component-wrapper
         [text-header "Lomakeosio" path :form-section? true]
         [:div.editor-form__text-field-wrapper.editor-form__text-field--section
@@ -148,4 +145,4 @@
               {:value     (get-in @value [:label lang])
                :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
        children
-       [add-component (conj path :children (count children))]])))
+       [add-component (conj path :children (count children))]]))))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -97,55 +97,10 @@
 (defn text-area [initial-content path]
   [text-component initial-content path :header-label "Tekstialue" :size-label "Tekstialueen leveys"])
 
-(defn render-link-info [{:keys [params] :as content} path]
-  (let [languages (subscribe [:editor/languages])
-        value     (subscribe [:editor/get-component-value path])]
-    (fn [{:keys [params] :as content} path]
-      (into
-        [:div.link-info
-         [:p "Linkki"]]
-        (for [lang @languages]
-          [:div
-           [:p "Osoite"]
-           [:input {:value       (get-in @value [:params :href lang])
-                    :type        "url"
-                    :on-change   #(dispatch [:editor/set-component-value (-> % .-target .-value) path :params :href lang])
-                    :placeholder "http://"}]
-           [language lang]
-           [:input {:on-change   #(dispatch [:editor/set-component-value (-> % .-target .-value) path :text lang])
-                    :value       (get-in @value [:text lang])
-                    :placeholder "Otsikko"}]
-           [language lang]])))))
-
-(defn render-info [{:keys [params] :as content} path]
-  (let [languages (subscribe [:editor/languages])
-        value     (subscribe [:editor/get-component-value path :text])]
-    (fn [{:keys [params] :as content} path]
-      (into
-        [:div.info
-         [:p "Ohjeteksti"]]
-        (for [lang @languages]
-          [:div
-           [:input
-            {:value       (get @value lang)
-             :on-change   #(dispatch [:editor/set-component-value (-> % .-target .-value) path :text lang])
-             :placeholder "Ohjetekstin sisältö"}]
-           [language lang]
-           ])))))
-
 (def ^:private toolbar-elements
-  (let [dummy [:div "ei vielä toteutettu.."]]
-    {"Lomakeosio"                component/form-section
-     "Tekstikenttä"              component/text-field
-     "Tekstialue"                component/text-area}))
-;"Lista, monta valittavissa" dummy
-;"Lista, yksi valittavissa"  dummy
-;"Pudotusvalikko"            dummy
-;"Vierekkäiset kentät"       dummy
-;"Liitetiedosto"             dummy
-;"Ohjeteksti"                info
-;"Linkki"                    link-info
-;"Väliotsikko"               dummy
+  {"Lomakeosio"                component/form-section
+   "Tekstikenttä"              component/text-field
+   "Tekstialue"                component/text-area})
 
 (defn ^:private component-toolbar [path]
   (fn [path]

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -51,8 +51,6 @@
         radio-buttons    ["S" "M" "L"]
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
-    (r/create-class
-      {:reagent-render
        (fn [initial-content path & {:keys [header-label size-label]}]
          [:div.editor-form__component-wrapper
           (when
@@ -91,7 +89,7 @@
                                      :else nil)}
                        btn-name]]))]]
           [:div.editor-form__checkbox-wrapper
-           (render-checkbox path initial-content :required)]])})))
+           (render-checkbox path initial-content :required)]])))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän leveys"])
@@ -134,8 +132,6 @@
 (defn component-group [content path children]
   (let [languages  (subscribe [:editor/languages])
         value      (subscribe [:editor/get-component-value path])]
-    (r/create-class
-      {:reagent-render
        (fn [content path children]
          [:div.editor-form__section_wrapper
           (when
@@ -152,4 +148,4 @@
                  {:value     (get-in @value [:label lang])
                   :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
           children
-          [add-component (conj path :children (count children))]])})))
+          [add-component (conj path :children (count children))]])))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -129,13 +129,24 @@
          [:div.plus-component
           [:span "+"]]]))))
 
-(defn component-group [path children]
-  (let [languages (subscribe [:editor/languages])
-        value     (subscribe [:editor/get-component-value path])]
+(defn component-group [content path children]
+  (let [languages  (subscribe [:editor/languages])
+        value      (subscribe [:editor/get-component-value path])
+        handler-fn (fn [_]
+                     (dispatch [:remove-component path]))]
     (r/create-class
-      {:reagent-render
-       (fn [path children]
+      {:component-did-mount
+       (fn [this]
+         (let [node   (r/dom-node this)
+               events ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]]
+           (doseq [event events]
+             (.addEventListener node event handler-fn))))
+       :reagent-render
+       (fn [content path children]
          [:div.editor-form__section_wrapper
+          (when
+            (= "fading-out" (get-in content [:params :status]))
+            {:class "animated fadeOutUp"})
           [:div.editor-form__component-wrapper
            [text-header "Lomakeosio" path]
            [:div.editor-form__text-field-wrapper.editor-form__text-field--section

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -134,15 +134,15 @@
         value     (subscribe [:editor/get-component-value path])]
     (r/create-class
       {:reagent-render
-    (fn [path]
-      (-> [:div.editor-form__component-wrapper
-           [text-header "Lomakeosio" path]]
-          (into
-            [[:div.editor-form__text-field-wrapper.editor-form__text-field--section
-              [:header.editor-form__component-item-header "Osion nimi"]
-              (doall
-                (for [lang @languages]
-                  ^{:key lang}
-                  [:input.editor-form__text-field
-                   {:value     (get-in @value [:label lang])
-                    :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]])))})))
+       (fn [path]
+         (-> [:div.editor-form__component-wrapper
+              [text-header "Lomakeosio" path]]
+           (into
+             [[:div.editor-form__text-field-wrapper.editor-form__text-field--section
+               [:header.editor-form__component-item-header "Osion nimi"]
+               (doall
+                 (for [lang @languages]
+                   ^{:key lang}
+                   [:input.editor-form__text-field
+                    {:value     (get-in @value [:label lang])
+                     :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]])))})))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -51,45 +51,45 @@
         radio-buttons    ["S" "M" "L"]
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
-       (fn [initial-content path & {:keys [header-label size-label]}]
-         [:div.editor-form__component-wrapper
-          (when
-            (= "fading-out" (get-in initial-content [:params :status]))
-            {:class "animated fadeOutUp"})
-          [text-header header-label path]
-          [:div.editor-form__text-field-wrapper
-           [:header.editor-form__component-item-header "Otsikko"]
-           (doall
-             (for [lang @languages]
-               ^{:key lang}
-               [:input.editor-form__text-field {:value     (get-in @value [:label lang])
-                                                :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
-          [:div.editor-form__size-button-wrapper
-           [:header.editor-form__component-item-header size-label]
-           [:div.editor-form__size-button-group
-            (doall (for [[btn-name btn-id] radio-button-ids]
-                     ^{:key (str btn-id "-radio")}
-                     [:div
-                      [:input.editor-form__size-button.editor-form__size-button
-                       {:type      "radio"
-                        :value     btn-name
-                        :checked   (or
-                                     (= @size btn-name)
-                                     (and
-                                       (nil? @size)
-                                       (= "M" btn-name)))
-                        :name      radio-group-id
-                        :id        btn-id
-                        :on-change (fn [] (size-change btn-name))}]
-                      [:label
-                       {:for btn-id
-                        :class     (match btn-name
-                                     "S" "editor-form__size-button--left-edge"
-                                     "L" "editor-form__size-button--right-edge"
-                                     :else nil)}
-                       btn-name]]))]]
-          [:div.editor-form__checkbox-wrapper
-           (render-checkbox path initial-content :required)]])))
+    (fn [initial-content path & {:keys [header-label size-label]}]
+      [:div.editor-form__component-wrapper
+       (when
+         (= "fading-out" (get-in initial-content [:params :status]))
+         {:class "animated fadeOutUp"})
+       [text-header header-label path]
+       [:div.editor-form__text-field-wrapper
+        [:header.editor-form__component-item-header "Otsikko"]
+        (doall
+          (for [lang @languages]
+            ^{:key lang}
+            [:input.editor-form__text-field {:value     (get-in @value [:label lang])
+                                             :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
+       [:div.editor-form__size-button-wrapper
+        [:header.editor-form__component-item-header size-label]
+        [:div.editor-form__size-button-group
+         (doall (for [[btn-name btn-id] radio-button-ids]
+                  ^{:key (str btn-id "-radio")}
+                  [:div
+                   [:input.editor-form__size-button.editor-form__size-button
+                    {:type      "radio"
+                     :value     btn-name
+                     :checked   (or
+                                  (= @size btn-name)
+                                  (and
+                                    (nil? @size)
+                                    (= "M" btn-name)))
+                     :name      radio-group-id
+                     :id        btn-id
+                     :on-change (fn [] (size-change btn-name))}]
+                   [:label
+                    {:for btn-id
+                     :class     (match btn-name
+                                  "S" "editor-form__size-button--left-edge"
+                                  "L" "editor-form__size-button--right-edge"
+                                  :else nil)}
+                    btn-name]]))]]
+       [:div.editor-form__checkbox-wrapper
+        (render-checkbox path initial-content :required)]])))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän leveys"])
@@ -132,20 +132,20 @@
 (defn component-group [content path children]
   (let [languages  (subscribe [:editor/languages])
         value      (subscribe [:editor/get-component-value path])]
-       (fn [content path children]
-         [:div.editor-form__section_wrapper
-          (when
-            (= "fading-out" (get-in content [:params :status]))
-            {:class "animated fadeOutUp"})
-          [:div.editor-form__component-wrapper
-           [text-header "Lomakeosio" path]
-           [:div.editor-form__text-field-wrapper.editor-form__text-field--section
-            [:header.editor-form__component-item-header "Osion nimi"]
-            (doall
-              (for [lang @languages]
-                ^{:key lang}
-                [:input.editor-form__text-field
-                 {:value     (get-in @value [:label lang])
-                  :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
-          children
-          [add-component (conj path :children (count children))]])))
+    (fn [content path children]
+      [:div.editor-form__section_wrapper
+       (when
+         (= "fading-out" (get-in content [:params :status]))
+         {:class "animated fadeOutUp"})
+       [:div.editor-form__component-wrapper
+        [text-header "Lomakeosio" path]
+        [:div.editor-form__text-field-wrapper.editor-form__text-field--section
+         [:header.editor-form__component-item-header "Osion nimi"]
+         (doall
+           (for [lang @languages]
+             ^{:key lang}
+             [:input.editor-form__text-field
+              {:value     (get-in @value [:label lang])
+               :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
+       children
+       [add-component (conj path :children (count children))]])))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -129,20 +129,22 @@
          [:div.plus-component
           [:span "+"]]]))))
 
-(defn form-component-group [path]
+(defn component-group [path children]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path])]
     (r/create-class
       {:reagent-render
-       (fn [path]
-         (-> [:div.editor-form__component-wrapper
-              [text-header "Lomakeosio" path]]
-           (into
-             [[:div.editor-form__text-field-wrapper.editor-form__text-field--section
-               [:header.editor-form__component-item-header "Osion nimi"]
-               (doall
-                 (for [lang @languages]
-                   ^{:key lang}
-                   [:input.editor-form__text-field
-                    {:value     (get-in @value [:label lang])
-                     :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]])))})))
+       (fn [path children]
+         [:div.editor-form__section_wrapper
+          [:div.editor-form__component-wrapper
+           [text-header "Lomakeosio" path]
+           [:div.editor-form__text-field-wrapper.editor-form__text-field--section
+            [:header.editor-form__component-item-header "Osion nimi"]
+            (doall
+              (for [lang @languages]
+                ^{:key lang}
+                [:input.editor-form__text-field
+                 {:value     (get-in @value [:label lang])
+                  :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
+          children
+          [add-component (conj path :children (count children))]])})))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -41,6 +41,8 @@
         radio-buttons    ["S" "M" "L"]
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
+    (r/create-class
+       {:reagent-render
     (fn [initial-content path & {:keys [header-label size-label]}]
       [:div.editor-form__component-wrapper
        [text-header header-label path]
@@ -77,6 +79,7 @@
                     btn-name]]))]]
        [:div.editor-form__checkbox-wrapper
         (render-checkbox path initial-content :required)]])))
+        (render-checkbox path initial-content :required)]])})))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän leveys"])

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -129,7 +129,7 @@
          [:div.plus-component
           [:span "+"]]]))))
 
-(defn section-label [path]
+(defn form-component-group [path]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path])]
     (fn []

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -132,7 +132,7 @@
 (defn form-component-group [path]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path])]
-    (fn []
+    (fn [path]
       (-> [:div.editor-form__component-wrapper
            [text-header "Lomakeosio" path]]
           (into

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -54,41 +54,41 @@
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
     (fn [initial-content path & {:keys [header-label size-label]}]
       (component-with-fade-effects [initial-content]
-      [:div.editor-form__component-wrapper
-       [text-header header-label path]
-       [:div.editor-form__text-field-wrapper
-        [:header.editor-form__component-item-header "Otsikko"]
-        (doall
-          (for [lang @languages]
-            ^{:key lang}
-            [:input.editor-form__text-field {:value     (get-in @value [:label lang])
-                                             :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
-       [:div.editor-form__size-button-wrapper
-        [:header.editor-form__component-item-header size-label]
-        [:div.editor-form__size-button-group
-         (doall (for [[btn-name btn-id] radio-button-ids]
-                  ^{:key (str btn-id "-radio")}
-                  [:div
-                   [:input.editor-form__size-button.editor-form__size-button
-                    {:type      "radio"
-                     :value     btn-name
-                     :checked   (or
-                                  (= @size btn-name)
-                                  (and
-                                    (nil? @size)
-                                    (= "M" btn-name)))
-                     :name      radio-group-id
-                     :id        btn-id
-                     :on-change (fn [] (size-change btn-name))}]
-                   [:label
-                    {:for btn-id
-                     :class     (match btn-name
-                                  "S" "editor-form__size-button--left-edge"
-                                  "L" "editor-form__size-button--right-edge"
-                                  :else nil)}
-                    btn-name]]))]]
-       [:div.editor-form__checkbox-wrapper
-        (render-checkbox path initial-content :required)]]))))
+        [:div.editor-form__component-wrapper
+         [text-header header-label path]
+         [:div.editor-form__text-field-wrapper
+          [:header.editor-form__component-item-header "Otsikko"]
+          (doall
+            (for [lang @languages]
+              ^{:key lang}
+              [:input.editor-form__text-field {:value     (get-in @value [:label lang])
+                                               :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
+         [:div.editor-form__size-button-wrapper
+          [:header.editor-form__component-item-header size-label]
+          [:div.editor-form__size-button-group
+           (doall (for [[btn-name btn-id] radio-button-ids]
+                    ^{:key (str btn-id "-radio")}
+                    [:div
+                     [:input.editor-form__size-button.editor-form__size-button
+                      {:type      "radio"
+                       :value     btn-name
+                       :checked   (or
+                                    (= @size btn-name)
+                                    (and
+                                      (nil? @size)
+                                      (= "M" btn-name)))
+                       :name      radio-group-id
+                       :id        btn-id
+                       :on-change (fn [] (size-change btn-name))}]
+                     [:label
+                      {:for btn-id
+                       :class     (match btn-name
+                                    "S" "editor-form__size-button--left-edge"
+                                    "L" "editor-form__size-button--right-edge"
+                                    :else nil)}
+                      btn-name]]))]]
+         [:div.editor-form__checkbox-wrapper
+          (render-checkbox path initial-content :required)]]))))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän leveys"])
@@ -133,16 +133,16 @@
         value      (subscribe [:editor/get-component-value path])]
     (fn [content path children]
       (component-with-fade-effects [content]
-      [:div.editor-form__section_wrapper
-       [:div.editor-form__component-wrapper
-        [text-header "Lomakeosio" path :form-section? true]
-        [:div.editor-form__text-field-wrapper.editor-form__text-field--section
-         [:header.editor-form__component-item-header "Osion nimi"]
-         (doall
-           (for [lang @languages]
-             ^{:key lang}
-             [:input.editor-form__text-field
-              {:value     (get-in @value [:label lang])
-               :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
-       children
-       [add-component (conj path :children (count children))]]))))
+        [:div.editor-form__section_wrapper
+         [:div.editor-form__component-wrapper
+          [text-header "Lomakeosio" path :form-section? true]
+          [:div.editor-form__text-field-wrapper.editor-form__text-field--section
+           [:header.editor-form__component-item-header "Osion nimi"]
+           (doall
+             (for [lang @languages]
+               ^{:key lang}
+               [:input.editor-form__text-field
+                {:value     (get-in @value [:label lang])
+                 :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
+         children
+         [add-component (conj path :children (count children))]]))))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -30,7 +30,7 @@
   [:div.editor-form__header-wrapper
    [:header.editor-form__component-header label]
    [:a.editor-form__component-header-link
-    {:on-click #(dispatch [:remove-component path])}
+    {:on-click #(dispatch [:hide-component path])}
     "Poista"]])
 
 (defn text-component [initial-content path & {:keys [header-label size-label]}]
@@ -40,9 +40,17 @@
         radio-group-id   (str "form-size-" (gensym))
         radio-buttons    ["S" "M" "L"]
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
-        size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
+        size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))
+        handler-fn       (fn [_]
+                           (dispatch [:remove-component path]))]
     (r/create-class
-       {:reagent-render
+      {:component-did-mount
+       (fn [this]
+         (let [node   (r/dom-node this)
+               events ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]]
+           (doseq [event events]
+             (.addEventListener node event handler-fn))))
+       :reagent-render
     (fn [initial-content path & {:keys [header-label size-label]}]
       [:div.editor-form__component-wrapper
        [text-header header-label path]

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -26,15 +26,15 @@
      [:label.editor-form__checkbox-label {:for id} label]]))
 
 (defn- text-header
-  [label path]
+  [label path & {:keys [form-section?]}]
   [:div.editor-form__header-wrapper
    [:header.editor-form__component-header label]
    [:a.editor-form__component-header-link
     {:on-click (fn [event]
-                 (let [target     (if-not
-                                    (some #(= :children %) path)
-                                    (-> event .-target .-parentNode .-parentNode)
-                                    (-> event .-target .-parentNode .-parentNode .-parentNode))
+                 (let [target     (if
+                                    form-section?
+                                    (-> event .-target .-parentNode .-parentNode .-parentNode)
+                                    (-> event .-target .-parentNode .-parentNode))
                        events     ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]
                        handler-fn (fn [_]
                                     (dispatch [:remove-component path]))]
@@ -138,7 +138,7 @@
          (= "fading-out" (get-in content [:params :status]))
          {:class "animated fadeOutUp"})
        [:div.editor-form__component-wrapper
-        [text-header "Lomakeosio" path]
+        [text-header "Lomakeosio" path :form-section? true]
         [:div.editor-form__text-field-wrapper.editor-form__text-field--section
          [:header.editor-form__component-item-header "Osion nimi"]
          (doall

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -51,43 +51,45 @@
            (doseq [event events]
              (.addEventListener node event handler-fn))))
        :reagent-render
-    (fn [initial-content path & {:keys [header-label size-label]}]
-      [:div.editor-form__component-wrapper
-       [text-header header-label path]
-       [:div.editor-form__text-field-wrapper
-        [:header.editor-form__component-item-header "Otsikko"]
-        (doall
-          (for [lang @languages]
-            ^{:key lang}
-            [:input.editor-form__text-field {:value     (get-in @value [:label lang])
-                                             :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
-       [:div.editor-form__size-button-wrapper
-        [:header.editor-form__component-item-header size-label]
-        [:div.editor-form__size-button-group
-         (doall (for [[btn-name btn-id] radio-button-ids]
-                  ^{:key (str btn-id "-radio")}
-                  [:div
-                   [:input.editor-form__size-button.editor-form__size-button
-                    {:type      "radio"
-                     :value     btn-name
-                     :checked   (or
-                                  (= @size btn-name)
-                                  (and
-                                    (nil? @size)
-                                    (= "M" btn-name)))
-                     :name      radio-group-id
-                     :id        btn-id
-                     :on-change (fn [] (size-change btn-name))}]
-                   [:label
-                    {:for btn-id
-                     :class     (match btn-name
-                                       "S" "editor-form__size-button--left-edge"
-                                       "L" "editor-form__size-button--right-edge"
-                                       :else nil)}
-                    btn-name]]))]]
-       [:div.editor-form__checkbox-wrapper
-        (render-checkbox path initial-content :required)]])))
-        (render-checkbox path initial-content :required)]])})))
+       (fn [initial-content path & {:keys [header-label size-label]}]
+         [:div.editor-form__component-wrapper
+          (when
+            (= "fading-out" (get-in initial-content [:params :status]))
+            {:class "animated fadeOutUp"})
+          [text-header header-label path]
+          [:div.editor-form__text-field-wrapper
+           [:header.editor-form__component-item-header "Otsikko"]
+           (doall
+             (for [lang @languages]
+               ^{:key lang}
+               [:input.editor-form__text-field {:value     (get-in @value [:label lang])
+                                                :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
+          [:div.editor-form__size-button-wrapper
+           [:header.editor-form__component-item-header size-label]
+           [:div.editor-form__size-button-group
+            (doall (for [[btn-name btn-id] radio-button-ids]
+                     ^{:key (str btn-id "-radio")}
+                     [:div
+                      [:input.editor-form__size-button.editor-form__size-button
+                       {:type      "radio"
+                        :value     btn-name
+                        :checked   (or
+                                     (= @size btn-name)
+                                     (and
+                                       (nil? @size)
+                                       (= "M" btn-name)))
+                        :name      radio-group-id
+                        :id        btn-id
+                        :on-change (fn [] (size-change btn-name))}]
+                      [:label
+                       {:for btn-id
+                        :class     (match btn-name
+                                     "S" "editor-form__size-button--left-edge"
+                                     "L" "editor-form__size-button--right-edge"
+                                     :else nil)}
+                       btn-name]]))]]
+          [:div.editor-form__checkbox-wrapper
+           (render-checkbox path initial-content :required)]])})))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän leveys"])

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -132,6 +132,8 @@
 (defn form-component-group [path]
   (let [languages (subscribe [:editor/languages])
         value     (subscribe [:editor/get-component-value path])]
+    (r/create-class
+      {:reagent-render
     (fn [path]
       (-> [:div.editor-form__component-wrapper
            [text-header "Lomakeosio" path]]
@@ -143,4 +145,4 @@
                   ^{:key lang}
                   [:input.editor-form__text-field
                    {:value     (get-in @value [:label lang])
-                    :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]])))))
+                    :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]])))})))

--- a/src/cljs/ataru/virkailija/editor/core.cljs
+++ b/src/cljs/ataru/virkailija/editor/core.cljs
@@ -28,7 +28,7 @@
          (let [children (for [[index child] (zipmap (range) children)]
                           ^{:key index}
                           [soresu->reagent child (conj path :children index)])]
-           [ec/component-group path children])
+           [ec/component-group content path children])
 
          [{:fieldClass "formField" :fieldType "textField"}]
          [ec/text-field content path]

--- a/src/cljs/ataru/virkailija/editor/core.cljs
+++ b/src/cljs/ataru/virkailija/editor/core.cljs
@@ -27,7 +27,7 @@
            :children   children}]
          (let [wrapper-element (->> (for [[index child] (zipmap (range) children)]
                                       [soresu->reagent child (conj path :children index)])
-                                    (into [:div.editor-form__section_wrapper [ec/section-label path]]))]
+                                    (into [:div.editor-form__section_wrapper [ec/form-component-group path]]))]
            (conj wrapper-element [ec/add-component (conj path :children (count (:children content)))]))
 
          [{:fieldClass "formField" :fieldType "textField"}]

--- a/src/cljs/ataru/virkailija/editor/core.cljs
+++ b/src/cljs/ataru/virkailija/editor/core.cljs
@@ -27,7 +27,11 @@
            :children   children}]
          (let [wrapper-element (->> (for [[index child] (zipmap (range) children)]
                                       [soresu->reagent child (conj path :children index)])
-                                    (into [:div.editor-form__section_wrapper [ec/form-component-group path]]))]
+                                    (into [:div.editor-form__section_wrapper
+                                           (when
+                                             (= "fading-out" (get-in content [:params :status]))
+                                             {:class "animated fadeOutUp"})
+                                           [ec/form-component-group path]]))]
            (conj wrapper-element [ec/add-component (conj path :children (count (:children content)))]))
 
          [{:fieldClass "formField" :fieldType "textField"}]

--- a/src/cljs/ataru/virkailija/editor/core.cljs
+++ b/src/cljs/ataru/virkailija/editor/core.cljs
@@ -36,13 +36,6 @@
          [{:fieldClass "formField" :fieldType "textArea"}]
          [ec/text-area content path]
 
-         [{:fieldClass "infoElement"
-           :fieldType  "link"}]
-         [ec/render-link-info content path]
-
-         [{:fieldClass "infoElement"}]
-         [ec/render-info content path]
-
          :else (do
                  (error content)
                  (throw "error" content))))

--- a/src/cljs/ataru/virkailija/editor/core.cljs
+++ b/src/cljs/ataru/virkailija/editor/core.cljs
@@ -25,14 +25,10 @@
   (match [content]
          [{:fieldClass "wrapperElement"
            :children   children}]
-         (let [wrapper-element (->> (for [[index child] (zipmap (range) children)]
-                                      [soresu->reagent child (conj path :children index)])
-                                    (into [:div.editor-form__section_wrapper
-                                           (when
-                                             (= "fading-out" (get-in content [:params :status]))
-                                             {:class "animated fadeOutUp"})
-                                           [ec/form-component-group path]]))]
-           (conj wrapper-element [ec/add-component (conj path :children (count (:children content)))]))
+         (let [children (for [[index child] (zipmap (range) children)]
+                          ^{:key index}
+                          [soresu->reagent child (conj path :children index)])]
+           [ec/component-group path children])
 
          [{:fieldClass "formField" :fieldType "textField"}]
          [ec/text-field content path]
@@ -55,3 +51,4 @@
                  :when             (not-empty @content)]
              [soresu->reagent json-blob [index]]))
          [ec/add-component (count @content)])])))
+

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -77,6 +77,14 @@
 (register-handler :remove-component remove-component)
 
 (register-handler
+  :hide-component
+  (fn [db [_ path]]
+    (let [form-id   (get-in db [:editor :selected-form-id])
+          path-vec  (flatten [:editor :forms form-id :content [path] :params :status])
+          new-state (assoc-in db path-vec "fading-out")]
+      new-state)))
+
+(register-handler
   :editor/handle-user-info
   (fn [db [_ user-info-response]]
     (assoc-in db [:editor :user-info] user-info-response)))


### PR DESCRIPTION
When remove link is pressed either on a component or a component section, the target is removed with a fade-out effect.

The flow of removing a component works now like this:

1. User clicks remove link
2. An event handler that detects when the fade-out animation ends is installed onto the parent div containing the form component, or the whole wrapper component in case of a form section.
3. A `:hide-component` event is dispatched.
4. The `:hide-component` handler associates a `fading-out` status to the component to be removed.
5. The `component-with-fade-effects` associates the correct animation style to the component to be removed.
6. When the animation ends, the handler installed in part `2` of this list will be triggered. The handler function dispatches the `:remove-component` event.
7. The `:remove-component` event handler updates the application state by removing the component.

This branch also features some refactorings to the codebase.