### PR TITLE
Dropdown component

### DIFF
--- a/resources/less/banner.less
+++ b/resources/less/banner.less
@@ -13,6 +13,7 @@
   flex-flow: row nowrap;
   background-color: @pale-blue;
   color: white;
+  z-index: 10;
 
   .logo {
     margin-left: 85px;

--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -110,10 +110,15 @@
   flex-basis: 390px;
 }
 
+.editor-form__text-field-wrapper__option {
+  padding: 0 14px 10px 0;
+}
+
 .editor-form__multi-question-wrapper {
-  padding: 10px 14px 20px;
   width: 100%;
   display: flex;
+  flex-direction: column;
+  flex-flow: row wrap;
 }
 
 .editor-form__multi-options_wrapper {

--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -110,6 +110,21 @@
   flex-basis: 390px;
 }
 
+.editor-form__multi-question-wrapper {
+  padding: 10px 14px 20px;
+  width: 100%;
+  display: flex;
+}
+
+.editor-form__multi-options_wrapper {
+  padding: 10px 14px 20px;
+  width: 100%;
+}
+
+.editor-form__multi-option-wrapper {
+  display: flex;
+}
+
 form > div > .editor-form__component-wrapper {
   margin-left: 0;
   margin-right: 0;

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -141,7 +141,7 @@
   margin: auto;
   width: @desktop-content-width;
 }
-.application__form-field {
+.application__form-field, .application__form-dropdown {
   margin-left: 245px;
   display: flex;
   flex-direction: column;
@@ -153,6 +153,69 @@
   color: @blue-text-color;
   margin-bottom: 6px;
 }
+
+.application__form-select-wrapper {
+  font-size: 16px;
+  position: relative;
+  display: inline-block;
+}
+
+.application__form-select {
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  transition: border-color 0.2s;
+  line-height: normal;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  width: 100%;
+
+  padding-left: 10px;
+  border: solid 1px #06526B;
+  border-radius: 2px;
+  height: 43px;
+  font-size: 16px;
+  color: @text-color;
+  background-color: #fff;
+  box-shadow: inset 0 0 2px #00526c;
+}
+
+.application__form-select-arrow {
+  background: #fff;
+  bottom: 5px;
+  position: absolute;
+  right: 5px;
+  top: 5px;
+  width: 50px;
+  pointer-events: none;
+}
+
+.application__form-select-arrow:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 24px;
+  margin-top: -5px;
+  pointer-events: none;
+  border-top: 10px solid #EB5168;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+}
+
+.application__form-select-arrow:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 28px;
+  margin-top: -5px;
+  pointer-events: none;
+  border-top: 6px solid #fff;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+}
+
 .application__form-text-input {
   border: solid 1px #06526B;
   border-radius: 2px;

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -166,11 +166,7 @@
   -moz-appearance: none;
   appearance: none;
   transition: border-color 0.2s;
-  line-height: normal;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  width: 100%;
+  width: 305px;
 
   padding-left: 10px;
   border: solid 1px #06526B;
@@ -183,12 +179,12 @@
 }
 
 .application__form-select-arrow {
-  background: #fff;
-  bottom: 5px;
+  background-color: #06526B;
+  bottom: 0;
+  left: 260px;
+  top: 0;
   position: absolute;
-  right: 5px;
-  top: 5px;
-  width: 50px;
+  width: 44px;
   pointer-events: none;
 }
 
@@ -196,24 +192,24 @@
   content: '';
   position: absolute;
   top: 50%;
-  right: 24px;
-  margin-top: -5px;
+  right: 14px;
+  margin-top: -3px;
   pointer-events: none;
-  border-top: 10px solid #EB5168;
-  border-left: 10px solid transparent;
-  border-right: 10px solid transparent;
+  border-top: 8px solid #fff;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
 }
 
 .application__form-select-arrow:after {
   content: '';
   position: absolute;
   top: 50%;
-  right: 28px;
+  right: 14px;
   margin-top: -5px;
   pointer-events: none;
-  border-top: 6px solid #fff;
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
+  border-top: 8px solid #06526B;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
 }
 
 .application__form-text-input {

--- a/src/clj/ataru/schema/clj_schema.clj
+++ b/src/clj/ataru/schema/clj_schema.clj
@@ -60,7 +60,8 @@
                                         s/Int
                                         [s/Str])
                      :fieldType (apply s/enum ["textField"
-                                               "textArea"])
+                                               "textArea"
+                                               "dropdown"])
                      :label OptionalLocalizedString})
 
 (s/defschema Application {:form Long

--- a/src/cljc/ataru/virkailija/soresu/component.cljc
+++ b/src/cljc/ataru/virkailija/soresu/component.cljc
@@ -21,3 +21,17 @@
    :label      {:fi "Osion nimi" :sv "Avsnitt namn"}
    :children   []
    :params     {}})
+
+(defn dropdown-option
+  []
+  {:value "" :label {:fi "" :sv ""}})
+
+(defn dropdown
+  []
+  {:fieldClass "formField"
+   :fieldType "dropdown"
+   :id (str (gensym))
+   :label {:fi "", :sv ""}
+   :params {}
+   :options [(dropdown-option)]
+   :required false})

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -15,19 +15,19 @@
          :else "application__form-text-input__size-medium"))
 
 (defn- field-value-valid?
-  [field-value]
-  (if (:required field-value) (not (empty? (trim field-value))) true))
+  [field-data value]
+  (if (:required field-data) (not (clojure.string/blank? value)) true))
 
 (defn- textual-field-change [text-field-data evt]
   (let [value (-> evt .-target .-value)
-        valid (field-value-valid? value)]
+        valid (field-value-valid? text-field-data value)]
     (dispatch [:application/set-application-field (answer-key text-field-data) {:value value :valid valid}])))
 
 (defn- init-dropdown-value
   [dropdown-data this]
   (let [select (-> (r/dom-node this) (.querySelector "select"))
         value (-> select .-value)
-        valid (field-value-valid? value)]
+        valid (field-value-valid? dropdown-data value)]
     (dispatch [:application/set-application-field (answer-key dropdown-data) {:value value :valid valid}])))
 
 (defn- field-id [field-descriptor]
@@ -81,10 +81,11 @@
                               [:div.application__form-dropdown
                                {:on-change (partial textual-field-change field-descriptor)}
                                [:label.application_form_field_label {:id (field-id field-descriptor)} label (required-hint field-descriptor)]
-                               [:select.application__form-select
-                                (for [option (:options field-descriptor)]
-                                  ^{:key (:value option)}
-                                  [:option {:value (:value option)} (-> option :label :fi)])]])})))
+                               [:div.application__form-select-wrapper
+                                [:select.application__form-select
+                                 (for [option (:options field-descriptor)]
+                                   ^{:key (:value option)}
+                                   [:option {:value (:value option)} (-> option :label :fi)])]]])})))
 
 (defn render-field
   [field-descriptor]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -80,8 +80,9 @@
        :reagent-render      (fn [field-descriptor]
                               [:div.application__form-dropdown
                                {:on-change (partial textual-field-change field-descriptor)}
-                               [:label.application_form_field_label {:id (field-id field-descriptor)} label (required-hint field-descriptor)]
+                               [:label.application_form-field-label {:id (field-id field-descriptor)} label (required-hint field-descriptor)]
                                [:div.application__form-select-wrapper
+                                [:span.application__form-select-arrow]
                                 [:select.application__form-select
                                  (for [option (:options field-descriptor)]
                                    ^{:key (:value option)}

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -60,13 +60,26 @@
     (-> field-descriptor :label :fi)]
    (into [:div.application__wrapper-contents] (mapv render-field children))])
 
+(defn dropdown
+  [field-descriptor]
+  (let [application (subscribe [:state-query [:application]])
+        label (-> field-descriptor :label :fi)]
+    (fn [field-descriptor]
+      [:div.application__form-dropdown
+       [:label.application_form_field_label {:id (field-id field-descriptor)} label (required-hint field-descriptor)]
+       [:select
+        (for [option (:options field-descriptor)]
+          ^{:key (:value option)}
+          [:option {:value (:value option)} (-> option :label :fi)])]])))
+
 (defn render-field
   [field-descriptor]
   (match field-descriptor
          {:fieldClass "wrapperElement"
           :children   children} [wrapper-field field-descriptor children]
          {:fieldClass "formField" :fieldType "textField"} [text-field field-descriptor]
-         {:fieldClass "formField" :fieldType "textArea"} [text-area field-descriptor]))
+         {:fieldClass "formField" :fieldType "textArea"} [text-area field-descriptor]
+         {:fieldClass "formField" :fieldType "dropdown"} [dropdown field-descriptor]))
 
 (defn render-editable-fields [form-data]
   (when form-data

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -5,7 +5,8 @@
             [ataru.hakija.application-field-common :refer [answer-key
                                                            required-hint
                                                            textual-field-value
-                                                           wrapper-id]]))
+                                                           wrapper-id]]
+            [reagent.core :as r]))
 (defn- text-field-size->class [size]
   (match size
          "S" "application__form-text-input__size-small"
@@ -13,10 +14,21 @@
          "L" "application__form-text-input__size-large"
          :else "application__form-text-input__size-medium"))
 
+(defn- field-value-valid?
+  [field-value]
+  (if (:required field-value) (not (empty? (trim field-value))) true))
+
 (defn- textual-field-change [text-field-data evt]
   (let [value (-> evt .-target .-value)
-        valid (if (:required text-field-data) (not (empty? (trim value))) true)]
+        valid (field-value-valid? value)]
     (dispatch [:application/set-application-field (answer-key text-field-data) {:value value :valid valid}])))
+
+(defn- init-dropdown-value
+  [dropdown-data this]
+  (let [select (-> (r/dom-node this) (.querySelector "select"))
+        value (-> select .-value)
+        valid (field-value-valid? value)]
+    (dispatch [:application/set-application-field (answer-key dropdown-data) {:value value :valid valid}])))
 
 (defn- field-id [field-descriptor]
   (str "field-" (:id field-descriptor)))
@@ -62,15 +74,17 @@
 
 (defn dropdown
   [field-descriptor]
-  (let [label (-> field-descriptor :label :fi)
-        update-fn (partial textual-field-change field-descriptor)]
-    (fn [field-descriptor]
-      [:div.application__form-dropdown
-       [:label.application_form_field_label {:id (field-id field-descriptor)} label (required-hint field-descriptor)]
-       [:select.application__form-select
-        (for [option (:options field-descriptor)]
-          ^{:key (:value option)}
-          [:option {:value (:value option)} (-> option :label :fi)])]])))
+  (let [label (-> field-descriptor :label :fi)]
+    (r/create-class
+      {:component-did-mount (partial init-dropdown-value field-descriptor)
+       :reagent-render      (fn [field-descriptor]
+                              [:div.application__form-dropdown
+                               {:on-change (partial textual-field-change field-descriptor)}
+                               [:label.application_form_field_label {:id (field-id field-descriptor)} label (required-hint field-descriptor)]
+                               [:select.application__form-select
+                                (for [option (:options field-descriptor)]
+                                  ^{:key (:value option)}
+                                  [:option {:value (:value option)} (-> option :label :fi)])]])})))
 
 (defn render-field
   [field-descriptor]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -62,12 +62,12 @@
 
 (defn dropdown
   [field-descriptor]
-  (let [application (subscribe [:state-query [:application]])
-        label (-> field-descriptor :label :fi)]
+  (let [label (-> field-descriptor :label :fi)
+        update-fn (partial textual-field-change field-descriptor)]
     (fn [field-descriptor]
       [:div.application__form-dropdown
        [:label.application_form_field_label {:id (field-id field-descriptor)} label (required-hint field-descriptor)]
-       [:select
+       [:select.application__form-select
         (for [option (:options field-descriptor)]
           ^{:key (:value option)}
           [:option {:value (:value option)} (-> option :label :fi)])]])))

--- a/src/cljs/ataru/hakija/application_readonly.cljs
+++ b/src/cljs/ataru/hakija/application_readonly.cljs
@@ -27,9 +27,8 @@
 (defn field
   [content]
   (match content
-         {:fieldClass "wrapperElement"
-          :children   children} [wrapper content children]
-         {:fieldClass "formField" :fieldType (:or "textField" "textArea")} [text content]))
+         {:fieldClass "wrapperElement" :children children} [wrapper content children]
+         {:fieldClass "formField" :fieldType (:or "textField" "textArea" "dropdown")} [text content]))
 
 (defn render-readonly-fields [form-data]
   (when form-data

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -128,10 +128,10 @@
                option-with-index (map vector (range (count (:options @value))) (:options @value))]
            (let [[option-index option] option-with-index
                  option-label (get-in option [:label lang])]
-             ^{:key (str "option-" lang "-" (gensym))}
+             ^{:key (str "option-" lang "-" option-index)}
              [:div.editor-form__text-field-wrapper
               [:input.editor-form__text-field {:value     option-label
-                                               :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :options option-index :label lang])}]
+                                               :on-change #(dispatch [:editor/set-dropdown-option-value (-> % .-target .-value) path :options option-index :label lang])}]
               [:a {:on-click #(dispatch [:editor/remove-dropdown-option option-index path])} "x"]])))
        [:div.editor-form__add-dropdown-item
         [:a {:on-click #(dispatch [:editor/add-dropdown-option nil path])} "+"]]])))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -149,7 +149,7 @@
                   nil
                   ^{:key (str "option-" lang "-" option-index)}
                   [:div.editor-form__multi-option-wrapper
-                   [:div.editor-form__text-field-wrapper
+                   [:div.editor-form__text-field-wrapper__option
                     [:input.editor-form__text-field
                      {:value       option-label
                       :placeholder "Lisää..."

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -49,6 +49,13 @@
   [event]
   (.preventDefault event))
 
+(defn- fade-out-effect
+  [path]
+  (reaction (case @(subscribe [:state-query [:editor :forms-meta path]])
+              :fade-out "animated fadeOutUp"
+              :fade-in  "animated fadeInUp"
+              nil)))
+
 (defn text-component [initial-content path & {:keys [header-label size-label]}]
   (let [languages        (subscribe [:editor/languages])
         value            (subscribe [:editor/get-component-value path])
@@ -57,10 +64,7 @@
         radio-buttons    ["S" "M" "L"]
         radio-button-ids (reduce (fn [acc btn] (assoc acc btn (str radio-group-id "-" btn))) {} radio-buttons)
         size-change      (fn [new-size] (dispatch [:editor/set-component-value new-size path :params :size]))
-        animation-effect (reaction (case @(subscribe [:state-query [:editor :forms-meta path]])
-                                     :fade-out "animated fadeOutUp"
-                                     :fade-in  "animated fadeInUp"
-                                     nil))]
+        animation-effect (fade-out-effect path)]
     (fn [initial-content path & {:keys [header-label size-label]}]
       [:div.editor-form__component-wrapper
        {:draggable true
@@ -110,10 +114,14 @@
 
 (defn dropdown [initial-content path]
   (let [languages (subscribe [:editor/languages])
-        value (subscribe [:editor/get-component-value path])]
+        value (subscribe [:editor/get-component-value path])
+        animation-effect (fade-out-effect path)]
     (fn [initial-content]
       [:div.editor-form__component-wrapper.animated.fadeInUp
-       {:draggable true}
+       {:draggable true
+        :on-drag-start (on-drag-start path)
+        :on-drag-over prevent-default
+        :class @animation-effect}
        [text-header "Pudotusvalikko" path]
        [:div.editor-form__multi-question-wrapper
         [:div.editor-form__text-field-wrapper
@@ -205,10 +213,7 @@
 (defn component-group [content path children]
   (let [languages        (subscribe [:editor/languages])
         value            (subscribe [:editor/get-component-value path])
-        animation-effect (reaction (case @(subscribe [:state-query [:editor :forms-meta path]])
-                                     :fade-out "animated fadeOutUp"
-                                     :fade-in  "animated fadeInUp"
-                                     nil))]
+        animation-effect (fade-out-effect path)]
     (fn [content path children]
       [:div.editor-form__section_wrapper
        {:class @animation-effect}

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -136,19 +136,24 @@
        [:div.editor-form__multi-options_wrapper
         [:header.editor-form__component-item-header "Vastausvaihtoehdot"]
         (doall
-          (for [lang @languages
-                option-with-index (map vector (range (+ 1 (count (:options @value)))) (into (:options @value) (component/dropdown-option)))]
-            (let [[option-index option] option-with-index
-                  option-label (get-in option [:label lang])]
-              (if (and (clojure.string/blank? option-label) (= option-index 0) (not= (count (:options @value)) 1))
-                nil
-                ^{:key (str "option-" lang "-" option-index)}
-                [:div.editor-form__multi-option-wrapper
-                 [:div.editor-form__text-field-wrapper
-                  [:input.editor-form__text-field
-                   {:value       option-label
-                    :placeholder "Lisää..."
-                    :on-change   #(dispatch [:editor/set-dropdown-option-value (-> % .-target .-value) path :options option-index :label lang])}]]]))))]])))
+          (let [options-raw (:options @value)
+                options (if (clojure.string/blank? (:value (last options-raw)))
+                          options-raw
+                          (into options-raw [(component/dropdown-option)]))
+                options-count (count options)]
+            (for [lang @languages
+                  option-with-index (map vector (range options-count) options)]
+              (let [[option-index option] option-with-index
+                    option-label (get-in option [:label lang])]
+                (if (and (clojure.string/blank? option-label) (= option-index 0) (not= options-count 1))
+                  nil
+                  ^{:key (str "option-" lang "-" option-index)}
+                  [:div.editor-form__multi-option-wrapper
+                   [:div.editor-form__text-field-wrapper
+                    [:input.editor-form__text-field
+                     {:value       option-label
+                      :placeholder "Lisää..."
+                      :on-change   #(dispatch [:editor/set-dropdown-option-value (-> % .-target .-value) path :options option-index :label lang])}]]])))))]])))
 
 (def ^:private toolbar-elements
   {"Lomakeosio"     component/form-section

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -110,32 +110,34 @@
 
 (defn dropdown [initial-content path]
   (let [languages (subscribe [:editor/languages])
-        value            (subscribe [:editor/get-component-value path])]
+        value (subscribe [:editor/get-component-value path])]
     (fn [initial-content]
       [:div.editor-form__component-wrapper.animated.fadeInUp
        [text-header "Pudotusvalikko" path]
-       [:div.editor-form__text-field-wrapper
-        [:header.editor-form__component-item-header "Kysymys"]
-        (doall
-          (for [lang @languages]
-            ^{:key lang}
-            [:input.editor-form__text-field {:value     (get-in @value [:label lang])
-                                             :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))
+       [:div.editor-form__multi-question-wrapper
+        [:div.editor-form__text-field-wrapper
+         [:header.editor-form__component-item-header "Kysymys"]
+         (doall
+           (for [lang @languages]
+             ^{:key lang}
+             [:input.editor-form__text-field {:value     (get-in @value [:label lang])
+                                              :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))]
         [:div.editor-form__checkbox-wrapper
          (render-checkbox path initial-content :required)]]
-       (doall
-         (for [lang @languages
-               option-with-index (map vector (range (count (:options @value))) (:options @value))]
-           (let [[option-index option] option-with-index
-                 option-label (get-in option [:label lang])]
-             ^{:key (str "option-" lang "-" option-index)}
-             [:div.editor-form__text-field-wrapper
-              [:input.editor-form__text-field {:value     option-label
-                                               :on-change #(dispatch [:editor/set-dropdown-option-value (-> % .-target .-value) path :options option-index :label lang])}]
-              [:a {:on-click #(dispatch [:editor/remove-dropdown-option option-index path])} "x"]])))
-       [:div.editor-form__add-dropdown-item
-        [:a {:on-click #(dispatch [:editor/add-dropdown-option nil path])} "+"]]])))
-
+       [:div.editor-form__multi-options_wrapper
+        [:header.editor-form__component-item-header "Vastausvaihtoehdot"]
+        (doall
+          (for [lang @languages
+                option-with-index (map vector (range (count (:options @value))) (:options @value))]
+            (let [[option-index option] option-with-index
+                  option-label (get-in option [:label lang])]
+              ^{:key (str "option-" lang "-" option-index)}
+              [:div.editor-form__multi-option-wrapper
+               [:div.editor-form__text-field-wrapper
+                [:input.editor-form__text-field
+                 {:value     option-label
+                  :placeholder "Lisää..."
+                  :on-change #(dispatch [:editor/set-dropdown-option-value (-> % .-target .-value) path :options option-index :label lang])}]]])))]])))
 
 (def ^:private toolbar-elements
   {"Lomakeosio"     component/form-section

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -108,10 +108,40 @@
 (defn text-area [initial-content path]
   [text-component initial-content path :header-label "Tekstialue" :size-label "Tekstialueen koko"])
 
+(defn dropdown [initial-content path]
+  (let [languages (subscribe [:editor/languages])
+        value            (subscribe [:editor/get-component-value path])]
+    (fn [initial-content]
+      [:div.editor-form__component-wrapper.animated.fadeInUp
+       [text-header "Pudotusvalikko" path]
+       [:div.editor-form__text-field-wrapper
+        [:header.editor-form__component-item-header "Kysymys"]
+        (doall
+          (for [lang @languages]
+            ^{:key lang}
+            [:input.editor-form__text-field {:value     (get-in @value [:label lang])
+                                             :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])}]))
+        [:div.editor-form__checkbox-wrapper
+         (render-checkbox path initial-content :required)]]
+       (doall
+         (for [lang @languages
+               option-with-index (map vector (range (count (:options @value))) (:options @value))]
+           (let [[option-index option] option-with-index
+                 option-label (get-in option [:label lang])]
+             ^{:key (str "option-" lang "-" (gensym))}
+             [:div.editor-form__text-field-wrapper
+              [:input.editor-form__text-field {:value     option-label
+                                               :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :options option-index :label lang])}]
+              [:a {:on-click #(dispatch [:editor/remove-dropdown-option option-index path])} "x"]])))
+       [:div.editor-form__add-dropdown-item
+        [:a {:on-click #(dispatch [:editor/add-dropdown-option nil path])} "+"]]])))
+
+
 (def ^:private toolbar-elements
-  {"Lomakeosio"   component/form-section
-   "Tekstikenttä" component/text-field
-   "Tekstialue"   component/text-area})
+  {"Lomakeosio"     component/form-section
+   "Tekstikenttä"   component/text-field
+   "Tekstialue"     component/text-area
+   "Pudotusvalikko" component/dropdown})
 
 (defn ^:private component-toolbar [path]
   (fn [path]

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -129,16 +129,18 @@
         [:header.editor-form__component-item-header "Vastausvaihtoehdot"]
         (doall
           (for [lang @languages
-                option-with-index (map vector (range (count (:options @value))) (:options @value))]
+                option-with-index (map vector (range (+ 1 (count (:options @value)))) (into (:options @value) (component/dropdown-option)))]
             (let [[option-index option] option-with-index
                   option-label (get-in option [:label lang])]
-              ^{:key (str "option-" lang "-" option-index)}
-              [:div.editor-form__multi-option-wrapper
-               [:div.editor-form__text-field-wrapper
-                [:input.editor-form__text-field
-                 {:value     option-label
-                  :placeholder "Lisää..."
-                  :on-change #(dispatch [:editor/set-dropdown-option-value (-> % .-target .-value) path :options option-index :label lang])}]]])))]])))
+              (if (and (clojure.string/blank? option-label) (= option-index 0) (not= (count (:options @value)) 1))
+                nil
+                ^{:key (str "option-" lang "-" option-index)}
+                [:div.editor-form__multi-option-wrapper
+                 [:div.editor-form__text-field-wrapper
+                  [:input.editor-form__text-field
+                   {:value       option-label
+                    :placeholder "Lisää..."
+                    :on-change   #(dispatch [:editor/set-dropdown-option-value (-> % .-target .-value) path :options option-index :label lang])}]]]))))]])))
 
 (def ^:private toolbar-elements
   {"Lomakeosio"     component/form-section

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -113,6 +113,7 @@
         value (subscribe [:editor/get-component-value path])]
     (fn [initial-content]
       [:div.editor-form__component-wrapper.animated.fadeInUp
+       {:draggable true}
        [text-header "Pudotusvalikko" path]
        [:div.editor-form__multi-question-wrapper
         [:div.editor-form__text-field-wrapper

--- a/src/cljs/ataru/virkailija/editor/core.cljs
+++ b/src/cljs/ataru/virkailija/editor/core.cljs
@@ -57,6 +57,9 @@
             [{:fieldClass "formField" :fieldType "textArea"}]
             [ec/text-area content path]
 
+            [{:fieldClass "formField" :fieldType "dropdown"}]
+            [ec/dropdown content path]
+
             :else (do
                     (error content)
                     (throw "error" content)))

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -93,6 +93,23 @@
       value)))
 
 (register-handler
+  :editor/add-dropdown-option
+  (fn [db [_ _ & path]]
+    (let [final-path (flatten [:editor :forms (-> db :editor :selected-form-id) :content [path] :options])]
+      (update-in db final-path merge (ataru.virkailija.soresu.component/dropdown-option)))))
+
+(defn remove-nth
+  "remove nth elem in vector"
+  [v n]
+  (vec (concat (subvec v 0 n) (subvec v (inc n)))))
+
+(register-handler
+  :editor/remove-dropdown-option
+  (fn [db [_ n & path]]
+    (let [final-path (flatten [:editor :forms (-> db :editor :selected-form-id) :content [path] :options])]
+      (update-in db final-path remove-nth n))))
+
+(register-handler
   :handle-get-forms
   (fn [db [_ forms-response]]
     (if-let [forms (not-empty (:forms forms-response))]

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -101,7 +101,7 @@
 
 (defn- add-option
   [db path]
-  (update-in db path merge (ataru.virkailija.soresu.component/dropdown-option)))
+  (update-in db path into (ataru.virkailija.soresu.component/dropdown-option)))
 
 (register-handler
   :editor/set-dropdown-option-value

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -260,10 +260,14 @@
           (:content form))]
     (merge form {:content new-content})))
 
+(defn- set-modified-time
+  [form]
+  (assoc-in form [:modified-time] (temporal/time->iso-str (:modified-time form))))
+
 (defn save-form
   [db _]
   (let [form (-> (get-in db [:editor :forms (-> db :editor :selected-form-id)])
-                 (assoc :modified-time (temporal/time->iso-str (:modified-time form)))
+                 (set-modified-time)
                  (update-dropdown-field-options))]
     (post
       "/lomake-editori/api/form"

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -85,6 +85,15 @@
         (update :editor dissoc :forms-meta))))
 
 (register-handler
+  :editor/set-dropdown-option-value
+  (fn [db [_ value & path]]
+    (let [label-path (flatten [:editor :forms (-> db :editor :selected-form-id) :content [path]])
+          value-path (flatten [(drop-last 2 label-path) :value])]
+      (-> db
+          (assoc-in label-path value)
+          (assoc-in value-path value)))))
+
+(register-handler
   :editor/set-component-value
   (fn [db [_ value & path]]
     (assoc-in


### PR DESCRIPTION
Implements dropdown question component. Looks like this (editor):

<img width="841" alt="screen shot 2016-06-22 at 12 18 39" src="https://cloud.githubusercontent.com/assets/1083484/16261251/9136f324-3873-11e6-84da-7c4549c6acd8.png">

and (applicant):

<img width="636" alt="screen shot 2016-06-22 at 12 20 07" src="https://cloud.githubusercontent.com/assets/1083484/16261311/bb585f12-3873-11e6-9b6b-553b7af43a92.png">

Most of the ugliness in the implementation is due to how the empty option fields are created and shown (new options are added to empty input field at the _end_ of the list in the editor, and shown as the _first_ item in the applicant form).