### PR TITLE
IE layout fixes

### DIFF
--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -324,8 +324,8 @@ section.editor-form > div > .editor-form__component-wrapper {
   display: flex;
   justify-content: flex-end;
   position: relative;
-  left: -10px;
-  width: 0;
+  left: -30px;
+  width: 20px;
 }
 
 .editor-form__multi-option-wrapper {

--- a/resources/less/general-style-settings.less
+++ b/resources/less/general-style-settings.less
@@ -23,4 +23,8 @@ input, textarea {
   font-family: 'Open Sans', sans-serif;
 }
 
+input::-ms-clear {
+  display: none;
+}
+
 .no-margin { margin: 0; }


### PR DESCRIPTION
Fixes following IE specific issues:

* Language labels were not positioned correctly.
* Disabled IE's "clear input field contents" checkbox globally.