### PR TITLE
Prevent concurrent editing

### DIFF
--- a/resources/less/banner.less
+++ b/resources/less/banner.less
@@ -8,6 +8,8 @@
   display: flex;
   flex: none;
   height: 100px;
+  position: fixed;
+  top: 0;
   flex-flow: row nowrap;
   background-color: @pale-blue;
   color: white;

--- a/resources/less/banner.less
+++ b/resources/less/banner.less
@@ -3,10 +3,10 @@
 .top-banner {
   font-size: 14px;
   justify-content: space-between;
-  padding-top: 28px;
   width: 100%;
   display: flex;
   flex: none;
+  align-items: center;
   height: 100px;
   position: fixed;
   top: 0;

--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -1,5 +1,9 @@
 @import "vars";
 
+.main-container {
+  padding-top: 100px;
+}
+
 .editor-form__container {
   background-color: @very-light-gray;
   border-bottom: 1px solid #E6E6E6;

--- a/resources/less/virkailija-banner.less
+++ b/resources/less/virkailija-banner.less
@@ -38,10 +38,16 @@
     background: #0094C3;
     color: #A8D6E6;
     border-radius: 2px;
-    padding: 5px 15px 0 15px;
-    height: 31px;
-    margin-top: 7px;
-    white-space: nowrap;
+    padding: 10px 15px;
+    margin: 3px 20px;
+    -webkit-animation-iteration-count: 1.5;
+    -moz-animation-iteration-count: 1.5;
+    -o-animation-iteration-count: 1.5;
+    animation-iteration-count: 1.5;
+
+    span {
+      display: inline-block;
+    }
   }
 
   .section-link {

--- a/src/cljs/ataru/virkailija/temporal.cljs
+++ b/src/cljs/ataru/virkailija/temporal.cljs
@@ -35,6 +35,11 @@
   (fn [element]
     (update-in element [kw] str->googdate)))
 
+(defn time->iso-str [t]
+  (->> t
+       c/to-default-time-zone
+       (f/unparse (f/formatters :date-time))))
+
 (defn- time->str [google-date]
   (->> google-date
        c/to-default-time-zone

--- a/src/cljs/ataru/virkailija/views/banner.cljs
+++ b/src/cljs/ataru/virkailija/views/banner.cljs
@@ -72,6 +72,10 @@
       [:div
        (when @flasher
          (match [@loading? @flasher]
+                [false {:error-type :concurrent-edit
+                        :message message}]
+                [:div.flasher {:class "concurrent-edit-error animated flash"}
+                 [:span message]]
                 [false {:detail detailed-error
                         :message message}]
                 [:div.flasher {:style {"color" "crimson"}}


### PR DESCRIPTION
Do not overwrite changes & show error message when form has been changed in the background.