### PR TITLE
Hard-coded keys and email bindings for person info module

### DIFF
--- a/spec/ataru/hakija/email_spec.clj
+++ b/spec/ataru/hakija/email_spec.clj
@@ -78,5 +78,8 @@
                      (should= "application/json" (get-in request [:headers "content-type"]))
                      (let [body (json/parse-string (:body request) true)]
                        (should= "no-reply@opintopolku.fi" (get-in body [:email :from]))
-                       (should= "Hakemus vastaanotettu" (get-in body [:email :subject]))))
+                       (should= "Hakemus vastaanotettu" (get-in body [:email :subject]))
+                       (let [recipients (:recipient body)]
+                         (should= 1 (count recipients))
+                         (should= "aku@ankkalinna.com" (get-in recipients [0 :email])))))
       (email/send-email-verification application))))

--- a/spec/ataru/hakija/email_spec.clj
+++ b/spec/ataru/hakija/email_spec.clj
@@ -16,7 +16,7 @@
                     :value "050123123",
                     :fieldType "textField",
                     :label {:fi "Matkapuhelin", :sv "Mobiltelefonnummer"}}
-                   {:key "referrer-name",
+                   {:key "preferred-name",
                     :value "Aku",
                     :fieldType "textField",
                     :label {:fi "Kutsumanimi", :sv "Smeknamn"}}

--- a/spec/ataru/hakija/email_spec.clj
+++ b/spec/ataru/hakija/email_spec.clj
@@ -8,51 +8,51 @@
                   :lang "fi",
                   :state :received,
                   :answers
-                  [{:key "b0dc66fc-b8fc-4c1d-bd8f-095f5890d3fc",
+                  [{:key "ssn",
                     :value "010101-123n",
                     :fieldType "textField",
                     :label {:fi "Henkilötunnus", :sv "Personnummer"}}
-                   {:key "f5de0137-d1e4-403f-bf66-e93e8032b3bc",
+                   {:key "phone",
                     :value "050123123",
                     :fieldType "textField",
                     :label {:fi "Matkapuhelin", :sv "Mobiltelefonnummer"}}
-                   {:key "d7698e7c-6b8f-4345-be8b-2ac9d3de277f",
+                   {:key "referrer-name",
                     :value "Aku",
                     :fieldType "textField",
                     :label {:fi "Kutsumanimi", :sv "Smeknamn"}}
-                   {:key "6fa67b6a-7df4-4b70-8e43-9eaae171e6ab",
+                   {:key "municipality",
                     :value "Ankkalinna",
                     :fieldType "textField",
                     :label {:fi "Kotikunta", :sv "Bostadsort"}}
-                   {:key "87dca441-f16c-424b-a521-b93314132bab",
+                   {:key "last-name",
                     :value "Ankka",
                     :fieldType "textField",
                     :label {:fi "Sukunimi", :sv "Efternamn"}}
-                   {:key "9552180f-33c8-4bee-b782-da2a11ba6b9c",
+                   {:key "first-name",
                     :value "Aku Petteri",
                     :fieldType "textField",
                     :label {:fi "Etunimet", :sv "Förnamn"}}
-                   {:key "7cda2f0e-930d-4274-8345-e6fee3de365a",
+                   {:key "address",
                     :value "Paratiisitie 13",
                     :fieldType "textField",
                     :label {:fi "Katuosoite", :sv "Adress"}}
-                   {:key "a91b0915-a4b7-4b57-bc3d-1f3925a42367",
+                   {:key "nationality",
                     :value "fi",
                     :fieldType "dropdown",
                     :label {:fi "Kansalaisuus", :sv "Nationalitet"}}
-                   {:key "09bd613f-285c-492a-82d7-e7a0c4d8b241",
+                   {:key "postal-code",
                     :value "00013",
                     :fieldType "textField",
                     :label {:fi "Postinumero", :sv "Postnummer"}}
-                   {:key "0e0b1636-ad29-45c1-8ba2-a558af45c0af",
+                   {:key "language",
                     :value "sv",
                     :fieldType "dropdown",
                     :label {:fi "Äidinkieli", :sv "Modersmål"}}
-                   {:key "b5d9bd55-a3aa-494b-928e-7ca19dd8f502",
+                   {:key "gender",
                     :value "female",
                     :fieldType "dropdown",
                     :label {:fi "Sukupuoli", :sv "Kön"}}
-                   {:key "e7feb75b-1275-4049-a740-287ae7d5aa91",
+                   {:key "email",
                     :value "aku@ankkalinna.com",
                     :fieldType "textField",
                     :label {:fi "Sähköpostiosoite", :sv "E-postadress"}}]})

--- a/spec/ataru/hakija/email_spec.clj
+++ b/spec/ataru/hakija/email_spec.clj
@@ -4,6 +4,59 @@
             [cheshire.core :as json]
             [speclj.core :refer :all]))
 
+(def application {:form 44,
+                  :lang "fi",
+                  :state :received,
+                  :answers
+                  [{:key "b0dc66fc-b8fc-4c1d-bd8f-095f5890d3fc",
+                    :value "010101-123n",
+                    :fieldType "textField",
+                    :label {:fi "Henkilötunnus", :sv "Personnummer"}}
+                   {:key "f5de0137-d1e4-403f-bf66-e93e8032b3bc",
+                    :value "050123123",
+                    :fieldType "textField",
+                    :label {:fi "Matkapuhelin", :sv "Mobiltelefonnummer"}}
+                   {:key "d7698e7c-6b8f-4345-be8b-2ac9d3de277f",
+                    :value "Aku",
+                    :fieldType "textField",
+                    :label {:fi "Kutsumanimi", :sv "Smeknamn"}}
+                   {:key "6fa67b6a-7df4-4b70-8e43-9eaae171e6ab",
+                    :value "Ankkalinna",
+                    :fieldType "textField",
+                    :label {:fi "Kotikunta", :sv "Bostadsort"}}
+                   {:key "87dca441-f16c-424b-a521-b93314132bab",
+                    :value "Ankka",
+                    :fieldType "textField",
+                    :label {:fi "Sukunimi", :sv "Efternamn"}}
+                   {:key "9552180f-33c8-4bee-b782-da2a11ba6b9c",
+                    :value "Aku Petteri",
+                    :fieldType "textField",
+                    :label {:fi "Etunimet", :sv "Förnamn"}}
+                   {:key "7cda2f0e-930d-4274-8345-e6fee3de365a",
+                    :value "Paratiisitie 13",
+                    :fieldType "textField",
+                    :label {:fi "Katuosoite", :sv "Adress"}}
+                   {:key "a91b0915-a4b7-4b57-bc3d-1f3925a42367",
+                    :value "fi",
+                    :fieldType "dropdown",
+                    :label {:fi "Kansalaisuus", :sv "Nationalitet"}}
+                   {:key "09bd613f-285c-492a-82d7-e7a0c4d8b241",
+                    :value "00013",
+                    :fieldType "textField",
+                    :label {:fi "Postinumero", :sv "Postnummer"}}
+                   {:key "0e0b1636-ad29-45c1-8ba2-a558af45c0af",
+                    :value "sv",
+                    :fieldType "dropdown",
+                    :label {:fi "Äidinkieli", :sv "Modersmål"}}
+                   {:key "b5d9bd55-a3aa-494b-928e-7ca19dd8f502",
+                    :value "female",
+                    :fieldType "dropdown",
+                    :label {:fi "Sukupuoli", :sv "Kön"}}
+                   {:key "e7feb75b-1275-4049-a740-287ae7d5aa91",
+                    :value "aku@ankkalinna.com",
+                    :fieldType "textField",
+                    :label {:fi "Sähköpostiosoite", :sv "E-postadress"}}]})
+
 (defmacro with-mock-api
   [eval-fn & body]
   `(let [api-called?# (atom false)]
@@ -26,4 +79,4 @@
                      (let [body (json/parse-string (:body request) true)]
                        (should= "no-reply@opintopolku.fi" (get-in body [:email :from]))
                        (should= "Hakemus vastaanotettu" (get-in body [:email :subject]))))
-      (email/send-email-verification {}))))
+      (email/send-email-verification application))))

--- a/src/clj/ataru/hakija/email.clj
+++ b/src/clj/ataru/hakija/email.clj
@@ -10,7 +10,7 @@
                (get-in config [:email :email_service_url])
                "/ryhmasahkoposti-service/email/firewall")
         body (selmer/render-file "templates/email_confirmation_template.txt" {})
-        recipient (-> (filter #(= "Sähköpostiosoite" (get-in % [:label :fi])) (:answers application))
+        recipient (-> (filter #(= "email" (:key %)) (:answers application))
                       first
                       :value)]
     (http/post url {:headers {"content-type" "application/json"}

--- a/src/clj/ataru/hakija/email.clj
+++ b/src/clj/ataru/hakija/email.clj
@@ -9,10 +9,13 @@
   (let [url  (str
                (get-in config [:email :email_service_url])
                "/ryhmasahkoposti-service/email/firewall")
-        body (selmer/render-file "templates/email_confirmation_template.txt" {})]
+        body (selmer/render-file "templates/email_confirmation_template.txt" {})
+        recipient (-> (filter #(= "Sähköpostiosoite" (get-in % [:label :fi])) (:answers application))
+                      first
+                      :value)]
     (http/post url {:headers {"content-type" "application/json"}
                     :body (json/generate-string {:email {:from "no-reply@opintopolku.fi"
                                                          :subject "Hakemus vastaanotettu"
                                                          :isHtml true
                                                          :body body}
-                                                 :recipient [{:email "hakija@opintopolku.fi"}]})})))
+                                                 :recipient [{:email recipient}]})})))

--- a/src/cljc/ataru/virkailija/component_data/person_info_module.cljc
+++ b/src/cljc/ataru/virkailija/component_data/person_info_module.cljc
@@ -13,14 +13,14 @@
   []
   (text-field {:fi "Etunimet" :sv "Förnamn"} :id :first-name))
 
-(defn ^:private referrer-name-component
+(defn ^:private preferred-name-component
   []
-  (text-field {:fi "Kutsumanimi" :sv "Smeknamn"} :size "S" :id :referrer-name))
+  (text-field {:fi "Kutsumanimi" :sv "Smeknamn"} :size "S" :id :preferred-name))
 
 (defn ^:private first-name-section
   []
   (component/row-section [(first-name-component)
-                          (referrer-name-component)]))
+                          (preferred-name-component)]))
 
 (defn ^:private last-name-component
   []

--- a/src/cljc/ataru/virkailija/component_data/person_info_module.cljc
+++ b/src/cljc/ataru/virkailija/component_data/person_info_module.cljc
@@ -2,19 +2,20 @@
   (:require [ataru.virkailija.component-data.component :as component]))
 
 (defn ^:private text-field
-  [labels & {:keys [size] :or {size "M"}}]
+  [labels & {:keys [size id] :or {size "M"}}]
   (-> (component/text-field)
       (assoc :label labels)
       (assoc :required true)
-      (assoc-in [:params :size] size)))
+      (assoc-in [:params :size] size)
+      (assoc :id id)))
 
 (defn ^:private first-name-component
   []
-  (text-field {:fi "Etunimet" :sv "Förnamn"}))
+  (text-field {:fi "Etunimet" :sv "Förnamn"} :id :first-name))
 
 (defn ^:private referrer-name-component
   []
-  (text-field {:fi "Kutsumanimi" :sv "Smeknamn"} :size "S"))
+  (text-field {:fi "Kutsumanimi" :sv "Smeknamn"} :size "S" :id :referrer-name))
 
 (defn ^:private first-name-section
   []
@@ -23,7 +24,7 @@
 
 (defn ^:private last-name-component
   []
-  (text-field {:fi "Sukunimi" :sv "Efternamn"}))
+  (text-field {:fi "Sukunimi" :sv "Efternamn"} :id :last-name))
 
 (defn ^:private dropdown-option
   [value labels]
@@ -34,11 +35,12 @@
   (merge (component/dropdown) {:label {:fi "Kansalaisuus" :sv "Nationalitet"}
                                :required true
                                :options [(dropdown-option "fi" {:fi "Suomi" :sv "Finland"})
-                                         (dropdown-option "sv" {:fi "Ruotsi" :sv "Sverige"})]}))
+                                         (dropdown-option "sv" {:fi "Ruotsi" :sv "Sverige"})]
+                               :id :nationality}))
 
 (defn ^:private ssn-component
   []
-  (text-field {:fi "Henkilötunnus" :sv "Personnummer"} :size "S"))
+  (text-field {:fi "Henkilötunnus" :sv "Personnummer"} :size "S" :id :ssn))
 
 (defn ^:private identification-section
   []
@@ -50,27 +52,28 @@
   (merge (component/dropdown) {:label {:fi "Sukupuoli" :sv "Kön"}
                                :required true
                                :options [(dropdown-option "male" {:fi "Mies" :sv "Människa"})
-                                         (dropdown-option "female" {:fi "Nainen" :sv "Kvinna"})]}))
+                                         (dropdown-option "female" {:fi "Nainen" :sv "Kvinna"})]
+                               :id :gender}))
 
 (defn ^:private email-component
   []
-  (text-field {:fi "Sähköpostiosoite" :sv "E-postadress"}))
+  (text-field {:fi "Sähköpostiosoite" :sv "E-postadress"} :id :email))
 
 (defn ^:private phone-component
   []
-  (text-field {:fi "Matkapuhelin" :sv "Mobiltelefonnummer"}))
+  (text-field {:fi "Matkapuhelin" :sv "Mobiltelefonnummer"} :id :phone))
 
 (defn ^:private street-address-component
   []
-  (text-field {:fi "Katuosoite" :sv "Adress"} :size "L"))
+  (text-field {:fi "Katuosoite" :sv "Adress"} :size "L" :id :address))
 
 (defn ^:private municipality-component
   []
-  (text-field {:fi "Kotikunta" :sv "Bostadsort"}))
+  (text-field {:fi "Kotikunta" :sv "Bostadsort"} :id :municipality))
 
 (defn ^:private postal-code-component
   []
-  (text-field {:fi "Postinumero" :sv "Postnummer"} :size "S"))
+  (text-field {:fi "Postinumero" :sv "Postnummer"} :size "S" :id :postal-code))
 
 (defn ^:private municipality-section
   []
@@ -82,7 +85,8 @@
   (merge (component/dropdown) {:label {:fi "Äidinkieli" :sv "Modersmål"}
                                :required true
                                :options [(dropdown-option "fi" {:fi "suomi" :sv "finska"})
-                                         (dropdown-option "sv" {:fi "ruotsi" :sv "svenska"})]}))
+                                         (dropdown-option "sv" {:fi "ruotsi" :sv "svenska"})]
+                               :id :language}))
 
 (defn person-info-module
   []


### PR DESCRIPTION
This feature replaces random UUID keys in the perfon info module with hard-coded human-readable values like "email", "ssn", "first-name" etc.

Also binding to the person info module's email field is introduced: the recipient address of the confirmation email is now automatically picked from the person info module answers.