### PR TITLE
Send email confirmation when application is submitted

### DIFF
--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -9,4 +9,5 @@
  :authentication {:opintopolku-login-url "{{ataru_authentication_opintopolku_login_url}}"
                   :opintopolku-logout-url  "{{ataru_authentication_opintopolku_logout_url}}"
                   :ataru-login-success-url "{{ataru_authentication_ataru_login_success_url}}"
-                  :cas-client-url "{{ataru_authentication_cas_client_url}}"}}
+                  :cas-client-url "{{ataru_authentication_cas_client_url}}"}
+ :email {:email_service_url "{{ataru_email_service_url}}"}}

--- a/spec/ataru/hakija/email_spec.clj
+++ b/spec/ataru/hakija/email_spec.clj
@@ -19,10 +19,7 @@
     (with-mock-api (fn [uri request]
                      (should= uri "https://itest-virkailija.oph.ware.fi/ryhmasahkoposti-service/email/firewall")
                      (should= (get-in request [:headers "content-type"]) "application/json")
-                       (should=
-                         (json/parse-string (:body request) true)
-                         {:email {:from "no-reply@opintopolku.fi"
-                                  :subject "Hakemus vastaanotettu"
-                                  :isHtml false
-                                  :body "Hakemuksesi on vastaanotettu!"}}))
+                     (let [body (json/parse-string (:body request) true)]
+                       (should= (get-in body [:email :from]) "no-reply@opintopolku.fi")
+                       (should= (get-in body [:email :subject]) "Hakemus vastaanotettu")))
       (email/send-email-verification {}))))

--- a/spec/ataru/hakija/email_spec.clj
+++ b/spec/ataru/hakija/email_spec.clj
@@ -1,0 +1,28 @@
+(ns ataru.hakija.email-spec
+  (:require [aleph.http :as http]
+            [ataru.hakija.email :as email]
+            [cheshire.core :as json]
+            [speclj.core :refer :all]))
+
+(defmacro with-mock-api
+  [eval-fn & body]
+  `(let [api-called?# (atom false)]
+     (with-redefs-fn {#'http/post (fn [& args#]
+                                    (apply ~eval-fn args#)
+                                    (reset! api-called?# true))}
+       (fn []
+         ~@body
+         (should @api-called?#)))))
+
+(describe "sending email"
+  (it "sends email using the /ryhmasahkoposti-service/email/firewall API call"
+    (with-mock-api (fn [uri request]
+                     (should= uri "https://itest-virkailija.oph.ware.fi/ryhmasahkoposti-service/email/firewall")
+                     (should= (get-in request [:headers "content-type"]) "application/json")
+                       (should=
+                         (json/parse-string (:body request) true)
+                         {:email {:from "no-reply@opintopolku.fi"
+                                  :subject "Hakemus vastaanotettu"
+                                  :isHtml false
+                                  :body "Hakemuksesi on vastaanotettu!"}}))
+      (email/send-email-verification {}))))

--- a/src/clj/ataru/hakija/email.clj
+++ b/src/clj/ataru/hakija/email.clj
@@ -1,0 +1,16 @@
+(ns ataru.hakija.email
+  (:require [aleph.http :as http]
+            [cheshire.core :as json]
+            [oph.soresu.common.config :refer [config]]))
+
+(defn send-email-verification
+  [application]
+  (let [url (str
+              (get-in config [:email :email_service_url])
+              "/ryhmasahkoposti-service/email/firewall")]
+    (http/post url {:headers {"content-type" "application/json"}
+                    :body (json/generate-string {:email {:from "no-reply@opintopolku.fi"
+                                                         :subject "Hakemus vastaanotettu"
+                                                         :isHtml false
+                                                         :body "Hakemuksesi on vastaanotettu!"}
+                                                 :recipient [{:email "hakija@opintopolku.fi"}]})})))

--- a/src/clj/ataru/hakija/email.clj
+++ b/src/clj/ataru/hakija/email.clj
@@ -5,12 +5,19 @@
 
 (defn send-email-verification
   [application]
-  (let [url (str
-              (get-in config [:email :email_service_url])
-              "/ryhmasahkoposti-service/email/firewall")]
+  (let [url  (str
+               (get-in config [:email :email_service_url])
+               "/ryhmasahkoposti-service/email/firewall")
+        body (clojure.string/join "<br/>" (map
+                                            (fn [element]
+                                              (str
+                                                (get-in element [:label :fi])
+                                                ": "
+                                                (:value element)))
+                                            (:answers application)))]
     (http/post url {:headers {"content-type" "application/json"}
                     :body (json/generate-string {:email {:from "no-reply@opintopolku.fi"
                                                          :subject "Hakemus vastaanotettu"
                                                          :isHtml false
-                                                         :body "Hakemuksesi on vastaanotettu!"}
+                                                         :body body}
                                                  :recipient [{:email "hakija@opintopolku.fi"}]})})))

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -1,5 +1,6 @@
 (ns ataru.hakija.hakija-routes
   (:require [ataru.buildversion :refer [buildversion-routes]]
+            [ataru.hakija.email :as email]
             [ataru.forms.form-store :as form-store]
             [ataru.applications.application-store :as application-store]
             [compojure.core :refer [routes defroutes wrap-routes context GET]]
@@ -25,6 +26,7 @@
   (info application)
   (let [stored-app-id (application-store/insert-application application)]
     (info "Stored application with id:" stored-app-id)
+    (email/send-email-verification application)
     (ok {})))
 
 (defn- handle-client-error [error-details]


### PR DESCRIPTION
In this implementation the recipient is hard-coded to a non-existing email address. The real recipient address must be set when we actually know who is the recipient.