### PR TITLE
Working "preview application" link

### DIFF
--- a/config/defaults.edn
+++ b/config/defaults.edn
@@ -4,4 +4,6 @@
        :password "oph"
        :server-name "localhost"
        :port-number 5432
-       :schema "public"}}
+       :schema "public"}
+ :email {:email_service_url "https://itest-virkailija.oph.ware.fi"}
+ :public-config {:applicant {:service_url "http://localhost:8351"}}}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -10,4 +10,5 @@
                   :opintopolku-logout-url  "{{ataru_authentication_opintopolku_logout_url}}"
                   :ataru-login-success-url "{{ataru_authentication_ataru_login_success_url}}"
                   :cas-client-url "{{ataru_authentication_cas_client_url}}"}
- :email {:email_service_url "{{ataru_email_service_url}}"}}
+ :email {:email_service_url "{{ataru_email_service_url}}"}
+ :public-config {:applicant {:service_url "{{ataru_applicant_service_url}}"}}}

--- a/resources/templates/virkailija.html
+++ b/resources/templates/virkailija.html
@@ -6,6 +6,9 @@
     <link rel="stylesheet" href="vendor/css/material-design-iconic-font.min.css?fingerprint={{cache-fingerprint}}">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,600,400italic,600italic,700italic' rel='stylesheet' type='text/css'>
     <link href="css/compiled/site.css?fingerprint={{cache-fingerprint}}" rel="stylesheet" type="text/css">
+    <script type="text/javascript">
+      var config = {{config|safe}};
+    </script>
   </head>
   <body class="ataru-app">
     <div id="app"></div>

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -7,12 +7,14 @@
             [ataru.virkailija.authentication.auth-routes :refer [auth-routes]]
             [ataru.forms.form-store :as form-store]
             [ataru.util.client-error :as client-error]
+            [cheshire.core :as json]
             [compojure.api.sweet :as api]
             [compojure.core :refer [GET POST PUT defroutes context routes wrap-routes]]
             [compojure.response :refer [Renderable]]
             [compojure.route :as route]
             [environ.core :refer [env]]
             [manifold.deferred :as d]
+            [oph.soresu.common.config :refer [config]]
             [ring.middleware.defaults :refer [wrap-defaults site-defaults]]
             [ring.middleware.gzip :refer [wrap-gzip]]
             [ring.util.http-response :refer [ok internal-server-error not-found bad-request content-type]]
@@ -50,7 +52,11 @@
 (def ^:private cache-fingerprint (System/currentTimeMillis))
 
 (defroutes app-routes
-  (GET "/" [] (selmer/render-file "templates/virkailija.html" {:cache-fingerprint cache-fingerprint})))
+  (GET "/" [] (selmer/render-file "templates/virkailija.html"
+                {:cache-fingerprint cache-fingerprint
+                 :config (-> config
+                           :public-config
+                           json/generate-string)})))
 
 (defroutes test-routes
   (GET "/test.html" []

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -71,7 +71,10 @@
         [:div.panel-content
          [:div
           [editor-name]]
-         [:div.editor-form__preview-link-row [:a.editor-form__preview-link {:href (str "#/editor/" (:id @form))} "Esikatsele lomake"]] 
+         [:div.editor-form__preview-link-row [:a.editor-form__preview-link
+                                              {:href (str js/config.applicant.service_url "/hakemus/" (:id @form))
+                                               :target "_blank"}
+                                              "Esikatsele lomake"]]
          [c/editor]]))))
 
 (defn editor []


### PR DESCRIPTION
This branch adds working "preview application" link for the officer side. The "OPH" configuration mechanism is used to provide the public CLJS application configuration by placing it onto the root of the officer application's HTML using Selmer templating.