### PR TITLE
Show correct dropdown content in readonly view

### DIFF
--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -106,7 +106,7 @@
                               [:select.application__form-select
                                (for [option (:options field-descriptor)]
                                  ^{:key (:value option)}
-                                 [:option {:value (:value option)} (get-in option [:label :fi])])]]])}))
+                                 [:option (get-in option [:label :fi])])]]])}))
 
 (defn render-field
   [field-descriptor & args]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -106,7 +106,7 @@
                               [:select.application__form-select
                                (for [option (:options field-descriptor)]
                                  ^{:key (:value option)}
-                                 [:option {:value (:value option)} (-> option :label :fi)])]]])}))
+                                 [:option {:value (:value option)} (get-in option [:label :fi])])]]])}))
 
 (defn render-field
   [field-descriptor & args]


### PR DESCRIPTION
When an application with a dropdown is submitted, the value attribute from the option element of the dropdown will be submitted instead of the actual human-readable value.

This MIGHT be good behavior in the future when we hopefully have some kind of versioning in place for applications and therefore we have capability to map submitted value attributes to actual human-readable answers.

For example, when submitting a language, a `fi` value was submitted instead of `Finnish`. We can't unabigously map the `fi` to `Finnish` just based on the answer: the actual form might've been changed over time and the corresponding value to `fi` along with it.

But since we just want to have the human-readable answers on Excel, just submitting the actual human-readable value from the selected `option` element is the fastest possible solution. Works with IE 9.