### PR TITLE
Edit previously submitted application

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                  [binaryage/devtools "0.8.2"]
                  [re-frisk "0.2.2"] ; will only be used in development side
                  [venantius/accountant "0.1.7"]
+                 [com.cemerick/url "0.1.1"]
 
                  ;clojure/clojurescript
                  [prismatic/schema "1.1.1"]

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -44,7 +44,13 @@ select id, key, lang, form_id as form, created_time, content from applications w
 with latest_version as (
     select max(created_time) as latest_time from applications a where a.key = :application_key
 )
-select id, key, secret, lang, form_id as form, created_time, content from applications a join latest_version lv on a.created_time = lv.latest_time;
+select id, key, lang, form_id as form, created_time, content from applications a join latest_version lv on a.created_time = lv.latest_time;
+
+-- name: yesql-get-latest-application-by-secret
+with latest_version as (
+    select max(created_time) as latest_time from applications a where a.secret = :secret
+)
+select id, key, lang, form_id as form, created_time, content from applications a join latest_version lv on a.created_time = lv.latest_time;
 
 -- name: yesql-get-application-organization-by-key
 -- Get the related form's organization oid for access checks

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -44,7 +44,7 @@ select id, key, lang, form_id as form, created_time, content from applications w
 with latest_version as (
     select max(created_time) as latest_time from applications a where a.key = :application_key
 )
-select id, key, lang, form_id as form, created_time, content from applications a join latest_version lv on a.created_time = lv.latest_time;
+select id, key, secret, lang, form_id as form, created_time, content from applications a join latest_version lv on a.created_time = lv.latest_time;
 
 -- name: yesql-get-application-organization-by-key
 -- Get the related form's organization oid for access checks

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -52,6 +52,12 @@ with latest_version as (
 )
 select id, key, lang, form_id as form, created_time, content from applications a join latest_version lv on a.created_time = lv.latest_time;
 
+-- name: yesql-get-latest-version-by-secret-lock-for-update
+with latest_version as (
+    select max(created_time) as latest_time from applications a where a.secret = :secret
+)
+select id, key, lang, form_id as form, created_time, content from applications a join latest_version lv on a.created_time = lv.latest_time for update;
+
 -- name: yesql-get-application-organization-by-key
 -- Get the related form's organization oid for access checks
 

--- a/spec/ataru/fixtures/db/browser_test_db.clj
+++ b/spec/ataru/fixtures/db/browser_test_db.clj
@@ -1,9 +1,11 @@
 (ns ataru.fixtures.db.browser-test-db
   "Database fixture, insert test-data to DB"
   (:require [yesql.core :refer [defqueries]]
+            [clojure.java.jdbc :as jdbc]
             [ataru.forms.form-store :as form-store]
             [ataru.applications.application-store :as application-store]
-            [ataru.fixtures.application :as app-fixture]))
+            [ataru.fixtures.application :as app-fixture]
+            [oph.soresu.common.db :as db]))
 
 (defqueries "sql/form-queries.sql")
 
@@ -51,4 +53,5 @@
 (defn init-db-fixture []
   (form-store/create-form-or-increment-version! form1 "1.2.246.562.10.0439845")
   (form-store/create-form-or-increment-version! form2 "1.2.246.562.10.0439845")
-  (application-store/add-new-application application1))
+  (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
+    (application-store/add-new-application application1 conn)))

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -61,7 +61,7 @@
   "Get application that has human-readable koodisto values populated
    onto raw koodi values."
   [application-key session organization-service]
-  (let [application (application-store/get-latest-application-by-key application-key)
+  (let [application (dissoc (application-store/get-latest-application-by-key application-key) :secret)
         form        (form-store/fetch-by-id (:form application))
         application (populate-koodisto-fields application form)]
     (aac/check-application-access application-key session organization-service)

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -103,6 +103,11 @@
 (defn get-latest-application-by-key [application-key]
   (unwrap-application {:lang "fi"} (first (exec-db :db yesql-get-latest-application-by-key {:application_key application-key}))))
 
+(defn get-latest-application-by-secret [secret]
+  (->> (exec-db :db yesql-get-latest-application-by-secret {:secret secret})
+       (first)
+       (unwrap-application {:lang "fi"})))
+
 (defn get-application-events [application-key]
   (mapv ->kebab-case-kw (exec-db :db yesql-get-application-events {:application_key application-key})))
 

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -117,10 +117,10 @@
       :summary "Submit application"
       :body [application ataru-schema/Application]
       (handle-application application))
-    (api/GET "/application/:application-key/:secret" []
+    (api/GET "/application/:application-key" []
       :summary "Get submitted application"
-      :path-params [application-key :- s/Str
-                    secret :- s/Str]
+      :path-params [application-key :- s/Str]
+      :query-params [secret :- s/Str]
       :return ataru-schema/Application
       (get-application application-key secret))
     (api/POST "/client-error" []

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -59,15 +59,25 @@
         (info "Started person creation job (to person service) with job id" person-service-job-id)
         (response/ok {:id application-id})))))
 
-(defn- get-application [secret]
-  (let [application (application-store/get-latest-application-by-secret secret)]
-    (if (some? (:id application))
+(defn- get-application [secret form-key]
+  (let [application (application-store/get-latest-application-by-secret secret)
+        form        (form-store/fetch-by-id (:form application))]
+    (cond
+      (and (some? (:id application))
+           (= form-key (:key form)))
       (do
-        (println application)
         (info (str "Getting application " (:id application) " with answers"))
         (response/ok (dissoc application :secret)))
+
+      (and (some? (:id application))
+           (not= form-key (:key form)))
       (do
-        (info (str "Not returning application for provided secret " secret))
+        (warn (str "Mismatching form keys (key in database: " (:key form) ", key from the client: " form-key ") when getting application by secret, returning HTTP 404 for security reasons"))
+        (response/not-found))
+
+      :else
+      (do
+        (info (str "Failed to get application belonging to form " form-key " by secret, returning HTTP 404"))
         (response/not-found)))))
 
 (defn- handle-client-error [error-details]
@@ -118,9 +128,10 @@
       (handle-application application))
     (api/GET "/application" []
       :summary "Get submitted application"
-      :query-params [secret :- s/Str]
+      :query-params [form-key :- s/Str
+                     secret :- s/Str]
       :return ataru-schema/Application
-      (get-application secret))
+      (get-application secret form-key))
     (api/POST "/client-error" []
       :summary "Log client-side errors to server log"
       :body [error-details client-error/ClientError]

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -144,7 +144,8 @@
    (s/optional-key :id)             s/Int
    (s/optional-key :hakukohde)      (s/maybe s/Str)
    (s/optional-key :hakukohde-name) (s/maybe s/Str)
-   (s/optional-key :created-time)   org.joda.time.DateTime})
+   (s/optional-key :created-time)   org.joda.time.DateTime
+   (s/optional-key :secret)         s/Str})
 
 (def application-states (s/enum "received"
                                 "processing"

--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -45,11 +45,14 @@
     {:key (name ans-key) :value value :fieldType field-type :label label}))
 
 (defn create-application-to-submit [application form lang]
-  {:form           (:id form)
-   :lang           lang
-   :hakukohde      (:hakukohde-oid form)
-   :hakukohde-name (:hakukohde-name form)
-   :answers        (create-answers-to-submit (:answers application) form)})
+  (let [secret (:secret application)]
+    (cond-> {:form           (:id form)
+             :lang           lang
+             :hakukohde      (:hakukohde-oid form)
+             :hakukohde-name (:hakukohde-name form)
+             :answers        (create-answers-to-submit (:answers application) form)}
+      (some? secret)
+      (assoc :secret secret))))
 
 (defn extract-wrapper-sections [form]
   (map #(select-keys % [:id :label :children])

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -182,7 +182,8 @@
          ; default-value because IE11 will "flicker" on input fields. This has side-effect of NOT showing any
          ; dynamically made changes to the text-field value.
          :default-value (textual-field-value field-descriptor @application)
-         :on-change (partial textual-field-change field-descriptor)}]])))
+         :on-change (partial textual-field-change field-descriptor)
+         :value (textual-field-value field-descriptor @application)}]])))
 
 (declare render-field)
 

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -108,7 +108,7 @@
     (cond-> {:db db}
       (some? application-secret)
       (assoc :http {:method  :get
-                    :url     (str "/hakemus/api/application?secret=" application-secret "&form-key=" (:key form))
+                    :url     (str "/hakemus/api/application?secret=" application-secret)
                     :handler [:application/handle-get-application application-secret]}))))
 
 (reg-event-db

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -14,18 +14,13 @@
   {:form nil
    :application {:answers {}}})
 
-(reg-fx
-  :event
-  (fn [& event]
-    (debug event)))
-
 (reg-event-fx
   :application/get-latest-form-by-key
-  (fn [cofx [_ form-key]]
-    (assoc cofx
-      :http {:method :get
-             :url (str "/hakemus/api/form/" form-key)
-             :handler :application/handle-form})))
+  (fn [{:keys [db]} [_ form-key]]
+    {:db   db
+     :http {:method  :get
+            :url     (str "/hakemus/api/form/" form-key)
+            :handler :application/handle-form}}))
 
 (defn- get-latest-form-by-hakukohde [db [_ hakukohde-oid]]
   (ajax/get

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -108,7 +108,7 @@
     (cond-> {:db db}
       (some? application-secret)
       (assoc :http {:method  :get
-                    :url     (str "/hakemus/api/application?secret=" application-secret)
+                    :url     (str "/hakemus/api/application?secret=" application-secret "&form-key=" (:key form))
                     :handler [:application/handle-get-application application-secret]}))))
 
 (reg-event-db

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -10,10 +10,9 @@
                                               extract-wrapper-sections]]
             [taoensso.timbre :refer-macros [spy debug]]))
 
-(defn initialize-db [cofx _]
-  {:db {:form         nil
-        :application  {:answers {}}
-        :query-params (:query-params cofx)}})
+(defn initialize-db [_ _]
+  {:form        nil
+   :application {:answers {}}})
 
 (reg-event-fx
   :application/get-latest-form-by-key
@@ -101,9 +100,8 @@
   :application/handle-form
   handle-form)
 
-(reg-event-fx
+(reg-event-db
   :application/initialize-db
-  [(inject-cofx :query-params)]
   initialize-db)
 
 (defn set-application-field [db [_ key values]]

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -23,13 +23,13 @@
             :url     (str "/hakemus/api/form/" form-key)
             :handler :application/handle-form}}))
 
-(defn- get-latest-form-by-hakukohde [db [_ hakukohde-oid]]
-  (ajax/get
-    (str "/hakemus/api/hakukohde/" hakukohde-oid)
-    :application/handle-form)
-  db)
+(defn- get-latest-form-by-hakukohde [{:keys [db]} [_ hakukohde-oid]]
+  {:db   db
+   :http {:method  :get
+          :url     (str "/hakemus/api/hakukohde/" hakukohde-oid)
+          :handler :application/handle-form}})
 
-(reg-event-db
+(reg-event-fx
   :application/get-latest-form-by-hakukohde
   get-latest-form-by-hakukohde)
 

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -1,5 +1,5 @@
 (ns ataru.hakija.application-handlers
-  (:require [re-frame.core :refer [reg-event-db reg-fx reg-event-fx dispatch]]
+  (:require [re-frame.core :refer [reg-event-db reg-fx reg-event-fx dispatch inject-cofx]]
             [ataru.hakija.application-validators :as validator]
             [ataru.cljs-util :as util]
             [ataru.hakija.hakija-ajax :as ajax]
@@ -10,9 +10,10 @@
                                               extract-wrapper-sections]]
             [taoensso.timbre :refer-macros [spy debug]]))
 
-(defn initialize-db [_ _]
-  {:form nil
-   :application {:answers {}}})
+(defn initialize-db [cofx _]
+  {:db {:form         nil
+        :application  {:answers {}}
+        :query-params (:query-params cofx)}})
 
 (reg-event-fx
   :application/get-latest-form-by-key
@@ -100,8 +101,9 @@
   :application/handle-form
   handle-form)
 
-(reg-event-db
+(reg-event-fx
   :application/initialize-db
+  [(inject-cofx :query-params)]
   initialize-db)
 
 (defn set-application-field [db [_ key values]]

--- a/src/cljs/ataru/hakija/banner.cljs
+++ b/src/cljs/ataru/hakija/banner.cljs
@@ -53,7 +53,8 @@
              :else nil))))
 
 (defn send-button-or-placeholder [valid-status submit-status]
-  (let [lang (subscribe [:application/form-language])]
+  (let [lang   (subscribe [:application/form-language])
+        secret (subscribe [:state-query [:application :secret]])]
     (fn [valid-status submit-status]
       (match submit-status
              :submitted [:div.application__sent-placeholder.animated.fadeIn
@@ -66,9 +67,9 @@
                     {:disabled (or (not (:valid valid-status)) (contains? #{:submitting :submitted} submit-status))
                      :on-click #(dispatch [:application/submit-form])}
                     (case @lang
-                      :fi "LÄHETÄ HAKEMUS"
-                      :sv "SKICKA ANSÖKAN"
-                      :en "SEND APPLICATION")]))))
+                      :fi (if (some? @secret) "LÄHETÄ MUUTOKSET" "LÄHETÄ HAKEMUS")
+                      :sv (if (some? @secret) "SCICKA FÖRÄNDRINGAR" "SKICKA ANSÖKAN")
+                      :en (if (some? @secret) "SEND MODIFICATIONS" "SEND APPLICATION"))]))))
 
 (defn status-controls []
   (let [valid-status (subscribe [:application/valid-status])

--- a/src/cljs/ataru/hakija/core.cljs
+++ b/src/cljs/ataru/hakija/core.cljs
@@ -8,6 +8,7 @@
             [ataru.hakija.application-view :refer [form-view]]
             [ataru.hakija.application-handlers] ;; required although no explicit dependency
             [ataru.hakija.subs] ;; required although no explicit dependency
+            [ataru.hakija.hakija-fx] ;; required although no explicit dependency
             [clojure.string :as str]))
 
 (enable-console-print!)

--- a/src/cljs/ataru/hakija/hakija_fx.cljs
+++ b/src/cljs/ataru/hakija/hakija_fx.cljs
@@ -8,9 +8,9 @@
 
 (re-frame/reg-cofx
   :query-params
-  (fn [{:keys [db]} _]
+  (fn [cofx _]
     (let [query-params (-> (.. js/window -location -href)
                            (url/url)
                            (:query)
                            (->kebab-case-kw))]
-      (assoc db :query-params query-params))))
+      (assoc cofx :query-params query-params))))

--- a/src/cljs/ataru/hakija/hakija_fx.cljs
+++ b/src/cljs/ataru/hakija/hakija_fx.cljs
@@ -1,0 +1,16 @@
+(ns ataru.hakija.hakija-fx
+  (:require [cemerick.url :as url]
+            [camel-snake-kebab.core :refer [->kebab-case-keyword]]
+            [camel-snake-kebab.extras :refer [transform-keys]]
+            [re-frame.core :as re-frame]))
+
+(def ^:private ->kebab-case-kw (partial transform-keys ->kebab-case-keyword))
+
+(re-frame/reg-cofx
+  :query-params
+  (fn [{:keys [db]} _]
+    (let [query-params (-> (.. js/window -location -href)
+                           (url/url)
+                           (:query)
+                           (->kebab-case-kw))]
+      (assoc db :query-params query-params))))


### PR DESCRIPTION
Edit previously submitted application by providing a `?modify=secret` query parameter for the usual `/hakemus/:form-id` call.

Does not yet send emails. Also the `:form-id` part will be removed in future.
