### PR TITLE
Fade in effects for new components

### DIFF
--- a/src/cljc/ataru/virkailija/editor/component_macros.cljc
+++ b/src/cljc/ataru/virkailija/editor/component_macros.cljc
@@ -2,12 +2,13 @@
 
 (defmacro component-with-fade-effects
   [bindings & body]
-  `(let [component# (do ~@body)
-         status-path# [:params :status]
-         fade-out-class# "animated fadeOutUp"]
-     (if
-       (= "fading-out" (get-in ~(first bindings) status-path#))
+  `(let [component# (do ~@body)]
+     (if-let [status# (get-in ~(first bindings) [:params :status])]
        (let [element# (first component#)
-             content# (subvec component# 1)]
-         (into [element# {:class fade-out-class#}] content#))
+             content# (subvec component# 1)
+             class#   (case status#
+                        "fading-out" "animated fadeOutUp"
+                        "fading-in"  "animated fadeInUp"
+                        "ready"      nil)]
+         (into [element# {:class class#}] content#))
        component#)))

--- a/src/cljc/ataru/virkailija/soresu/component.cljc
+++ b/src/cljc/ataru/virkailija/soresu/component.cljc
@@ -6,7 +6,7 @@
    :fieldType  "textField"
    :label      {:fi "", :sv ""}
    :id         (str (gensym))
-   :params     {}
+   :params     {:status "fading-in"}
    :required   false})
 
 (defn text-area []
@@ -19,4 +19,5 @@
    :fieldType  "fieldset"
    :id         (str (gensym))
    :label      {:fi "Osion nimi" :sv "Avsnitt namn"}
-   :children   []})
+   :children   []
+   :params     {:status "fading-in"}})

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -72,43 +72,43 @@
            (doseq [event events]
              (.addEventListener target event handler-fn))))
        :reagent-render
-    (fn [initial-content path & {:keys [header-label size-label]}]
-      (component-with-fade-effects [initial-content]
-        [:div.editor-form__component-wrapper
-         [text-header header-label path]
-         [:div.editor-form__text-field-wrapper
-          [:header.editor-form__component-item-header "Kysymys"]
-          (doall
-            (for [lang @languages]
-              ^{:key lang}
-              [:input.editor-form__text-field {:value     (get-in @value [:label lang])
-                                               :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
-         [:div.editor-form__size-button-wrapper
-          [:header.editor-form__component-item-header size-label]
-          [:div.editor-form__size-button-group
-           (doall (for [[btn-name btn-id] radio-button-ids]
-                    ^{:key (str btn-id "-radio")}
-                    [:div
-                     [:input.editor-form__size-button.editor-form__size-button
-                      {:type      "radio"
-                       :value     btn-name
-                       :checked   (or
-                                    (= @size btn-name)
-                                    (and
-                                      (nil? @size)
-                                      (= "M" btn-name)))
-                       :name      radio-group-id
-                       :id        btn-id
-                       :on-change (fn [] (size-change btn-name))}]
-                     [:label
-                      {:for btn-id
-                       :class     (match btn-name
-                                    "S" "editor-form__size-button--left-edge"
-                                    "L" "editor-form__size-button--right-edge"
-                                    :else nil)}
-                      btn-name]]))]]
-         [:div.editor-form__checkbox-wrapper
-          (render-checkbox path initial-content :required)]]))})))
+       (fn [initial-content path & {:keys [header-label size-label]}]
+         (component-with-fade-effects [initial-content]
+           [:div.editor-form__component-wrapper
+            [text-header header-label path]
+            [:div.editor-form__text-field-wrapper
+             [:header.editor-form__component-item-header "Kysymys"]
+             (doall
+               (for [lang @languages]
+                 ^{:key lang}
+                 [:input.editor-form__text-field {:value     (get-in @value [:label lang])
+                                                  :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
+            [:div.editor-form__size-button-wrapper
+             [:header.editor-form__component-item-header size-label]
+             [:div.editor-form__size-button-group
+              (doall (for [[btn-name btn-id] radio-button-ids]
+                       ^{:key (str btn-id "-radio")}
+                       [:div
+                        [:input.editor-form__size-button.editor-form__size-button
+                         {:type      "radio"
+                          :value     btn-name
+                          :checked   (or
+                                       (= @size btn-name)
+                                       (and
+                                         (nil? @size)
+                                         (= "M" btn-name)))
+                          :name      radio-group-id
+                          :id        btn-id
+                          :on-change (fn [] (size-change btn-name))}]
+                        [:label
+                         {:for btn-id
+                          :class     (match btn-name
+                                       "S" "editor-form__size-button--left-edge"
+                                       "L" "editor-form__size-button--right-edge"
+                                       :else nil)}
+                         btn-name]]))]]
+            [:div.editor-form__checkbox-wrapper
+             (render-checkbox path initial-content :required)]]))})))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän koko"])
@@ -160,18 +160,18 @@
            (doseq [event events]
              (.addEventListener target event handler-fn))))
        :reagent-render
-    (fn [content path children]
-      (component-with-fade-effects [content]
-        [:div.editor-form__section_wrapper
-         [:div.editor-form__component-wrapper
-          [text-header "Lomakeosio" path :form-section? true]
-          [:div.editor-form__text-field-wrapper.editor-form__text-field--section
-           [:header.editor-form__component-item-header "Osion nimi"]
-           (doall
-             (for [lang @languages]
-               ^{:key lang}
-               [:input.editor-form__text-field
-                {:value     (get-in @value [:label lang])
-                 :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
-         children
-         [add-component (conj path :children (count children))]]))})))
+       (fn [content path children]
+         (component-with-fade-effects [content]
+           [:div.editor-form__section_wrapper
+            [:div.editor-form__component-wrapper
+             [text-header "Lomakeosio" path :form-section? true]
+             [:div.editor-form__text-field-wrapper.editor-form__text-field--section
+              [:header.editor-form__component-item-header "Osion nimi"]
+              (doall
+                (for [lang @languages]
+                  ^{:key lang}
+                  [:input.editor-form__text-field
+                   {:value     (get-in @value [:label lang])
+                    :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
+            children
+            [add-component (conj path :children (count children))]]))})))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -63,6 +63,15 @@
         radio-buttons    ["S" "M" "L"]
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
+    (r/create-class
+      {:component-did-mount
+       (fn [this]
+         (let [events     ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]
+               handler-fn (animation-did-end-handler #(dispatch [:component-did-fade-in path]))
+               target     (r/dom-node this)]
+           (doseq [event events]
+             (.addEventListener target event handler-fn))))
+       :reagent-render
     (fn [initial-content path & {:keys [header-label size-label]}]
       (component-with-fade-effects [initial-content]
         [:div.editor-form__component-wrapper
@@ -99,7 +108,7 @@
                                     :else nil)}
                       btn-name]]))]]
          [:div.editor-form__checkbox-wrapper
-          (render-checkbox path initial-content :required)]]))))
+          (render-checkbox path initial-content :required)]]))})))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän koko"])
@@ -142,6 +151,15 @@
 (defn component-group [content path children]
   (let [languages  (subscribe [:editor/languages])
         value      (subscribe [:editor/get-component-value path])]
+    (r/create-class
+      {:component-did-mount
+       (fn [this]
+         (let [events     ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]
+               handler-fn (animation-did-end-handler #(dispatch [:component-did-fade-in path]))
+               target     (r/dom-node this)]
+           (doseq [event events]
+             (.addEventListener target event handler-fn))))
+       :reagent-render
     (fn [content path children]
       (component-with-fade-effects [content]
         [:div.editor-form__section_wrapper
@@ -156,4 +174,4 @@
                 {:value     (get-in @value [:label lang])
                  :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
          children
-         [add-component (conj path :children (count children))]]))))
+         [add-component (conj path :children (count children))]]))})))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -26,8 +26,8 @@
                                     :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path metadata-kwd])}]
      [:label.editor-form__checkbox-label {:for id} label]]))
 
-(defn- get-fade-out-did-end-handler
-  [path]
+(defn- animation-did-end-handler
+  [f]
   (let [handler-fn (fn [event]
                      (let [target (.-target event)
                            events ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]]
@@ -35,7 +35,7 @@
                          (->> (js-arguments)
                               .-callee
                               (.removeEventListener target event)))
-                     (dispatch [:remove-component path])))]
+                       (f)))]
     handler-fn))
 
 (defn- text-header
@@ -49,7 +49,7 @@
                                     (-> event .-target .-parentNode .-parentNode .-parentNode)
                                     (-> event .-target .-parentNode .-parentNode))
                        events     ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]
-                       handler-fn (get-fade-out-did-end-handler path)]
+                       handler-fn (animation-did-end-handler #(dispatch [:remove-component path]))]
                    (doseq [event events]
                      (.addEventListener target event handler-fn)))
                  (dispatch [:hide-component path]))}

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -26,6 +26,12 @@
                                     :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path metadata-kwd])}]
      [:label.editor-form__checkbox-label {:for id} label]]))
 
+(defn- get-fade-out-did-end-handler
+  [path]
+  (let [handler-fn (fn [_]
+                     (dispatch [:remove-component path]))]
+    handler-fn))
+
 (defn- text-header
   [label path & {:keys [form-section?]}]
   [:div.editor-form__header-wrapper
@@ -37,8 +43,7 @@
                                     (-> event .-target .-parentNode .-parentNode .-parentNode)
                                     (-> event .-target .-parentNode .-parentNode))
                        events     ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]
-                       handler-fn (fn [_]
-                                    (dispatch [:remove-component path]))]
+                       handler-fn (get-fade-out-did-end-handler path)]
                    (doseq [event events]
                      (.addEventListener target event handler-fn)))
                  (dispatch [:hide-component path]))}

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -14,6 +14,7 @@
   {:required {:id-suffix "_required"
               :label "Pakollinen tieto"}})
 
+
 (defn- render-checkbox
   [path initial-content metadata-kwd]
   (let [metadata (get checkbox-metadata metadata-kwd)
@@ -26,11 +27,13 @@
                                     :on-change #(dispatch [:editor/set-component-value (-> % .-target .-checked) path metadata-kwd])}]
      [:label.editor-form__checkbox-label {:for id} label]]))
 
+(def ^:private events
+  ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"])
+
 (defn- animation-did-end-handler
   [f]
   (let [handler-fn (fn [event]
-                     (let [target (.-target event)
-                           events ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]]
+                     (let [target (.-target event)]
                        (doseq [event events]
                          (->> (js-arguments)
                               .-callee
@@ -48,7 +51,6 @@
                                     form-section?
                                     (-> event .-target .-parentNode .-parentNode .-parentNode)
                                     (-> event .-target .-parentNode .-parentNode))
-                       events     ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]
                        handler-fn (animation-did-end-handler #(dispatch [:remove-component path]))]
                    (doseq [event events]
                      (.addEventListener target event handler-fn)))
@@ -60,8 +62,7 @@
   (r/create-class
     {:component-did-mount
      (fn [this]
-       (let [events     ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]
-             handler-fn (animation-did-end-handler #(dispatch [:component-did-fade-in path]))
+       (let [handler-fn (animation-did-end-handler #(dispatch [:component-did-fade-in path]))
              target     (r/dom-node this)]
          (doseq [event events]
            (.addEventListener target event handler-fn))))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -28,8 +28,14 @@
 
 (defn- get-fade-out-did-end-handler
   [path]
-  (let [handler-fn (fn [_]
-                     (dispatch [:remove-component path]))]
+  (let [handler-fn (fn [event]
+                     (let [target (.-target event)
+                           events ["webkitAnimationEnd" "mozAnimationEnd" "MSAnimationEnd" "oanimationend" "animationend"]]
+                       (doseq [event events]
+                         (->> (js-arguments)
+                              .-callee
+                              (.removeEventListener target event)))
+                     (dispatch [:remove-component path])))]
     handler-fn))
 
 (defn- text-header

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -76,43 +76,43 @@
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))]
     (component-with-fade-in-effect path
-       (fn [initial-content path & {:keys [header-label size-label]}]
-         (component-with-fade-effects [initial-content]
-           [:div.editor-form__component-wrapper
-            [text-header header-label path]
-            [:div.editor-form__text-field-wrapper
-             [:header.editor-form__component-item-header "Kysymys"]
-             (doall
-               (for [lang @languages]
-                 ^{:key lang}
-                 [:input.editor-form__text-field {:value     (get-in @value [:label lang])
-                                                  :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
-            [:div.editor-form__size-button-wrapper
-             [:header.editor-form__component-item-header size-label]
-             [:div.editor-form__size-button-group
-              (doall (for [[btn-name btn-id] radio-button-ids]
-                       ^{:key (str btn-id "-radio")}
-                       [:div
-                        [:input.editor-form__size-button.editor-form__size-button
-                         {:type      "radio"
-                          :value     btn-name
-                          :checked   (or
-                                       (= @size btn-name)
-                                       (and
-                                         (nil? @size)
-                                         (= "M" btn-name)))
-                          :name      radio-group-id
-                          :id        btn-id
-                          :on-change (fn [] (size-change btn-name))}]
-                        [:label
-                         {:for btn-id
-                          :class     (match btn-name
-                                       "S" "editor-form__size-button--left-edge"
-                                       "L" "editor-form__size-button--right-edge"
-                                       :else nil)}
-                         btn-name]]))]]
-            [:div.editor-form__checkbox-wrapper
-             (render-checkbox path initial-content :required)]])))))
+      (fn [initial-content path & {:keys [header-label size-label]}]
+        (component-with-fade-effects [initial-content]
+          [:div.editor-form__component-wrapper
+           [text-header header-label path]
+           [:div.editor-form__text-field-wrapper
+            [:header.editor-form__component-item-header "Kysymys"]
+            (doall
+              (for [lang @languages]
+                ^{:key lang}
+                [:input.editor-form__text-field {:value     (get-in @value [:label lang])
+                                                 :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
+           [:div.editor-form__size-button-wrapper
+            [:header.editor-form__component-item-header size-label]
+            [:div.editor-form__size-button-group
+             (doall (for [[btn-name btn-id] radio-button-ids]
+                      ^{:key (str btn-id "-radio")}
+                      [:div
+                       [:input.editor-form__size-button.editor-form__size-button
+                        {:type      "radio"
+                         :value     btn-name
+                         :checked   (or
+                                      (= @size btn-name)
+                                      (and
+                                        (nil? @size)
+                                        (= "M" btn-name)))
+                         :name      radio-group-id
+                         :id        btn-id
+                         :on-change (fn [] (size-change btn-name))}]
+                       [:label
+                        {:for btn-id
+                         :class     (match btn-name
+                                      "S" "editor-form__size-button--left-edge"
+                                      "L" "editor-form__size-button--right-edge"
+                                      :else nil)}
+                        btn-name]]))]]
+           [:div.editor-form__checkbox-wrapper
+            (render-checkbox path initial-content :required)]])))))
 
 (defn text-field [initial-content path]
   [text-component initial-content path :header-label "Tekstikenttä" :size-label "Tekstikentän koko"])
@@ -156,18 +156,18 @@
   (let [languages  (subscribe [:editor/languages])
         value      (subscribe [:editor/get-component-value path])]
     (component-with-fade-in-effect path
-       (fn [content path children]
-         (component-with-fade-effects [content]
-           [:div.editor-form__section_wrapper
-            [:div.editor-form__component-wrapper
-             [text-header "Lomakeosio" path :form-section? true]
-             [:div.editor-form__text-field-wrapper.editor-form__text-field--section
-              [:header.editor-form__component-item-header "Osion nimi"]
-              (doall
-                (for [lang @languages]
-                  ^{:key lang}
-                  [:input.editor-form__text-field
-                   {:value     (get-in @value [:label lang])
-                    :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
-            children
-            [add-component (conj path :children (count children))]])))))
+      (fn [content path children]
+        (component-with-fade-effects [content]
+          [:div.editor-form__section_wrapper
+           [:div.editor-form__component-wrapper
+            [text-header "Lomakeosio" path :form-section? true]
+            [:div.editor-form__text-field-wrapper.editor-form__text-field--section
+             [:header.editor-form__component-item-header "Osion nimi"]
+             (doall
+               (for [lang @languages]
+                 ^{:key lang}
+                 [:input.editor-form__text-field
+                  {:value     (get-in @value [:label lang])
+                   :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]]
+           children
+           [add-component (conj path :children (count children))]])))))

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -76,21 +76,17 @@
 
 (register-handler :remove-component remove-component)
 
-(register-handler
-  :hide-component
+(defn- component-status-handler
+  [status]
   (fn [db [_ path]]
     (let [form-id   (get-in db [:editor :selected-form-id])
           path-vec  (flatten [:editor :forms form-id :content [path] :params :status])
-          new-state (assoc-in db path-vec "fading-out")]
+          new-state (assoc-in db path-vec status)]
       new-state)))
 
-(register-handler
-  :component-did-fade-in
-  (fn [db [_ path]]
-    (let [form-id   (get-in db [:editor :selected-form-id])
-          path-vec  (flatten [:editor :forms form-id :content [path] :params :status])
-          new-state (assoc-in db path-vec "ready")]
-      new-state)))
+(register-handler :hide-component (component-status-handler "fading-out"))
+
+(register-handler :component-did-fade-in (component-status-handler "ready"))
 
 (register-handler
   :editor/handle-user-info

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -85,6 +85,14 @@
       new-state)))
 
 (register-handler
+  :component-did-fade-in
+  (fn [db [_ path]]
+    (let [form-id   (get-in db [:editor :selected-form-id])
+          path-vec  (flatten [:editor :forms form-id :content [path] :params :status])
+          new-state (assoc-in db path-vec "ready")]
+      new-state)))
+
+(register-handler
   :editor/handle-user-info
   (fn [db [_ user-info-response]]
     (assoc-in db [:editor :user-info] user-info-response)))


### PR DESCRIPTION
New components are faded-in to the form. The mechanism is pretty much the same than when fading out components (see https://github.com/Opetushallitus/ataru/pull/37).