### PR TITLE
Auto focus text field on new component

### DIFF
--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -63,9 +63,18 @@
                               (-> event .-target .-parentNode .-parentNode))]))}
     "Poista"]])
 
+(defn input-field
+  [path lang]
+  (let [value (subscribe [:editor/get-component-value path])]
+    (r/create-class
+      {:reagent-render
+       (fn [path lang]
+         [:input.editor-form__text-field {:value     (get-in @value [:label lang])
+                                          :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])
+                                          :on-drop prevent-default}])})))
+
 (defn text-component [initial-content path & {:keys [header-label size-label]}]
   (let [languages        (subscribe [:editor/languages])
-        value            (subscribe [:editor/get-component-value path])
         size             (subscribe [:editor/get-component-value path :params :size])
         radio-group-id   (util/new-uuid)
         radio-buttons    ["S" "M" "L"]
@@ -81,9 +90,7 @@
         (doall
           (for [lang @languages]
             ^{:key lang}
-            [:input.editor-form__text-field {:value     (get-in @value [:label lang])
-                                             :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])
-                                             :on-drop prevent-default}]))]
+            [input-field path lang]))]
        [:div.editor-form__size-button-wrapper
         [:header.editor-form__component-item-header size-label]
         [:div.editor-form__size-button-group

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -67,7 +67,12 @@
   [path lang]
   (let [value (subscribe [:editor/get-component-value path])]
     (r/create-class
-      {:reagent-render
+      {:component-did-mount
+       (fn [component]
+         (when (:focus? @value)
+           (let [dom-node (r/dom-node component)]
+             (.focus dom-node))))
+       :reagent-render
        (fn [path lang]
          [:input.editor-form__text-field {:value     (get-in @value [:label lang])
                                           :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -143,9 +143,7 @@
          (doall
            (for [lang @languages]
              ^{:key lang}
-             [:input.editor-form__text-field {:value     (get-in @value [:label lang])
-                                              :on-change #(dispatch [:editor/set-component-value (-> % .-target .-value) path :label lang])
-                                              :on-drop prevent-default}]))]
+             [input-field path lang]))]
         [:div.editor-form__checkbox-wrapper
          (render-checkbox path initial-content :required)]]
        [:div.editor-form__multi-options_wrapper

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -209,11 +209,21 @@
   [form]
   (assoc-in form [:modified-time] (temporal/time->iso-str (:modified-time form))))
 
+(defn- remove-focus
+  [form]
+  (clojure.walk/prewalk
+    (fn [x]
+      (if (map? x)
+        (dissoc x :focus?)
+        x))
+    form))
+
 (defn save-form
   [db _]
   (let [form (-> (get-in db [:editor :forms (-> db :editor :selected-form-id)])
                  (set-modified-time)
-                 (update-dropdown-field-options))]
+                 (update-dropdown-field-options)
+                 (remove-focus))]
     (when (not-empty (:content form))
       (post
         "/lomake-editori/api/form"

--- a/src/cljs/ataru/virkailija/soresu/component.cljs
+++ b/src/cljs/ataru/virkailija/soresu/component.cljs
@@ -8,7 +8,8 @@
    :label      {:fi "", :sv ""}
    :id         (util/new-uuid)
    :params     {}
-   :required   false})
+   :required   false
+   :focus?     true})
 
 (defn text-area []
   (assoc (text-field)
@@ -21,7 +22,8 @@
    :id         (util/new-uuid)
    :label      {:fi "Osion nimi" :sv "Avsnitt namn"}
    :children   []
-   :params     {}})
+   :params     {}
+   :focus?     true})
 
 (defn dropdown-option
   []

--- a/src/cljs/ataru/virkailija/soresu/component.cljs
+++ b/src/cljs/ataru/virkailija/soresu/component.cljs
@@ -37,4 +37,5 @@
    :label {:fi "", :sv ""}
    :params {}
    :options [(dropdown-option)]
-   :required false})
+   :required false
+   :focus? true})


### PR DESCRIPTION
Whenever a new form component is added, the input field used to define the component's name is automatically focused.

The implementation relies on the basic HTMLElement.focus() API call.