### PR TITLE
Indicate form used by tarjonta

### DIFF
--- a/config/defaults.edn
+++ b/config/defaults.edn
@@ -6,7 +6,8 @@
        :port-number 5432
        :schema "public"}
  :email {:email_service_url "https://itest-virkailija.oph.ware.fi"}
- :tarjonta-service {:hakukohde-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/hakukohde/"}
+ :tarjonta-service {:hakukohde-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/hakukohde/"
+                    :forms-in-use-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/haku/ataru/all"}
  :public-config {:applicant {:service_url "http://localhost:8351"}}
  :background-job {:exec-interval-seconds 15}
  :log {:virkailija-base-path "."

--- a/config/dev.edn
+++ b/config/dev.edn
@@ -11,5 +11,6 @@
                   :opintopolku-logout-url  "https://itest-virkailija.oph.ware.fi/cas/logout?service="
                   :ataru-login-success-url "http://localhost:8350/lomake-editori/auth/cas"
                   :cas-client-url "https://itest-virkailija.oph.ware.fi"}
- :tarjonta-service {:hakukohde-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/hakukohde/"}
+ :tarjonta-service {:hakukohde-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/hakukohde/"
+                    :forms-in-use-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/haku/ataru/all"}
  :dev {:fake-dependencies true}}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -23,6 +23,7 @@
        :password "{{ataru_cas_password}}"}
  :organization-service {:base-address "https://{{host_virkailija}}/organisaatio-service/rest/organisaatio/v2"}
  :authentication-service {:base-address "https://{{host_virkailija}}/authentication-service"}
- :tarjonta-service {:hakukohde-base-url "https://{{host_virkailija}}/tarjonta-service/rest/v1/hakukohde/"}
+ :tarjonta-service {:hakukohde-base-url "https://{{host_virkailija}}/tarjonta-service/rest/v1/hakukohde/"
+                    :forms-in-use-url "https://{{host_virkailija}}/tarjonta-service/rest/v1/haku/ataru/all"}
  :log {:virkailija-base-path "{{ataru_virkailija_log_path}}"
        :hakija-base-path "{{ataru_hakija_log_path}}"}}

--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -101,11 +101,25 @@
   vertical-align: top;
 }
 
+.editor-form__list-form-used-in-haku-count {
+  border-radius: 50%;
+  padding: 0 6px;
+  background-color: @selected-blue;
+  border: 2px solid @selected-blue;
+  color: #fff;
+  position: absolute;
+  right: 10px;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 18px;
+}
+
 .editor-form__row {
   padding: 0.5em;
   margin: 0;
   color: @blue-text-color;
   display: block;
+  position: relative;
 }
 
 .editor-form__selected-row {
@@ -114,6 +128,12 @@
   color: #fff;
   .editor-form__list-form-editor {
     color: #fff;
+  }
+
+  .editor-form__list-form-used-in-haku-count {
+    background-color: #fff;
+    color: @selected-blue;
+    border-color: #fff;
   }
 }
 

--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -172,13 +172,14 @@
 }
 
 .editor-form__used-in-haku-heading {
-  padding-left: 19px;
+  padding-left: 14px;
   font-weight: 600;
 }
 
 .editor-form__used-in-haku-list {
   list-style: none;
   margin-bottom: 0;
+  margin-left: -4px;
 }
 
 .editor-form__section_wrapper {

--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -171,11 +171,8 @@
   .solid-disc-number;
 }
 
-.editor-form__used-in-haku-count-details-wrapper {
-  padding-left: 17px;
-}
-
 .editor-form__used-in-haku-heading {
+  padding-left: 19px;
   font-weight: 600;
 }
 

--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -1,4 +1,5 @@
 @import "vars";
+@import "mixins";
 
 @editor-control-button-hover-blue: #00B5EF;
 @editor-control-button-confirm-red: #E44E4E;
@@ -102,16 +103,9 @@
 }
 
 .editor-form__list-form-used-in-haku-count {
-  border-radius: 50%;
-  padding: 0 6px;
-  background-color: @selected-blue;
-  border: 2px solid @selected-blue;
-  color: #fff;
+  .solid-disc-number;
   position: absolute;
   right: 10px;
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 18px;
 }
 
 .editor-form__row {
@@ -131,9 +125,7 @@
   }
 
   .editor-form__list-form-used-in-haku-count {
-    background-color: #fff;
-    color: @selected-blue;
-    border-color: #fff;
+    .solid-disc-number-inversed;
   }
 }
 
@@ -173,6 +165,23 @@
   border-radius: 2px;
   margin: 10px 0 5px 0;
   font-weight: 600;
+}
+
+.editor-form__used-in-haku-count {
+  .solid-disc-number;
+}
+
+.editor-form__used-in-haku-count-details-wrapper {
+  padding-left: 17px;
+}
+
+.editor-form__used-in-haku-heading {
+  font-weight: 600;
+}
+
+.editor-form__used-in-haku-list {
+  list-style: none;
+  margin-bottom: 0;
 }
 
 .editor-form__section_wrapper {

--- a/resources/less/mixins.less
+++ b/resources/less/mixins.less
@@ -22,3 +22,21 @@
 span, p {
   .text();
 }
+
+.solid-disc-number {
+  border-radius: 50%;
+  padding: 0 6px;
+  background-color: @selected-blue;
+  border: 2px solid @selected-blue;
+  color: #fff;
+  right: 10px;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 18px;
+}
+
+.solid-disc-number-inversed {
+  background-color: #fff;
+  color: @selected-blue;
+  border-color: #fff;
+}

--- a/resources/less/mixins.less
+++ b/resources/less/mixins.less
@@ -25,7 +25,7 @@ span, p {
 
 .solid-disc-number {
   border-radius: 50%;
-  padding: 0 6px;
+  padding: 0 5px;
   background-color: @selected-blue;
   border: 2px solid @selected-blue;
   color: #fff;

--- a/src/clj/ataru/tarjonta_service/tarjonta_client.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_client.clj
@@ -5,7 +5,8 @@
     [org.httpkit.client :as http]
     [taoensso.timbre :refer [warn]]))
 
-(defn get-hakukohde [hakukohde-oid]
+(defn get-hakukohde
+  [hakukohde-oid]
   (let [url      (str (get-in config [:tarjonta-service :hakukohde-base-url]) hakukohde-oid)
         response @(http/get url)
         status   (:status response)
@@ -14,6 +15,12 @@
     (if result
       result
       (warn "could not retrieve hakukohde details" url status))))
+
+(defn get-forms-in-use
+  []
+  (let [url      (get-in config [:tarjonta-service :forms-in-use-url])
+        response @(http/get url)]
+    (-> response :body (json/parse-string true) :result)))
 
 (defn get-form-key-for-hakukohde [hakukohde-oid]
   (when-let [hakukohde (get-hakukohde hakukohde-oid)]

--- a/src/clj/ataru/tarjonta_service/tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_service.clj
@@ -1,0 +1,15 @@
+(ns ataru.tarjonta-service.tarjonta-service
+  (:require
+    [ataru.tarjonta-service.tarjonta-client :as client]))
+
+(defn get-forms-in-use
+  []
+  (reduce (fn [acc1 {:keys [avain haut]}]
+            (assoc acc1 avain
+                        (reduce (fn [acc2 haku]
+                                  (assoc acc2 (:oid haku)
+                                              {:haku-oid  (:oid haku)
+                                               :haku-name (get-in haku [:nimi :kieli_fi])}))
+                                {} haut)))
+          {}
+          (client/get-forms-in-use)))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -12,6 +12,7 @@
             [ataru.forms.form-access-control :as access-controlled-form]
             [ataru.koodisto.koodisto :as koodisto]
             [ataru.applications.excel-export :as excel]
+            [ataru.tarjonta-service.tarjonta-service :as tarjonta-service]
             [cheshire.core :as json]
             [clojure.core.match :refer [match]]
             [clojure.java.io :as io]
@@ -92,6 +93,11 @@
                    :summary "Return all forms."
                    :return {:forms [ataru-schema/Form]}
                    (ok (access-controlled-form/get-forms include-deleted session organization-service)))
+
+                 (api/GET "/forms-in-use" {session :session}
+                          :summary "Return a map of form->haku currently in use in tarjonta-service"
+                          :return {s/Str {s/Str {:haku-oid s/Str :haku-name s/Str}}}
+                          (ok (tarjonta-service/get-forms-in-use)))
 
                  (api/GET "/forms/:id" []
                           :path-params [id :- Long]

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -389,6 +389,18 @@
 
 (reg-event-fx :editor/remove-form remove-form)
 
+(reg-event-fx
+  :editor/refresh-forms-in-use
+  (fn [_ _]
+    {:http {:method              :get
+            :path                "/lomake-editori/api/forms-in-use"
+            :handler-or-dispatch :editor/update-forms-in-use}}))
+
+(reg-event-db
+  :editor/update-forms-in-use
+  (fn [db [_ result]]
+    (assoc-in db [:editor :forms-in-use] result)))
+
 (reg-event-db
   :editor/change-form-name
   (fn [db [_ new-form-name]]

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -174,12 +174,14 @@
   (let [forms-in-use (subscribe [:state-query [:editor :forms-in-use]])]
     (fn [form]
       (when-let [form-used-in-hakus ((keyword (:key form)) @forms-in-use)]
-        [:div.editor-form__forms-in-use-warning
-         [:div.editor-form__used-in-haku-count (str (count (keys form-used-in-hakus)))]
-         [:div.editor-form__used-in-haku-heading "Lomake on käytössä!"]
-         [:ul.editor-form__used-in-haku-list
-          (for [haku (vals form-used-in-hakus)]
-            [:li {:key (str "form-used-in-haku_" (:haku-oid haku))} [:a {:href (str "/tarjonta-service/url/goes/here/" (:haku-oid haku)) } (:haku-name haku)]])]]))))
+        [:div.editor-form__module-wrapper
+         [:div.editor-form__module-fields
+          [:span.editor-form__used-in-haku-count (str (count (keys form-used-in-hakus)))]
+          [:span.editor-form__used-in-haku-count-details-wrapper
+           [:span.editor-form__used-in-haku-heading "Lomake on käytössä!"]
+           [:ul.editor-form__used-in-haku-list
+            (for [haku (vals form-used-in-hakus)]
+              [:li {:key (str "form-used-in-haku_" (:haku-oid haku))} [:a {:href (str "/tarjonta-service/url/goes/here/" (:haku-oid haku))} (:haku-name haku)]])]]]]))))
 
 (defn editor-panel []
   (let [form         (subscribe [:editor/selected-form])]

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -18,7 +18,8 @@
    [:span.editor-form__list-form-name (:name form)]
    [:span.editor-form__list-form-time (time->str (:created-time form))]
    [:span.editor-form__list-form-editor (:created-by form)]
-   [:span.editor-form__list-form-used-in-haku-count (if (< 0 used-in-haku-count) used-in-haku-count "")]])
+   (when (< 0 used-in-haku-count)
+     [:span.editor-form__list-form-used-in-haku-count used-in-haku-count])])
 
 (defn form-list []
   (let [forms            (debounce-subscribe 333 [:state-query [:editor :forms]])

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -177,7 +177,7 @@
         [:div.editor-form__module-wrapper
          [:div.editor-form__module-fields
           [:span.editor-form__used-in-haku-count (str (count (keys form-used-in-hakus)))]
-          [:span.editor-form__used-in-haku-heading "Lomake on käytössä!"]
+          [:span.editor-form__used-in-haku-heading.animated.flash "Lomake on käytössä!"]
           [:ul.editor-form__used-in-haku-list
            (for [haku (vals form-used-in-hakus)]
              [:li {:key (str "form-used-in-haku_" (:haku-oid haku))}

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -10,28 +10,31 @@
             [ataru.virkailija.routes :as routes]
             [taoensso.timbre :refer-macros [spy debug]]))
 
-(defn form-row [form selected?]
+(defn form-row [form selected? used-in-haku-count]
   [:a.editor-form__row
    {:href  (str "/lomake-editori/editor/" (:key form))
     :class (when selected? "editor-form__selected-row")
     :on-click routes/anchor-click-handler}
    [:span.editor-form__list-form-name (:name form)]
    [:span.editor-form__list-form-time (time->str (:created-time form))]
-   [:span.editor-form__list-form-editor (:created-by form)]])
+   [:span.editor-form__list-form-editor (:created-by form)]
+   [:span.editor-form__list-form-used-in-haku-count (if (< 0 used-in-haku-count) used-in-haku-count "")]])
 
 (defn form-list []
   (let [forms            (debounce-subscribe 333 [:state-query [:editor :forms]])
-        selected-form-key (subscribe [:state-query [:editor :selected-form-key]])]
+        selected-form-key (subscribe [:state-query [:editor :selected-form-key]])
+        forms-in-use      (subscribe [:state-query [:editor :forms-in-use]])]
     (fn []
       (into (if @selected-form-key
               [:div.editor-form__list]
               [:div.editor-form__list.editor-form__list_expanded])
             (for [[key form] @forms
-                  :let [selected? (= key @selected-form-key)]]
+                  :let [selected? (= key @selected-form-key)
+                        used-in-haku-count (count (get forms-in-use @selected-form-key))]]
               ^{:key key}
               (if selected?
-                [wrap-scroll-to [form-row form selected?]]
-                [form-row form selected?]))))))
+                [wrap-scroll-to [form-row form selected? used-in-haku-count]]
+                [form-row form selected? used-in-haku-count]))))))
 
 (defn- add-form []
   [:a.editor-form__control-button.editor-form__control-button--enabled

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -177,11 +177,10 @@
         [:div.editor-form__module-wrapper
          [:div.editor-form__module-fields
           [:span.editor-form__used-in-haku-count (str (count (keys form-used-in-hakus)))]
-          [:span.editor-form__used-in-haku-count-details-wrapper
-           [:span.editor-form__used-in-haku-heading "Lomake on käytössä!"]
-           [:ul.editor-form__used-in-haku-list
-            (for [haku (vals form-used-in-hakus)]
-              [:li {:key (str "form-used-in-haku_" (:haku-oid haku))} [:a {:href (str "/tarjonta-service/url/goes/here/" (:haku-oid haku))} (:haku-name haku)]])]]]]))))
+          [:span.editor-form__used-in-haku-heading "Lomake on käytössä!"]
+          [:ul.editor-form__used-in-haku-list
+           (for [haku (vals form-used-in-hakus)]
+             [:li {:key (str "form-used-in-haku_" (:haku-oid haku))} [:a {:href (str "/tarjonta-service/url/goes/here/" (:haku-oid haku))} (:haku-name haku)]])]]]))))
 
 (defn editor-panel []
   (let [form         (subscribe [:editor/selected-form])]

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -180,7 +180,9 @@
           [:span.editor-form__used-in-haku-heading "Lomake on käytössä!"]
           [:ul.editor-form__used-in-haku-list
            (for [haku (vals form-used-in-hakus)]
-             [:li {:key (str "form-used-in-haku_" (:haku-oid haku))} [:a {:href (str "/tarjonta-service/url/goes/here/" (:haku-oid haku))} (:haku-name haku)]])]]]))))
+             [:li {:key (str "form-used-in-haku_" (:haku-oid haku))}
+              [:a {:href   (str "/tarjonta-app/index.html#/haku/" (:haku-oid haku))
+                   :target "_blank"} (:haku-name haku)]])]]]))))
 
 (defn editor-panel []
   (let [form         (subscribe [:editor/selected-form])]

--- a/src/cljs/ataru/virkailija/routes.cljs
+++ b/src/cljs/ataru/virkailija/routes.cljs
@@ -30,11 +30,13 @@
   (defroute "/lomake-editori/editor" []
     (dispatch [:set-active-panel :editor])
     (dispatch [:editor/select-form nil])
-    (dispatch [:editor/refresh-forms]))
+    (dispatch [:editor/refresh-forms])
+    (dispatch [:editor/refresh-forms-in-use]))
 
   (defroute #"^/lomake-editori/editor/(.*)" [key]
     (dispatch [:set-active-panel :editor])
     (dispatch [:editor/refresh-forms])
+    (dispatch [:editor/refresh-forms-in-use])
     (dispatch-after-state
      :predicate
      (fn [db]


### PR DESCRIPTION
Shows when a form is currently linked to from tarjonta-app. Currently a bit hard to test, as the test environments are not fully up to date w/tarjonta. This will hopefully change soon.

The open periods for haku/hakukohde are not taken into account in this version of the functionality.

![screen shot 2016-11-16 at 12 25 50](https://cloud.githubusercontent.com/assets/1083484/20343652/dca16252-abf7-11e6-9d1d-305cbf52596b.png)
