### PR TITLE
Working Swagger UI for applicant side

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,5 @@ lein cljsbuild once <app id>-min
 
 Swagger specs for the APIs can be found at the following locations:
 
-http://localhost:8351/hakemus/swagger.json
-http://localhost:8350/lomake-editori/swagger.json
-
-To view them in a more human-friendly format, you can use the UIs at:
-
-http://localhost:8351/hakemus/api-docs/index.html
-http://localhost:8350/lomake-editori/api-docs/index.html
-
-**Note!** To actually see the documentation, you need to manually set the locations of the respective spec files to the .json URLs given above!
+* Applicant API: <http://localhost:8351/hakemus/swagger.json>
+* Officer API: <http://localhost:8350/lomake-editori/swagger.json>

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -3,7 +3,6 @@
             [ataru.hakija.email :as email]
             [ataru.forms.form-store :as form-store]
             [ataru.applications.application-store :as application-store]
-            [compojure.core :refer [routes defroutes wrap-routes context GET]]
             [com.stuartsierra.component :as component]
             [schema.core :as s]
             [ataru.schema.form-schema :as ataru-schema]
@@ -61,12 +60,12 @@
   component/Lifecycle
 
   (start [this]
-    (assoc this :routes (routes
-                          (context "/hakemus" []
+    (assoc this :routes (api/routes
+                          (api/context "/hakemus" []
                             buildversion-routes
                             api-routes
                             (route/resources "/")
-                            (GET "/:id" []
+                            (api/GET "/:id" []
                               (selmer/render-file "templates/hakija.html" {:cache-fingerprint cache-fingerprint})))
                           (route/not-found "<h1>Page not found</h1>"))))
 

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -34,40 +34,41 @@
   (ok {}))
 
 (def api-routes
-  (api/api
-    {:swagger {:spec "/swagger.json"
-               :ui "/api-docs"
-               :data {:info {:version "1.0.0"
-                             :title "Ataru Hakija API"
-                             :description "Specifies the Hakija API for Ataru"}}
-               :tags [{:name "application-api" :description "Application handling"}]}}
-    (api/context "/api" []
-                 :tags ["application-api"]
-                 (api/GET "/form/:id" []
-                          :path-params [id :- Long]
-                          :return ataru-schema/FormWithContent
-                          (fetch-form id))
-                 (api/POST "/application" []
-                           :summary "Submit application"
-                           :body [application ataru-schema/Application]
-                           (handle-application application))
-                 (api/POST "/client-error" []
-                           :summary "Log client-side errors to server log"
-                           :body [error-details client-error/ClientError]
-                           (handle-client-error error-details)))))
+  (api/context "/api" []
+    :tags ["application-api"]
+    (api/GET "/form/:id" []
+      :path-params [id :- Long]
+      :return ataru-schema/FormWithContent
+      (fetch-form id))
+    (api/POST "/application" []
+      :summary "Submit application"
+      :body [application ataru-schema/Application]
+      (handle-application application))
+    (api/POST "/client-error" []
+      :summary "Log client-side errors to server log"
+      :body [error-details client-error/ClientError]
+      (handle-client-error error-details))))
 
 (defrecord Handler []
   component/Lifecycle
 
   (start [this]
-    (assoc this :routes (api/routes
-                          (api/context "/hakemus" []
-                            buildversion-routes
-                            api-routes
-                            (route/resources "/")
-                            (api/GET "/:id" []
-                              (selmer/render-file "templates/hakija.html" {:cache-fingerprint cache-fingerprint})))
-                          (route/not-found "<h1>Page not found</h1>"))))
+    (assoc this :routes (api/api
+                          {:swagger {:spec "/hakemus/swagger.json"
+                                     :ui "/hakemus/api-docs"
+                                     :data {:info {:version "1.0.0"
+                                                   :title "Ataru Hakija API"
+                                                   :description "Specifies the Hakija API for Ataru"}}
+                                     :tags [{:name "application-api" :description "Application handling"}]}}
+                          (api/routes
+                            (api/context "/hakemus" []
+                              buildversion-routes
+                              api-routes
+                              (route/resources "/")
+                              (api/undocumented
+                                (api/GET "/:id" []
+                                  (selmer/render-file "templates/hakija.html" {:cache-fingerprint cache-fingerprint}))))
+                            (route/not-found "<h1>Page not found</h1>")))))
 
   (stop [this]
     this))


### PR DESCRIPTION
No more need for special instructions in README.md regarding Swagger UI. Just open the URL. API calls work directly too.