### PR TITLE
Persist and retry emails

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
                  [metosin/compojure-api "1.1.2"]
                  [com.stuartsierra/component "0.3.1"]
                  [aleph "0.4.1"]
+                 [http-kit "2.1.18"]
                  [ring "1.4.0"]
                  [ring/ring-defaults "0.2.0"]
                  [ring/ring-json "0.4.0"]

--- a/resources/db/migration/V1_11__Add_application_email_table.sql
+++ b/resources/db/migration/V1_11__Add_application_email_table.sql
@@ -1,0 +1,8 @@
+create table application_confirmation_emails (
+  id                bigserial primary key,
+  application_id    bigint references applications(id),
+  recipient         varchar(128) not null,
+  created_at        timestamp with time zone default now(),
+  delivery_attempts bigint default 0,
+  delivered_at      timestamp with time zone
+);

--- a/resources/db/migration/V1_11__Add_application_email_table.sql
+++ b/resources/db/migration/V1_11__Add_application_email_table.sql
@@ -6,3 +6,6 @@ create table application_confirmation_emails (
   delivery_attempts bigint default 0,
   delivered_at      timestamp with time zone
 );
+
+create index application_confirmation_emails_idx on application_confirmation_emails (created_at);
+

--- a/resources/db/migration/V1_11__Add_application_email_table.sql
+++ b/resources/db/migration/V1_11__Add_application_email_table.sql
@@ -7,5 +7,5 @@ create table application_confirmation_emails (
   delivered_at      timestamp with time zone
 );
 
-create index application_confirmation_emails_idx on application_confirmation_emails (created_at);
+create index application_confirmation_emails_idx on application_confirmation_emails (delivered_at, created_at);
 

--- a/resources/sql/email-queries.sql
+++ b/resources/sql/email-queries.sql
@@ -1,0 +1,10 @@
+-- name: yesql-add-application-confirmation-email<!
+insert into application_confirmation_emails (application_id, recipient) values (:application_id, :recipient);
+
+-- name: yesql-increment-delivery-attempt-count
+update application_confirmation_emails set delivery_attempts = delivery_attempts + 1 where id = :confirmation_id;
+
+-- name: yesql-increment-delivery-attempt-count-and-mark-delivered
+update application_confirmation_emails set delivered_at = now(), delivery_attempts = delivery_attempts + 1 where id = :confirmation_id;
+
+

--- a/resources/sql/email-queries.sql
+++ b/resources/sql/email-queries.sql
@@ -2,9 +2,12 @@
 insert into application_confirmation_emails (application_id, recipient) values (:application_id, :recipient);
 
 -- name: yesql-increment-delivery-attempt-count
-update application_confirmation_emails set delivery_attempts = delivery_attempts + 1 where id = :confirmation_id;
+update application_confirmation_emails set delivery_attempts = delivery_attempts + 1 where id = :id;
 
 -- name: yesql-increment-delivery-attempt-count-and-mark-delivered
-update application_confirmation_emails set delivered_at = now(), delivery_attempts = delivery_attempts + 1 where id = :confirmation_id;
+update application_confirmation_emails set delivered_at = now(), delivery_attempts = delivery_attempts + 1 where id = :id;
+
+-- name: yesql-get-unsent-application-confirmation-emails
+select distinct on (application_id, recipient) * from application_confirmation_emails where delivered_at = null order by created_at desc;
 
 

--- a/resources/sql/email-queries.sql
+++ b/resources/sql/email-queries.sql
@@ -1,13 +1,13 @@
 -- name: yesql-add-application-confirmation-email<!
 insert into application_confirmation_emails (application_id, recipient) values (:application_id, :recipient);
 
--- name: yesql-increment-delivery-attempt-count
+-- name: yesql-increment-delivery-attempt-count!
 update application_confirmation_emails set delivery_attempts = delivery_attempts + 1 where id = :id;
 
--- name: yesql-increment-delivery-attempt-count-and-mark-delivered
+-- name: yesql-increment-delivery-attempt-count-and-mark-delivered!
 update application_confirmation_emails set delivered_at = now(), delivery_attempts = delivery_attempts + 1 where id = :id;
 
 -- name: yesql-get-unsent-application-confirmation-emails
-select distinct on (application_id, recipient) * from application_confirmation_emails where delivered_at = null order by created_at desc;
+select distinct on (application_id, recipient) * from application_confirmation_emails where delivered_at is null order by application_id, recipient, created_at desc;
 
 

--- a/resources/sql/email-queries.sql
+++ b/resources/sql/email-queries.sql
@@ -8,6 +8,6 @@ update application_confirmation_emails set delivery_attempts = delivery_attempts
 update application_confirmation_emails set delivered_at = now(), delivery_attempts = delivery_attempts + 1 where id = :id;
 
 -- name: yesql-get-unsent-application-confirmation-emails
-select distinct on (application_id, recipient) * from application_confirmation_emails where delivered_at is null order by application_id, recipient, created_at desc;
+select * from application_confirmation_emails where delivered_at is null order by created_at;
 
 

--- a/resources/sql/email-queries.sql
+++ b/resources/sql/email-queries.sql
@@ -8,6 +8,4 @@ update application_confirmation_emails set delivery_attempts = delivery_attempts
 update application_confirmation_emails set delivered_at = now(), delivery_attempts = delivery_attempts + 1 where id = :id;
 
 -- name: yesql-get-unsent-application-confirmation-emails
-select * from application_confirmation_emails where delivered_at is null order by created_at;
-
-
+select * from application_confirmation_emails where delivered_at is null order by created_at for update;

--- a/spec/ataru/hakija/email_spec.clj
+++ b/spec/ataru/hakija/email_spec.clj
@@ -1,62 +1,17 @@
 (ns ataru.hakija.email-spec
-  (:require [aleph.http :as http]
-            [manifold.deferred :as d]
+  (:require [org.httpkit.client :as http]
             [ataru.hakija.email :as email]
+            [ataru.hakija.email-store :as store]
             [cheshire.core :as json]
             [speclj.core :refer :all]))
 
-(def application {:form 44,
-                  :lang "fi",
-                  :state :received,
-                  :answers
-                  [{:key "ssn",
-                    :value "010101-123n",
-                    :fieldType "textField",
-                    :label {:fi "Henkilötunnus", :sv "Personnummer"}}
-                   {:key "phone",
-                    :value "050123123",
-                    :fieldType "textField",
-                    :label {:fi "Matkapuhelin", :sv "Mobiltelefonnummer"}}
-                   {:key "preferred-name",
-                    :value "Aku",
-                    :fieldType "textField",
-                    :label {:fi "Kutsumanimi", :sv "Smeknamn"}}
-                   {:key "home-town",
-                    :value "Ankkalinna",
-                    :fieldType "textField",
-                    :label {:fi "Kotikunta", :sv "Bostadsort"}}
-                   {:key "last-name",
-                    :value "Ankka",
-                    :fieldType "textField",
-                    :label {:fi "Sukunimi", :sv "Efternamn"}}
-                   {:key "first-name",
-                    :value "Aku Petteri",
-                    :fieldType "textField",
-                    :label {:fi "Etunimet", :sv "Förnamn"}}
-                   {:key "address",
-                    :value "Paratiisitie 13",
-                    :fieldType "textField",
-                    :label {:fi "Katuosoite", :sv "Adress"}}
-                   {:key "nationality",
-                    :value "fi",
-                    :fieldType "dropdown",
-                    :label {:fi "Kansalaisuus", :sv "Nationalitet"}}
-                   {:key "postal-code",
-                    :value "00013",
-                    :fieldType "textField",
-                    :label {:fi "Postinumero", :sv "Postnummer"}}
-                   {:key "language",
-                    :value "sv",
-                    :fieldType "dropdown",
-                    :label {:fi "Äidinkieli", :sv "Modersmål"}}
-                   {:key "gender",
-                    :value "female",
-                    :fieldType "dropdown",
-                    :label {:fi "Sukupuoli", :sv "Kön"}}
-                   {:key "email",
-                    :value "aku@ankkalinna.com",
-                    :fieldType "textField",
-                    :label {:fi "Sähköpostiosoite", :sv "E-postadress"}}]})
+(def email-row
+  {:id                1
+   :application_id    1
+   :recipient         "applicant@example.com"
+   :created_at        nil
+   :delivery_attempts 0
+   :delivered_at      nil})
 
 (defmacro with-mock-api
   [eval-fn & body]
@@ -64,24 +19,36 @@
      (with-redefs-fn {#'http/post (fn [& args#]
                                     (apply ~eval-fn args#)
                                     (reset! api-called?# true)
-                                    (d/success-deferred nil))}
+                                    (future {:status 200}))}
        (fn []
          ~@body
          (should @api-called?#)))))
 
-(describe "sending email"
+(describe "sending application confirmation emails"
   (tags :unit)
 
-  (it "sends email using the /ryhmasahkoposti-service/email/firewall API call"
-    (tags :unit)
+  (it "works for failed and successful viestintäpalvelu API calls"
+      (let [sent-emails (atom 0)
+            failed-emails (atom 0)]
+        (with-redefs [store/get-unsent-emails (constantly [email-row])
+                      store/increment-delivery-attempt-count (fn [_ _] (swap! failed-emails inc))
+                      store/increment-delivery-attempt-count-and-mark-delivered (fn [_ _] (swap! sent-emails inc))]
+          (store/deliver-emails (fn [_] {:status 200}))
+          (should= @sent-emails 1)
+          (should= @failed-emails 0)
+          (store/deliver-emails (fn [_] {:status 500 :error "fail!"}))
+          (should= @sent-emails 1)
+          (should= @failed-emails 1))))
 
-    (with-mock-api (fn [uri request]
-                     (should= "https://itest-virkailija.oph.ware.fi/ryhmasahkoposti-service/email/firewall" uri)
-                     (should= "application/json" (get-in request [:headers "content-type"]))
-                     (let [body (json/parse-string (:body request) true)]
-                       (should= "no-reply@opintopolku.fi" (get-in body [:email :from]))
-                       (should= "Opintopolku.fi - Hakemuksesi on vastaanotettu" (get-in body [:email :subject]))
-                       (let [recipients (:recipient body)]
-                         (should= 1 (count recipients))
-                         (should= "aku@ankkalinna.com" (get-in recipients [0 :email])))))
-      (email/send-email-verification application 1))))
+  (it "sends email using the /ryhmasahkoposti-service/email/firewall API call"
+      (with-mock-api (fn [uri request]
+                       (should= "https://itest-virkailija.oph.ware.fi/ryhmasahkoposti-service/email/firewall" uri)
+                       (should= "application/json" (get-in request [:headers "content-type"]))
+                       (let [body (json/parse-string (:body request) true)]
+                         (should= "no-reply@opintopolku.fi" (get-in body [:email :from]))
+                         (should= "Opintopolku.fi - Hakemuksesi on vastaanotettu" (get-in body [:email :subject]))
+                         (let [recipients (:recipient body)]
+                           (should= 1 (count recipients))
+                           (should= "applicant@example.com" (get-in recipients [0 :email])))))
+                     (#'email/send-email-verification email-row))))
+

--- a/spec/ataru/hakija/email_spec.clj
+++ b/spec/ataru/hakija/email_spec.clj
@@ -5,13 +5,21 @@
             [cheshire.core :as json]
             [speclj.core :refer :all]))
 
-(def email-row
+(def undelivered-email
   {:id                1
    :application_id    1
    :recipient         "applicant@example.com"
    :created_at        nil
    :delivery_attempts 0
    :delivered_at      nil})
+
+(def delivered-email
+  {:id                2
+   :application_id    1
+   :recipient         "other.applicant@example.com"
+   :created_at        nil
+   :delivery_attempts 0
+   :delivered_at      "2016-08-10T12:00:00.000+03:00"})
 
 (defmacro with-mock-api
   [eval-fn & body]
@@ -24,13 +32,14 @@
          ~@body
          (should @api-called?#)))))
 
-(describe "sending application confirmation emails"
+(describe
+  "sending application confirmation emails"
   (tags :unit)
 
   (it "works for failed and successful viestintäpalvelu API calls"
       (let [sent-emails (atom 0)
             failed-emails (atom 0)]
-        (with-redefs [store/get-unsent-emails (constantly [email-row])
+        (with-redefs [store/get-unsent-emails (constantly [undelivered-email delivered-email])
                       store/increment-delivery-attempt-count (fn [_ _] (swap! failed-emails inc))
                       store/increment-delivery-attempt-count-and-mark-delivered (fn [_ _] (swap! sent-emails inc))]
           (store/deliver-emails (fn [_] {:status 200}))
@@ -39,6 +48,7 @@
           (store/deliver-emails (fn [_] {:status 500 :error "fail!"}))
           (should= @sent-emails 1)
           (should= @failed-emails 1))))
+
 
   (it "sends email using the /ryhmasahkoposti-service/email/firewall API call"
       (with-mock-api (fn [uri request]
@@ -50,5 +60,5 @@
                          (let [recipients (:recipient body)]
                            (should= 1 (count recipients))
                            (should= "applicant@example.com" (get-in recipients [0 :email])))))
-                     (#'email/send-email-verification email-row))))
+                     (#'email/send-email-verification undelivered-email))))
 

--- a/src/clj/ataru/hakija/email.clj
+++ b/src/clj/ataru/hakija/email.clj
@@ -1,6 +1,5 @@
 (ns ataru.hakija.email
-  (:require [aleph.http :as http]
-            [manifold.deferred :as deferred]
+  (:require [org.httpkit.client :as http]
             [cheshire.core :as json]
             [oph.soresu.common.config :refer [config]]
             [selmer.parser :as selmer]
@@ -41,6 +40,7 @@
   (->Emailer))
 
 (defn- send-email-verification
+  "Synchronous call to keep DB transactions intact"
   [email-verification]
   (let [url       (str
                     (get-in config [:email :email_service_url])
@@ -50,7 +50,7 @@
         application-id (:application_id email-verification)
         recipient (:recipient email-verification)]
     (info "sending email" id "to viestintäpalvelu at address" url "for application" application-id)
-    (http/post url {:headers {"content-type" "application/json"}
+    @(http/post url {:headers {"content-type" "application/json"}
                     :body (json/generate-string {:email {:from "no-reply@opintopolku.fi"
                                                          :subject "Opintopolku.fi - Hakemuksesi on vastaanotettu"
                                                          :isHtml true

--- a/src/clj/ataru/hakija/email.clj
+++ b/src/clj/ataru/hakija/email.clj
@@ -7,14 +7,13 @@
             [taoensso.timbre :refer [info error]]))
 
 (defn send-email-verification
-  [application application-id]
+  [email-verification]
   (let [url       (str
                     (get-in config [:email :email_service_url])
                     "/ryhmasahkoposti-service/email/firewall")
         body      (selmer/render-file "templates/email_confirmation_template.txt" {})
-        recipient (-> (filter #(= "email" (:key %)) (:answers application))
-                      first
-                      :value)]
+        application-id (:application-id email-verification)
+        recipient (:recipient email-verification)]
     (info "sending email to viestintäpalvelu at address " url " for application " application-id)
     (let [reply (http/post url {:headers {"content-type" "application/json"}
                                 :body (json/generate-string {:email {:from "no-reply@opintopolku.fi"

--- a/src/clj/ataru/hakija/email.clj
+++ b/src/clj/ataru/hakija/email.clj
@@ -52,9 +52,9 @@
                     "/ryhmasahkoposti-service/email/firewall")
         body      (selmer/render-file "templates/email_confirmation_template.txt" {})
         id (:id email-verification)
-        application-id (:application-id email-verification)
+        application-id (:application_id email-verification)
         recipient (:recipient email-verification)]
-    (info "sending email to viestintäpalvelu at address " url " for application " application-id)
+    (info "sending email" id "to viestintäpalvelu at address" url "for application" application-id)
     (let [reply (http/post url {:headers {"content-type" "application/json"}
                                 :body (json/generate-string {:email {:from "no-reply@opintopolku.fi"
                                                              :subject "Opintopolku.fi - Hakemuksesi on vastaanotettu"
@@ -65,13 +65,9 @@
             reply
             (fn [_]
               (store/mark-email-delivered id)
-              (info "Successfully sent email to viestintäpalvelu for application " application-id))
+              (info "Successfully sent email" id "to viestintäpalvelu for application" application-id))
             (fn [error-details]
               (store/increment-delivery-attempt-count id)
-              (error "Sending email to viestintäpalvelu failed for application " application-id)
-              (error "email details:")
-              (error "recipient: " recipient)
-              (error "body:")
-              (error  body)
+              (error "Sending email" id "to viestintäpalvelu failed for application" application-id)
               (error "error details:")
               (error error-details))))))

--- a/src/clj/ataru/hakija/email.clj
+++ b/src/clj/ataru/hakija/email.clj
@@ -34,7 +34,6 @@
     (info "Stopping emailer process")
     (let [emailer-future (:email this)]
       (future-cancel emailer-future)
-      (Thread/sleep 1000)
       (if (future-cancelled? emailer-future)
         (do
           (info "Stopped emailer process")

--- a/src/clj/ataru/hakija/email_store.clj
+++ b/src/clj/ataru/hakija/email_store.clj
@@ -18,8 +18,8 @@
 
 (defn mark-email-delivered
   [confirmation-id]
-  (exec :db yesql-increment-delivery-attempt-count-and-mark-delivered {:id confirmation-id}))
+  (exec :db yesql-increment-delivery-attempt-count-and-mark-delivered! {:id confirmation-id}))
 
 (defn increment-delivery-attempt-count
   [confirmation-id]
-  (exec :db yesql-increment-delivery-attempt-count {:id confirmation-id}))
+  (exec :db yesql-increment-delivery-attempt-count! {:id confirmation-id}))

--- a/src/clj/ataru/hakija/email_store.clj
+++ b/src/clj/ataru/hakija/email_store.clj
@@ -32,7 +32,7 @@
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
     (let [connection {:connection conn}
           emails (get-unsent-emails connection)
-          undelivered-emails (filter #(nil? (:delivered-at %)) emails)]
+          undelivered-emails (filter #(nil? (:delivered_at %)) emails)]
       (when (< 0 (count undelivered-emails))
         (info "Attempting to deliver" (count undelivered-emails) "application confirmation emails")
         (doseq [email undelivered-emails]

--- a/src/clj/ataru/hakija/email_store.clj
+++ b/src/clj/ataru/hakija/email_store.clj
@@ -1,0 +1,12 @@
+(ns ataru.hakija.email-store
+  (:require [oph.soresu.common.db :refer [exec]]))
+
+(defqueries "sql/email-queries.sql")
+
+(defn store-email-verification
+  [application application-id]
+  (let [recipient (-> (filter #(= "email" (:key %)) (:answers application))
+                      first
+                      :value)]
+    ; TODO: remove old rows with same recipient and application-id?
+    (exec :db yesql-add-application-confirmation-email<! {:application-id application-id :recipient recipient})))

--- a/src/clj/ataru/hakija/email_store.clj
+++ b/src/clj/ataru/hakija/email_store.clj
@@ -1,5 +1,6 @@
 (ns ataru.hakija.email-store
-  (:require [oph.soresu.common.db :refer [exec]]))
+  (:require [oph.soresu.common.db :refer [exec]]
+            [yesql.core :refer [defqueries]]))
 
 (defqueries "sql/email-queries.sql")
 
@@ -9,4 +10,16 @@
                       first
                       :value)]
     ; TODO: remove old rows with same recipient and application-id?
-    (exec :db yesql-add-application-confirmation-email<! {:application-id application-id :recipient recipient})))
+    (exec :db yesql-add-application-confirmation-email<! {:application_id application-id :recipient recipient})))
+
+(defn get-unsent-emails
+  []
+  (exec :db yesql-get-unsent-application-confirmation-emails {}))
+
+(defn mark-email-delivered
+  [confirmation-id]
+  (exec :db yesql-increment-delivery-attempt-count-and-mark-delivered {:id confirmation-id}))
+
+(defn increment-delivery-attempt-count
+  [confirmation-id]
+  (exec :db yesql-increment-delivery-attempt-count {:id confirmation-id}))

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -14,7 +14,7 @@
             [ring.util.http-response :as response]
             [compojure.route :as route]
             [selmer.parser :as selmer]
-            [taoensso.timbre :refer [info]]))
+            [taoensso.timbre :refer [info error]]))
 
 (def ^:private cache-fingerprint (System/currentTimeMillis))
 
@@ -32,7 +32,9 @@
       (info "Stored application with id:" stored-app-id)
       (email-store/store-email-verification application stored-app-id)
       (response/ok {:id stored-app-id}))
-    (response/bad-request)))
+    (do
+      (error "Invalid application!")
+      (response/bad-request))))
 
 (defn- handle-client-error [error-details]
   (client-error/log-client-error error-details)

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -1,6 +1,6 @@
 (ns ataru.hakija.hakija-routes
   (:require [ataru.buildversion :refer [buildversion-routes]]
-            [ataru.hakija.email :as email]
+            [ataru.hakija.email-store :as email-store]
             [ataru.hakija.validator :as validator]
             [ataru.forms.form-store :as form-store]
             [ataru.applications.application-store :as application-store]
@@ -30,7 +30,7 @@
   (if (validator/valid-application application)
     (let [stored-app-id (application-store/add-new-application application)]
       (info "Stored application with id:" stored-app-id)
-      (email/send-email-verification application stored-app-id)
+      (email-store/store-email-verification application stored-app-id)
       (response/ok {:id stored-app-id}))
     (response/bad-request)))
 

--- a/src/clj/ataru/hakija/hakija_system.clj
+++ b/src/clj/ataru/hakija/hakija_system.clj
@@ -3,6 +3,7 @@
             [ataru.db.migrations :as migrations]
             [ataru.hakija.hakija-routes :as handler]
             [ataru.http.server :as server]
+            [ataru.hakija.email :as email]
             [environ.core :refer [env]]))
 
 (defn new-system
@@ -18,6 +19,7 @@
                     :repl-port repl-port}
 
      :migration    (migrations/new-migration)
+     :email        (email/new-emailer)
      :server       (component/using
                      (server/new-server)
                      [:server-setup :handler]))))


### PR DESCRIPTION
Instead of immediately + synchronously attempting to send confirmation emails to users (and possibly failing), store them in the DB and have a separate mailer process attempt to deliver them via the Viestintäpalvelu API until successful.