### PR TITLE
Fix link anchors in application

### DIFF
--- a/resources/less/application-common.less
+++ b/resources/less/application-common.less
@@ -4,6 +4,7 @@
   please remember to test virkailija and hakija-applications both!
 */
 @import "vars";
+@total-banner-height: 130px;
 
 .application__readonly-container {
   width: 100%;
@@ -27,12 +28,15 @@
 }
 
 .application__wrapper-heading {
-  color: @blue-text-color;
-  font-size: 16px;
-  font-weight: normal;
-  text-transform: uppercase;
   position: absolute;
   width: 245px;
+  h2 {
+    color: @blue-text-color;
+    font-size: 16px;
+    font-weight: normal;
+    text-transform: uppercase;
+    display: inline-block;
+  }
 }
 .application__wrapper-element--border {
   border-top: solid #D7D7D7 1px;
@@ -51,4 +55,10 @@ and (max-width: @desktop-content-width) {
   .application__row-field.application__form-field, .application__form-field {
     margin-left: 10px;
   }
+}
+
+.application__scroll-to-anchor {
+  position: relative;
+  top: -@total-banner-height;
+  visibility: hidden;
 }

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -320,9 +320,3 @@ and (max-width: @desktop-content-width) {
     margin-right: 10px;
   }
 }
-
-.application__scroll-to-anchor {
-  position: relative;
-  top: -@total-banner-height;
-  visibility: hidden;
-}

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -2,6 +2,7 @@
 @banner-height: 33px;
 @field-margin-left: 245px;
 @form-select-width: 305px;
+@total-banner-height: 130px;
 
 .application__banner-container {
   z-index: 10;
@@ -150,7 +151,7 @@
   margin-top: 13px;
 }
 .application__form-content-area {
-  margin-top: 130px;
+  margin-top: @total-banner-height;
   margin-right: auto;
   margin-left: auto;
   width: @desktop-content-width;
@@ -318,4 +319,10 @@ and (max-width: @desktop-content-width) {
     max-width: 610px;
     margin-right: 10px;
   }
+}
+
+.application__scroll-to-anchor {
+  position: relative;
+  top: -@total-banner-height;
+  visibility: hidden;
 }

--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -10,3 +10,7 @@
 
 (defn wrapper-id [field-descriptor]
   (str "wrapper-" (:id field-descriptor)))
+
+(defn scroll-to-anchor
+  [field-descriptor]
+  [:span.application__scroll-to-anchor {:id (str "scroll-to-" (:id field-descriptor))} "."])

--- a/src/cljs/ataru/application_common/application_readonly.cljs
+++ b/src/cljs/ataru/application_common/application_readonly.cljs
@@ -5,7 +5,7 @@
             [ataru.application-common.application-field-common :refer [answer-key
                                                                        required-hint
                                                                        textual-field-value
-                                                                       wrapper-id]]))
+                                                                       scroll-to-anchor]]))
 
 (defn text [application field-descriptor]
   [:div.application__form-field
@@ -22,9 +22,9 @@
         [:div
          (when fieldset?
            {:class "application__wrapper-element application__wrapper-element--border"})
-         [:h2.application__wrapper-heading
-          {:id (wrapper-id content)}
-          (-> content :label :fi)]
+         [:div.application__wrapper-heading
+          [:h2 (-> content :label :fi)]
+          [scroll-to-anchor content]]
          (into [:div (when fieldset? {:class "application__wrapper-contents"})]
                (for [child children
                      :when (get-in @ui [(keyword (:id child)) :visible?] true)]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -5,7 +5,7 @@
             [ataru.application-common.application-field-common :refer [answer-key
                                                            required-hint
                                                            textual-field-value
-                                                           wrapper-id]]
+                                                           scroll-to-anchor]]
             [ataru.hakija.application-validators :as validator]
             [reagent.core :as r]
             [taoensso.timbre :refer-macros [spy debug]]))
@@ -55,9 +55,8 @@
         value  (subscribe [:state-query [:application :answers id :value]])]
     (fn [field-descriptor & [size-class]]
       [:label.application__form-field-label
-       {:id (field-id field-descriptor)
-        :class size-class}
        [:span (str (get-in field-descriptor [:label :fi]) (required-hint field-descriptor))]
+       [scroll-to-anchor field-descriptor]
        (when (and
                (not @valid?)
                (some #(= % "required") (:validators field-descriptor))
@@ -102,8 +101,8 @@
 (defn wrapper-field [field-descriptor children]
   [:div.application__wrapper-element.application__wrapper-element--border
    [:h2.application__wrapper-heading
-    {:id (wrapper-id field-descriptor)}
-    (-> field-descriptor :label :fi)]
+    (-> field-descriptor :label :fi)
+    [scroll-to-anchor field-descriptor]]
    (into [:div.application__wrapper-contents]
          (for [child children]
            [render-field child]))])

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -100,8 +100,8 @@
 
 (defn wrapper-field [field-descriptor children]
   [:div.application__wrapper-element.application__wrapper-element--border
-   [:h2.application__wrapper-heading
-    (-> field-descriptor :label :fi)
+   [:div.application__wrapper-heading
+    [:h2 (-> field-descriptor :label :fi)]
     [scroll-to-anchor field-descriptor]]
    (into [:div.application__wrapper-contents]
          (for [child children]

--- a/src/cljs/ataru/hakija/banner.cljs
+++ b/src/cljs/ataru/hakija/banner.cljs
@@ -27,7 +27,7 @@
                     [:span.application__close-invalid-fields
                      {:on-click toggle-show-details}
                      "x"]]
-                (mapv (fn [field] [:a {:href (str "#field-" (name (:key field)))} [:div (-> field :label :fi)]])
+                (mapv (fn [field] [:a {:href (str "#scroll-to-" (name (:key field)))} [:div (-> field :label :fi)]])
                       (:invalid-fields valid-status)))])]))))
 
 (defn sent-indicator [submit-status]
@@ -50,7 +50,7 @@
 
 (defn wrapper-section-link [ws]
   [:a.application__banner-wrapper-section-link
-   {:href (str "#wrapper-" (:id ws))
+   {:href (str "#scroll-to-" (:id ws))
     :class (if (:valid ws) "" "application__banner-wrapper-section-link-not-valid")}
    (-> ws :label :fi)])
 


### PR DESCRIPTION
Use position-relative span as anchor which is -BANNER_HEIGHT above it's normal position.

Sections and fields work with this in chrome and firefox, fields work in IE, but sections for some reason do not in IE.
