### PR TITLE
Followup field

### DIFF
--- a/src/cljc/ataru/virkailija/component_data/component.cljc
+++ b/src/cljc/ataru/virkailija/component_data/component.cljc
@@ -7,8 +7,7 @@
    :fieldType  "textField"
    :label      {:fi "", :sv ""}
    :id         (util/component-id)
-   :params     {}
-   :focus?     true})
+   :params     {}})
 
 (defn text-area []
   (assoc (text-field)
@@ -21,14 +20,12 @@
    :id         (util/component-id)
    :label      {:fi "Osion nimi" :sv "Avsnitt namn"}
    :children   []
-   :params     {}
-   :focus?     true})
+   :params     {}})
 
 (defn dropdown-option
   []
   {:value ""
-   :label {:fi "" :sv ""}
-   :focus? true})
+   :label {:fi "" :sv ""}})
 
 (defn dropdown
   []
@@ -37,8 +34,7 @@
    :id         (util/component-id)
    :label      {:fi "", :sv ""}
    :params     {}
-   :options    [(merge (dropdown-option) {:focus? false})]
-   :focus?     true})
+   :options    [(dropdown-option)]})
 
 (defn multiple-choice
   []
@@ -47,8 +43,7 @@
    :id         (util/component-id)
    :label      {:fi "" :sv ""}
    :params     {}
-   :options    []
-   :focus?     true})
+   :options    []})
 
 (defn row-section
   "Creates a data structure that represents a row that has multiple form

--- a/src/cljc/ataru/virkailija/component_data/person_info_module.cljc
+++ b/src/cljc/ataru/virkailija/component_data/person_info_module.cljc
@@ -35,8 +35,7 @@
   (-> (component/dropdown-option)
       (merge {:value value :label labels}
              (when default-value
-               {:default-value default-value}))
-      (dissoc :focus?)))
+               {:default-value default-value}))))
 
 (defn ^:private nationality-component
   []
@@ -137,26 +136,22 @@
 
 (defn person-info-module
   []
-  (clojure.walk/prewalk
-    (fn [x]
-      (if (map? x)
-        (dissoc x :focus?)
-        x))
-    (merge (component/form-section) {:label {:fi "Henkilötiedot"
-                                             :sv "Personuppgifter"
-                                             :en "Personal information"}
-                                     :label-amendment {:fi "(Osio lisätään automaattisesti lomakkeelle)"
-                                                       :sv "Partitionen automatiskt lägga formen"
-                                                       :en "The section will be automatically added to the application"}
-                                     :children [(first-name-section)
-                                                (last-name-component)
-                                                (nationality-component)
-                                                (have-finnish-ssn-component)
-                                                (ssn-birthdate-gender-wrapper)
-                                                (email-component)
-                                                (phone-component)
-                                                (street-address-component)
-                                                (postal-office-section)
-                                                (home-town-component)
-                                                (native-language-section)]
-                                     :module :person-info})))
+  (merge (component/form-section)
+    {:label           {:fi "Henkilötiedot"
+                       :sv "Personuppgifter"
+                       :en "Personal information"}
+     :label-amendment {:fi "(Osio lisätään automaattisesti lomakkeelle)"
+                       :sv "Partitionen automatiskt lägga formen"
+                       :en "The section will be automatically added to the application"}
+     :children        [(first-name-section)
+                       (last-name-component)
+                       (nationality-component)
+                       (have-finnish-ssn-component)
+                       (ssn-birthdate-gender-wrapper)
+                       (email-component)
+                       (phone-component)
+                       (street-address-component)
+                       (postal-office-section)
+                       (home-town-component)
+                       (native-language-section)]
+     :module          :person-info}))

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -231,13 +231,21 @@
                                   [:span.application__form-select-arrow]
                                   [:select.application__form-select
                                    {:value value}
-                                   (map-indexed (fn [idx option]
-                                                  (let [label (non-blank-val (get-in option [:label lang])
-                                                                             (get-in option [:label default-lang]))
-                                                        value (:value option)]
-                                                    ^{:key idx}
-                                                    [:option {:value value} label]))
-                                                (:options field-descriptor))]]]))})))
+                                   (concat
+                                     (when
+                                       (and
+                                         (nil? (:koodisto-source field-descriptor))
+                                         (not (:no-blank-option field-descriptor))
+                                         (not= "" (:value (first (:options field-descriptor)))))
+                                       [^{:key (str "blank-" (:id field-descriptor))} [:option {:value ""} ""]])
+                                     (map-indexed
+                                       (fn [idx option]
+                                         (let [label (non-blank-val (get-in option [:label lang])
+                                                       (get-in option [:label default-lang]))
+                                               value (:value option)]
+                                           ^{:key idx}
+                                           [:option {:value value} label]))
+                                       (:options field-descriptor)))]]]))})))
 
 (defn multiple-choice
   [field-descriptor & {:keys [div-kwd disabled] :or {div-kwd :div.application__form-field disabled false}}]
@@ -290,7 +298,6 @@
                         :children   children} [row-wrapper children]
                        {:fieldClass "formField"
                         :id         (_ :guard (complement visible?))} [:div]
-
                        {:fieldClass "formField" :fieldType "textField" :params {:repeatable true}} [repeatable-text-field field-descriptor]
                        {:fieldClass "formField" :fieldType "textField"} [text-field field-descriptor :disabled disabled?]
                        {:fieldClass "formField" :fieldType "textArea"} [text-area field-descriptor]

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -303,15 +303,9 @@
             (seq [
                   ^{:key "options-input"}
                   [:div.editor-form__multi-options-container
-                   (let [options (:options @value)]
-                     (->> options
-                          (map-indexed (fn [idx option]
-                                         (when-not (and (= "dropdown" field-type)
-                                                        (clojure.string/blank? (:value option))
-                                                        (= idx 0)
-                                                        (> (count options) 1))
-                                           (dropdown-option idx path languages))))
-                          (remove nil?)))]
+                   (map-indexed (fn [idx option]
+                                  (dropdown-option idx path languages))
+                     (:options @value))]
                   ^{:key "options-input-add"}
                   [:div.editor-form__add-dropdown-item
                    [:a

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -215,13 +215,67 @@
           languages))]
      (remove-dropdown-option-button path option-index)]))
 
-(defn dropdown [initial-content path]
-  (let [languages                  (subscribe [:editor/languages])
-        options-koodisto           (subscribe [:editor/get-component-value path :koodisto-source])
-        value                      (subscribe [:editor/get-component-value path])
-        dropdown-id                (util/new-uuid)
-        animation-effect           (fade-out-effect path)
+(defn- dropdown-multi-options [path options-koodisto]
+  (let [dropdown-id                (util/new-uuid)
+        custom-button-value        "Omat vastausvaihtoehdot"
+        custom-button-id           (str dropdown-id "-custom")
+        koodisto-button-value      (str "Koodisto" (if-let [koodisto-name (:title options-koodisto)] (str ": " koodisto-name) ""))
+        koodisto-button-id         (str dropdown-id "-koodisto")
         koodisto-popover-expanded? (r/atom false)]
+    [:div.editor-form__button-group
+     [:input
+      {:type      "radio"
+       :class     "editor-form__button editor-form__button--large"
+       :value     custom-button-value
+       :checked   (nil? options-koodisto)
+       :name      dropdown-id
+       :id        custom-button-id
+       :on-change (fn [evt]
+                    (.preventDefault evt)
+                    (reset! koodisto-popover-expanded? false)
+                    (dispatch [:editor/select-custom-multi-options path]))}]
+     [:label
+      {:for   custom-button-id
+       :class "editor-form-button--left-edge"}
+      custom-button-value]
+     [:input
+      {:type      "radio"
+       :class     "editor-form__button editor-form__button--large"
+       :value     koodisto-button-value
+       :checked   (not (nil? options-koodisto))
+       :name      dropdown-id
+       :id        koodisto-button-id
+       :on-change (fn [evt]
+                    (.preventDefault evt)
+                    (reset! koodisto-popover-expanded? true))}]
+     [:label
+      {:for   koodisto-button-id
+       :class "editor-form-button--right-edge"}
+      koodisto-button-value]
+     (when @koodisto-popover-expanded?
+       [:div.editor-form__koodisto-popover
+        [:div.editor-form__koodisto-popover-header "Koodisto"
+         [:a.editor-form__koodisto-popover-close
+          {:on-click (fn [e]
+                       (.preventDefault e)
+                       (reset! koodisto-popover-expanded? false))}
+          [:i.zmdi.zmdi-close.zmdi-hc-lg]]]
+        [:ul.editor-form__koodisto-popover-list
+         (doall (for [{:keys [uri title version]} koodisto-whitelist/koodisto-whitelist]
+                  ^{:key (str "koodisto-" uri)}
+                  [:li.editor-form__koodisto-popover-list-item
+                   [:a.editor-form__koodisto-popover-link
+                    {:on-click (fn [e]
+                                 (.preventDefault e)
+                                 (reset! koodisto-popover-expanded? false)
+                                 (dispatch [:editor/select-koodisto-options uri version title path]))}
+                    title]]))]])]))
+
+(defn dropdown [initial-content path]
+  (let [languages        (subscribe [:editor/languages])
+        options-koodisto (subscribe [:editor/get-component-value path :koodisto-source])
+        value            (subscribe [:editor/get-component-value path]) 
+        animation-effect (fade-out-effect path)]
     (fn [initial-content path]
       (let [languages  @languages
             field-type (:fieldType @value)]
@@ -246,58 +300,7 @@
 
          [:div.editor-form__multi-options_wrapper
           [:header.editor-form__component-item-header "Vastausvaihtoehdot"]
-          (let [custom-button-value        "Omat vastausvaihtoehdot"
-                custom-button-id           (str dropdown-id "-custom")
-                koodisto-button-value      (str "Koodisto" (if-let [koodisto-name (:title @options-koodisto)] (str ": " koodisto-name) ""))
-                koodisto-button-id         (str dropdown-id "-koodisto")]
-            [:div.editor-form__button-group
-             [:input
-              {:type      "radio"
-               :class     "editor-form__button editor-form__button--large"
-               :value     custom-button-value
-               :checked   (nil? @options-koodisto)
-               :name      dropdown-id
-               :id        custom-button-id
-               :on-change (fn [evt]
-                            (.preventDefault evt)
-                            (reset! koodisto-popover-expanded? false)
-                            (dispatch [:editor/select-custom-multi-options path]))}]
-             [:label
-              {:for   custom-button-id
-               :class "editor-form-button--left-edge"}
-              custom-button-value]
-             [:input
-              {:type      "radio"
-               :class     "editor-form__button editor-form__button--large"
-               :value     koodisto-button-value
-               :checked   (not (nil? @options-koodisto))
-               :name      dropdown-id
-               :id        koodisto-button-id
-               :on-change (fn [evt]
-                            (.preventDefault evt)
-                            (reset! koodisto-popover-expanded? true))}]
-             [:label
-              {:for   koodisto-button-id
-               :class "editor-form-button--right-edge"}
-              koodisto-button-value]
-             (when @koodisto-popover-expanded?
-               [:div.editor-form__koodisto-popover
-                [:div.editor-form__koodisto-popover-header "Koodisto"
-                 [:a.editor-form__koodisto-popover-close
-                  {:on-click (fn [e]
-                               (.preventDefault e)
-                               (reset! koodisto-popover-expanded? false))}
-                  [:i.zmdi.zmdi-close.zmdi-hc-lg]]]
-                [:ul.editor-form__koodisto-popover-list
-                 (doall (for [{:keys [uri title version]} koodisto-whitelist/koodisto-whitelist]
-                          ^{:key (str "koodisto-" uri)}
-                          [:li.editor-form__koodisto-popover-list-item
-                           [:a.editor-form__koodisto-popover-link
-                            {:on-click (fn [e]
-                                         (.preventDefault e)
-                                         (reset! koodisto-popover-expanded? false)
-                                         (dispatch [:editor/select-koodisto-options uri version title path]))}
-                            title]]))]])])
+          [dropdown-multi-options path @options-koodisto]
 
           (when (nil? @options-koodisto)
             (seq [

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -222,54 +222,55 @@
         koodisto-button-value      (str "Koodisto" (if-let [koodisto-name (:title options-koodisto)] (str ": " koodisto-name) ""))
         koodisto-button-id         (str dropdown-id "-koodisto")
         koodisto-popover-expanded? (r/atom false)]
-    [:div.editor-form__button-group
-     [:input
-      {:type      "radio"
-       :class     "editor-form__button editor-form__button--large"
-       :value     custom-button-value
-       :checked   (nil? options-koodisto)
-       :name      dropdown-id
-       :id        custom-button-id
-       :on-change (fn [evt]
-                    (.preventDefault evt)
-                    (reset! koodisto-popover-expanded? false)
-                    (dispatch [:editor/select-custom-multi-options path]))}]
-     [:label
-      {:for   custom-button-id
-       :class "editor-form-button--left-edge"}
-      custom-button-value]
-     [:input
-      {:type      "radio"
-       :class     "editor-form__button editor-form__button--large"
-       :value     koodisto-button-value
-       :checked   (not (nil? options-koodisto))
-       :name      dropdown-id
-       :id        koodisto-button-id
-       :on-change (fn [evt]
-                    (.preventDefault evt)
-                    (reset! koodisto-popover-expanded? true))}]
-     [:label
-      {:for   koodisto-button-id
-       :class "editor-form-button--right-edge"}
-      koodisto-button-value]
-     (when @koodisto-popover-expanded?
-       [:div.editor-form__koodisto-popover
-        [:div.editor-form__koodisto-popover-header "Koodisto"
-         [:a.editor-form__koodisto-popover-close
-          {:on-click (fn [e]
-                       (.preventDefault e)
-                       (reset! koodisto-popover-expanded? false))}
-          [:i.zmdi.zmdi-close.zmdi-hc-lg]]]
-        [:ul.editor-form__koodisto-popover-list
-         (doall (for [{:keys [uri title version]} koodisto-whitelist/koodisto-whitelist]
-                  ^{:key (str "koodisto-" uri)}
-                  [:li.editor-form__koodisto-popover-list-item
-                   [:a.editor-form__koodisto-popover-link
-                    {:on-click (fn [e]
-                                 (.preventDefault e)
-                                 (reset! koodisto-popover-expanded? false)
-                                 (dispatch [:editor/select-koodisto-options uri version title path]))}
-                    title]]))]])]))
+    (fn [path options-koodisto]
+      [:div.editor-form__button-group
+       [:input
+        {:type      "radio"
+         :class     "editor-form__button editor-form__button--large"
+         :value     custom-button-value
+         :checked   (nil? options-koodisto)
+         :name      dropdown-id
+         :id        custom-button-id
+         :on-change (fn [evt]
+                      (.preventDefault evt)
+                      (reset! koodisto-popover-expanded? false)
+                      (dispatch [:editor/select-custom-multi-options path]))}]
+       [:label
+        {:for   custom-button-id
+         :class "editor-form-button--left-edge"}
+        custom-button-value]
+       [:input
+        {:type      "radio"
+         :class     "editor-form__button editor-form__button--large"
+         :value     koodisto-button-value
+         :checked   (not (nil? options-koodisto))
+         :name      dropdown-id
+         :id        koodisto-button-id
+         :on-change (fn [evt]
+                      (.preventDefault evt)
+                      (reset! koodisto-popover-expanded? true))}]
+       [:label
+        {:for   koodisto-button-id
+         :class "editor-form-button--right-edge"}
+        koodisto-button-value]
+       (when @koodisto-popover-expanded?
+         [:div.editor-form__koodisto-popover
+          [:div.editor-form__koodisto-popover-header "Koodisto"
+           [:a.editor-form__koodisto-popover-close
+            {:on-click (fn [e]
+                         (.preventDefault e)
+                         (reset! koodisto-popover-expanded? false))}
+            [:i.zmdi.zmdi-close.zmdi-hc-lg]]]
+          [:ul.editor-form__koodisto-popover-list
+           (doall (for [{:keys [uri title version]} koodisto-whitelist/koodisto-whitelist]
+                    ^{:key (str "koodisto-" uri)}
+                    [:li.editor-form__koodisto-popover-list-item
+                     [:a.editor-form__koodisto-popover-link
+                      {:on-click (fn [e]
+                                   (.preventDefault e)
+                                   (reset! koodisto-popover-expanded? false)
+                                   (dispatch [:editor/select-koodisto-options uri version title path]))}
+                      title]]))]])])))
 
 (defn dropdown [initial-content path]
   (let [languages        (subscribe [:editor/languages])
@@ -306,7 +307,7 @@
             (seq [
                   ^{:key "options-input"}
                   [:div.editor-form__multi-options-container
-                   (map-indexed (fn [idx option]
+                   (map-indexed (fn [idx _]
                                   (dropdown-option idx path languages))
                      (:options @value))]
                   ^{:key "options-input-add"}

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -76,7 +76,7 @@
 
 (defn input-field [path lang dispatch-fn {:keys [class]}]
   (let [component (subscribe [:editor/get-component-value path])
-        focus?    (reaction (:focus? @component))
+        focus?    (subscribe [:state-query [:editor :ui (:id @component) :focus?]])
         value     (reaction (get-in @component [:label lang]))
         languages (subscribe [:editor/languages])]
     (r/create-class
@@ -216,11 +216,11 @@
      (remove-dropdown-option-button path option-index)]))
 
 (defn dropdown [initial-content path]
-  (let [languages        (subscribe [:editor/languages])
-        options-koodisto (subscribe [:editor/get-component-value path :koodisto-source])
-        value            (subscribe [:editor/get-component-value path])
-        dropdown-id      (util/new-uuid)
-        animation-effect (fade-out-effect path)
+  (let [languages                  (subscribe [:editor/languages])
+        options-koodisto           (subscribe [:editor/get-component-value path :koodisto-source])
+        value                      (subscribe [:editor/get-component-value path])
+        dropdown-id                (util/new-uuid)
+        animation-effect           (fade-out-effect path)
         koodisto-popover-expanded? (r/atom false)]
     (fn [initial-content path]
       (let [languages  @languages
@@ -292,10 +292,11 @@
                  (doall (for [{:keys [uri title version]} koodisto-whitelist/koodisto-whitelist]
                           ^{:key (str "koodisto-" uri)}
                           [:li.editor-form__koodisto-popover-list-item
-                           [:a.editor-form__koodisto-popover-link {:on-click (fn [e]
-                                                                               (.preventDefault e)
-                                                                               (reset! koodisto-popover-expanded? false)
-                                                                               (dispatch [:editor/select-koodisto-options uri version title path]))}
+                           [:a.editor-form__koodisto-popover-link
+                            {:on-click (fn [e]
+                                         (.preventDefault e)
+                                         (reset! koodisto-popover-expanded? false)
+                                         (dispatch [:editor/select-koodisto-options uri version title path]))}
                             title]]))]])])
 
           (when (nil? @options-koodisto)

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -85,8 +85,11 @@
 (reg-event-db
   :editor/add-dropdown-option
   (fn [db [_ & path]]
-    (let [dropdown-path (current-form-content-path db [path :options])]
-      (update-in db dropdown-path into [(ataru.virkailija.component-data.component/dropdown-option)]))))
+    (let [dropdown-path (current-form-content-path db [path :options])
+          component     (ataru.virkailija.component-data.component/dropdown-option)]
+      (->
+        (update-in db dropdown-path into [component])
+        (assoc-in [:editor :ui (:id component) :focus?] true)))))
 
 (reg-event-db
   :editor/set-dropdown-option-value
@@ -139,12 +142,14 @@
 (defn generate-component
   [db [_ generate-fn path]]
   (with-form-key [db form-key]
-    (let [form-key       (get-in db [:editor :selected-form-key])
-          path-vec      (current-form-content-path db [path])
-          component     (generate-fn)]
-      (if (zero? (last path-vec))
-        (assoc-in db (butlast path-vec) [component])
-        (assoc-in db path-vec component)))))
+    (let [form-key  (get-in db [:editor :selected-form-key])
+          path-vec  (current-form-content-path db [path])
+          component (generate-fn)]
+      (->
+        (if (zero? (last path-vec))
+          (assoc-in db (butlast path-vec) [component])
+          (assoc-in db path-vec component))
+        (assoc-in [:editor :ui (:id component) :focus?] true)))))
 
 (reg-event-db :generate-component generate-component)
 
@@ -223,6 +228,7 @@
 
 (defn- handle-fetch-form [db {:keys [key] :as response} _]
   (-> db
+      (update :editor dissoc :ui)
       (assoc-in [:editor :forms key] (languages->kwd response))
       (assoc-in [:editor :autosave]
         (autosave/interval-loop {:subscribe-path    [:editor :forms key]
@@ -246,22 +252,12 @@
           (fetch-form-content! id))
         (assoc-in db [:editor :selected-form-key] form-key)))))
 
-(defn- remove-focus
-  [form]
-  (clojure.walk/prewalk
-    (fn [x]
-      (if (map? x)
-        (dissoc x :focus?)
-        x))
-    form))
-
 (def save-chan (async/chan (async/sliding-buffer 1)))
 
 (defn save-loop [save-chan]
   (go-loop [_ (async/<! save-chan)]
     (let [form (-> @(subscribe [:editor/selected-form])
                    (update-dropdown-field-options)
-                   (remove-focus)
                    (dissoc :created-time))
           response-chan (async/chan)]
       (when (not-empty (:content form))
@@ -323,9 +319,7 @@
 (defn- copy-form [db _]
   (let [form-id (get-in db [:editor :selected-form-key])
         form    (-> (get-in db [:editor :forms form-id])
-                    (update :name (fn [name]
-                                    (str name " - KOPIO")))
-                    (remove-focus))]
+                    (update :name str " - KOPIO"))]
     (post-new-form form)
     db))
 
@@ -435,18 +429,22 @@
 (defn- toggle-language [db [_ lang]]
   (let [form-path [:editor :forms (get-in db [:editor :selected-form-key])]
         lang-path (conj form-path :languages)]
-    (->> (update-in db lang-path
-           (fn [languages]
-             (let [languages (or languages [:fi])]
-               (cond
-                 (not (some #{lang} languages)) (sort-by (partial index-of lang-order)
-                                                         (conj languages lang))
-                 (> (count languages) 1) (filter (partial not= lang) languages)
-                 :else languages))))
-         (clojure.walk/prewalk
-           (fn [x]
-             (if (= [:focus? true] x)
-               [:focus? false]
-               x))))))
+    (->
+      (update-in db lang-path
+        (fn [languages]
+          (let [languages (or languages [:fi])]
+            (cond
+              (not (some #{lang} languages)) (sort-by (partial index-of lang-order)
+                                               (conj languages lang))
+              (> (count languages) 1)        (filter (partial not= lang) languages)
+              :else                          languages))))
+      (update-in [:editor :ui]
+        (fn [ui]
+          (clojure.walk/prewalk
+            (fn [x]
+              (if (= [:focus? true] x)
+                [:focus? false]
+                x))
+            ui))))))
 
 (reg-event-db :editor/toggle-language toggle-language)


### PR DESCRIPTION
Fix some issues with dropdowns
- :focus? was moved outside of form structure, no need to filter/mangle form data before sending it over
- blank option logic was really complicated, moved it all to applicant side and removed editor side tweaks. Backwards compatible with old forms.
