### PR TITLE
Hilight invalid input on applicant side

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -164,7 +164,7 @@
   margin-right: 50px;
 }
 .application__form-field-error {
-  color: #E22070;
+  color: #E22070 !important;
 }
 .application__form-select-wrapper {
   font-size: 16px;

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -164,7 +164,7 @@
   margin-right: 50px;
 }
 .application__form-field-error {
-  color: #E22070 !important;
+  color: #E22070;
 }
 .application__form-select-wrapper {
   font-size: 16px;
@@ -231,11 +231,12 @@
   border-radius: 2px;
   height: 43px;
   font-size: 16px;
-  color: @text-color;
   padding: 8px;
   box-shadow: inset 0 0 2px #00526c;
 }
-
+.application__form-text-input--normal {
+  color: @text-color;
+}
 .application__form-text-input__size-small {
   width: 120px;
 }

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -54,7 +54,7 @@
 (defn text-field [field-descriptor & {:keys [div-kwd] :or {div-kwd :div.application__form-field}}]
   (let [application (subscribe [:state-query [:application]])]
     (fn [field-descriptor & {:keys [div-kwd] :or {div-kwd :div.application__form-field}}]
-      (let [size-class (text-field-size->class (-> field-descriptor :params :size))]
+      (let [size-class (text-field-size->class (get-in field-descriptor [:params :size]))]
         [div-kwd
          [label field-descriptor size-class]
          [:input.application__form-text-input

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -52,14 +52,17 @@
          [:span.application__form-field-error "Tarkista muoto"])])))
 
 (defn text-field [field-descriptor & {:keys [div-kwd] :or {div-kwd :div.application__form-field}}]
-  (let [application (subscribe [:state-query [:application]])]
+  (let [application (subscribe [:state-query [:application]])
+        id (keyword (:id field-descriptor))
+        valid? (subscribe [:state-query [:application :answers id :valid]])]
     (fn [field-descriptor & {:keys [div-kwd] :or {div-kwd :div.application__form-field}}]
       (let [size-class (text-field-size->class (get-in field-descriptor [:params :size]))]
         [div-kwd
          [label field-descriptor size-class]
          [:input.application__form-text-input
           {:type      "text"
-           :class     size-class
+           :class     (cond-> size-class
+                        (not @valid?) (str " application__form-field-error "))
            :value     (textual-field-value field-descriptor @application)
            :on-change (partial textual-field-change field-descriptor)}]]))))
 

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -61,8 +61,9 @@
          [label field-descriptor size-class]
          [:input.application__form-text-input
           {:type      "text"
-           :class     (cond-> size-class
-                        (not @valid?) (str " application__form-field-error "))
+           :class     (str size-class (if @valid?
+                                          " application__form-text-input--normal"
+                                          " application__form-field-error"))
            :value     (textual-field-value field-descriptor @application)
            :on-change (partial textual-field-change field-descriptor)}]]))))
 


### PR DESCRIPTION
When input of a text *field* is invalid, hilight it with red color. The hilighting is only added to text fields as it's not sensible to have any kind of validation on text areas or dropdowns.