### PR TITLE
Remove person info module from application editing

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -98,6 +98,11 @@
   max-width: 610px;
 }
 
+.application__form-field-not-edited {
+  font-style: italic;
+  margin: 0;
+}
+
 .application__form-info-text {
   font-size: 14px;
   margin-bottom: 10px;

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -123,6 +123,7 @@ select
   a.form_id AS form,
   a.created_time,
   a.content,
+  a.hakukohde,
   a.haku,
   ar.state as state,
   f.key as form_key

--- a/resources/templates/email_confirmation_template.html
+++ b/resources/templates/email_confirmation_template.html
@@ -17,6 +17,11 @@
         </td>
     </tr>
     <tr>
+        <td style="padding-left: 20px; padding-top: 10px;">
+            <a style="color: #0093C4;" href="{{application-url|safe}}">{{application-url|safe}}</a>
+        </td>
+    </tr>
+    <tr>
         <td style="padding-left: 20px; padding-top: 40px;">
             {{modify-link-text}}
         </td>
@@ -25,21 +30,6 @@
         <td style="padding-left: 20px; padding-top: 20px;">
             {{best-regards}},<br>
             Opintopolku
-        </td>
-    </tr>
-    <tr>
-        <td style="padding-left: 20px; padding-top: 20px;">
-            -
-        </td>
-    </tr>
-    <tr>
-        <td style="padding-left: 20px; padding-top: 20px;">
-            {{application-can-be-found-here}}:
-        </td>
-    </tr>
-    <tr>
-        <td style="padding-left: 20px; padding-top: 10px;">
-            <a style="color: #0093C4;" href="{{application-url|safe}}">{{application-url|safe}}</a>
         </td>
     </tr>
     <tr>

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -23,13 +23,15 @@
 (defn- find-value-from-answers [key answers]
   (:value (first (filter #(= key (:key %)) answers))))
 
-(defn unwrap-application [application]
-  (assoc (->kebab-case-kw (dissoc application :content))
-    :answers
-    (mapv (fn [answer]
-            (update answer :label (fn [label]
-                                    (label/get-language-label-in-preferred-order label))))
-          (-> application :content :answers))))
+(defn unwrap-application
+  [application]
+  (when application
+    (assoc (->kebab-case-kw (dissoc application :content))
+      :answers
+      (mapv (fn [answer]
+              (update answer :label (fn [label]
+                                      (label/get-language-label-in-preferred-order label))))
+            (-> application :content :answers)))))
 
 (defn- add-new-application-version
   "Add application and also initial metadata (event for receiving application, and initial review record)"

--- a/src/clj/ataru/cache/cache_service.clj
+++ b/src/clj/ataru/cache/cache_service.clj
@@ -76,7 +76,11 @@
     e.g. (cache-put :hakukohde objectid-of-hakukohde {...}")
   (cache-get-or-fetch [this cache key get-fn]
     "Get cached item or invoke get-fn to store & return
-    e.g. (cache-get-or-fetch :hakukohde #(hakukohde-client/get-hakukohde objectid-of-hakukohde)"))
+    e.g. (cache-get-or-fetch :hakukohde #(hakukohde-client/get-hakukohde objectid-of-hakukohde)")
+  (cache-remove [this cache key]
+    "Clears given entry in given cache")
+  (cache-clear [this cache]
+    "Clears all entries of given cache"))
 
 (defn- get-cached-map [component cache]
   "Only allow access to preconfigured maps"
@@ -111,7 +115,13 @@
         (do
           (cache-put component cache key new-value)
           new-value)
-        (warn "Could not fetch value for cache" cache key)))))
+        (warn "Could not fetch value for cache" cache key))))
+
+  (cache-remove [component cache key]
+    (.remove (get-cached-map component cache) key))
+
+  (cache-clear [component cache]
+    (.clear (get-cached-map component cache))))
 
 (defn new-cache-service
   []

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -27,6 +27,8 @@
           {hakuaika-on :on} (hakuaika/get-hakuaika-info hakukohde haku)]
       hakuaika-on)))
 
+(def not-allowed-reply {:passed? false :failures ["Not allowed to apply (probably hakuaika is not on)"]})
+
 (defn- merge-application-answers
   [old-application new-application]
   (let [answer-key-set      (fn [application] (set (map :key (:answers application))))
@@ -49,7 +51,7 @@
       validation-result
 
       (not allowed)
-      {:passed? false :failures ["Not allowed to apply (probably hakuaika is not on)"]}
+      not-allowed-reply
 
       :else
       (store-and-log final-application store-fn))))

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -84,10 +84,11 @@
 
 (defn remove-person-info-module-from-application-answers
   [application]
-  (let [form                    (form-store/fetch-by-id (:form application))
-        person-module-fields    (first (filter #(= (:module %) "person-info") (:content form)))
-        person-module-field-ids (flatten (find-person-info-module-field-ids person-module-fields))]
-    (flag-uneditable-answers application person-module-field-ids)))
+  (when application
+    (let [form                    (form-store/fetch-by-id (:form application))
+          person-module-fields    (first (filter #(= (:module %) "person-info") (:content form)))
+          person-module-field-ids (flatten (find-person-info-module-field-ids person-module-fields))]
+      (flag-uneditable-answers application person-module-field-ids))))
 
 (defn handle-application-submit [tarjonta-service application]
   (log/info "Application submitted:" application)

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -60,7 +60,7 @@
         (response/ok application))
       (do
         (info (str "Failed to get application belonging by secret, returning HTTP 404"))
-        (response/not-found)))))
+        (response/not-found {})))))
 
 (defn- handle-client-error [error-details]
   (client-error/log-client-error error-details)

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -39,7 +39,7 @@
     :answers
     (map (fn [answer]
            (if (contains? (set forbidden-field-ids) (:key answer))
-             (merge answer {:cannot-edit true})
+             (merge answer {:cannot-edit true :value nil})
              answer))
          answers)))
 

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -33,13 +33,13 @@
     (map find-person-info-module-field-ids children)
     id))
 
-(defn- remove-answers-from-application
+(defn- flag-uneditable-answers
   [{:keys [answers] :as application} forbidden-field-ids]
   (assoc application
     :answers
     (map (fn [answer]
            (if (contains? (set forbidden-field-ids) (:key answer))
-             (merge answer {:cannot-edit true :value nil})
+             (merge answer {:cannot-edit true})
              answer))
          answers)))
 
@@ -48,7 +48,7 @@
   (let [form                    (ataru.forms.form-store/fetch-by-id (:form application))
         person-module-fields    (first (filter #(= (:module %) "person-info") (:content form)))
         person-module-field-ids (flatten (find-person-info-module-field-ids person-module-fields))]
-    (remove-answers-from-application application person-module-field-ids)))
+    (flag-uneditable-answers application person-module-field-ids)))
 
 (defn- get-application [secret]
   (let [application (-> secret

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -27,33 +27,10 @@
 (defn- deleted? [{:keys [deleted]}]
   (true? deleted))
 
-(defn- find-person-info-module-field-ids
-  [{:keys [children id]}]
-  (if children
-    (map find-person-info-module-field-ids children)
-    id))
-
-(defn- flag-uneditable-answers
-  [{:keys [answers] :as application} forbidden-field-ids]
-  (assoc application
-    :answers
-    (map (fn [answer]
-           (if (contains? (set forbidden-field-ids) (:key answer))
-             (merge answer {:cannot-edit true :value nil})
-             answer))
-         answers)))
-
-(defn- remove-person-info-module-from-application-answers
-  [application]
-  (let [form                    (ataru.forms.form-store/fetch-by-id (:form application))
-        person-module-fields    (first (filter #(= (:module %) "person-info") (:content form)))
-        person-module-field-ids (flatten (find-person-info-module-field-ids person-module-fields))]
-    (flag-uneditable-answers application person-module-field-ids)))
-
 (defn- get-application [secret]
   (let [application (-> secret
                         (application-store/get-latest-application-by-secret)
-                        (remove-person-info-module-from-application-answers))]
+                        (application-service/remove-person-info-module-from-application-answers))]
     (if application
       (do
         (info (str "Getting application " (:id application) " with answers"))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -93,7 +93,7 @@
 
 (defn- organizations [session] (-> session :identity :organizations))
 
-(defn api-routes [{:keys [organization-service tarjonta-service virkailija-tarjonta-service]}]
+(defn api-routes [{:keys [organization-service tarjonta-service virkailija-tarjonta-service cache-service]}]
     (api/context "/api" []
                  :tags ["form-api"]
 
@@ -216,6 +216,21 @@
                                           session
                                           organization-service
                                           tarjonta-service)})))
+
+                 (api/context "/cache" []
+                   (api/POST "/clear/:cache" {session :session}
+                     :path-params [cache :- s/Str]
+                     :summary "Clear an entire cache map of its entries"
+                     {:status 200
+                      :body   (do (.cache-clear cache-service (keyword cache))
+                                  {})})
+                   (api/POST "/remove/:cache/:key" {session :session}
+                     :path-params [cache :- s/Str
+                                   key :- s/Str]
+                     :summary "Remove an entry from cache map"
+                     {:status 200
+                      :body   (do (.cache-remove cache-service (keyword cache) key)
+                                  {})}))
 
                  (api/GET "/hakukohteet" {session :session}
                           :summary "List hakukohde information found for applications stored in system"

--- a/src/clj/ataru/virkailija/virkailija_system.clj
+++ b/src/clj/ataru/virkailija/virkailija_system.clj
@@ -29,7 +29,7 @@
 
      :handler (component/using
                 (virkailija-routes/new-handler)
-                [:organization-service :virkailija-tarjonta-service :tarjonta-service])
+                [:organization-service :virkailija-tarjonta-service :tarjonta-service :cache-service])
 
      :server-setup {:port      http-port
                     :repl-port repl-port}

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -132,18 +132,19 @@
 (s/defschema FormWithContentAndTarjontaMetadata
   (merge FormWithContent {:tarjonta FormTarjontaMetadata}))
 
-(s/defschema Answer {:key                    s/Str,
-                     :value                  (s/cond-pre s/Str
-                                                         s/Int
-                                                         [s/Str])
-                     :fieldType              (apply s/enum ["textField"
-                                                            "textArea"
-                                                            "dropdown"
-                                                            "multipleChoice"
-                                                            "singleChoice"])
-                     (s/optional-key :label) (s/maybe (s/cond-pre
-                                                        LocalizedString
-                                                        s/Str))})
+(s/defschema Answer {:key                          s/Str,
+                     :value                        (s/cond-pre s/Str
+                                                               s/Int
+                                                               [s/Str])
+                     :fieldType                    (apply s/enum ["textField"
+                                                                  "textArea"
+                                                                  "dropdown"
+                                                                  "multipleChoice"
+                                                                  "singleChoice"])
+                     (s/optional-key :cannot-edit) s/Bool
+                     (s/optional-key :label)       (s/maybe (s/cond-pre
+                                                              LocalizedString
+                                                              s/Str))})
 
 ;; Header-level info about application, doesn't contain the actual answers
 (s/defschema ApplicationInfo

--- a/src/cljc/ataru/translations/application_view.cljc
+++ b/src/cljc/ataru/translations/application_view.cljc
@@ -18,4 +18,7 @@
                                    :en "Remove row"}
    :add-more                      {:fi "Lisää..."
                                    :sv "Lägg till..."
-                                   :en "Add more..."}})
+                                   :en "Add more..."}
+   :cannot-edit-personal-info     {:fi "Jos haluat muuttaa henkilötietojasi, ota yhteyttä hakemaasi oppilaitokseen."
+                                   :en "To update your personal information, please contact the institution you're applying to."
+                                   :sv "Om du vill ändra dina kontaktuppgifter, ta då kontakt med den läroanstalt som du har sökt till."}})

--- a/src/cljc/ataru/translations/application_view.cljc
+++ b/src/cljc/ataru/translations/application_view.cljc
@@ -21,4 +21,7 @@
                                    :en "Add more..."}
    :cannot-edit-personal-info     {:fi "Jos haluat muuttaa henkilötietojasi, ota yhteyttä hakemaasi oppilaitokseen."
                                    :en "To update your personal information, please contact the institution you're applying to."
-                                   :sv "Om du vill ändra dina kontaktuppgifter, ta då kontakt med den läroanstalt som du har sökt till."}})
+                                   :sv "Om du vill ändra dina kontaktuppgifter, ta då kontakt med den läroanstalt som du har sökt till."}
+   :not-edited                    {:fi "(ei muokattu)"
+                                   :en "(unchanged)"
+                                   :sv "(inte redigerat)"}})

--- a/src/cljc/ataru/translations/email_confirmation.cljc
+++ b/src/cljc/ataru/translations/email_confirmation.cljc
@@ -13,9 +13,9 @@
    :application-edited-text       {:fi "Hakemuksesi on päivitetty."
                                    :en "Your application has been updated."
                                    :sv "Din ansökan har uppdaterats."}
-   :modify-link-text              {:fi "Allaolevan linkin kautta voit katsella ja muokata hakemustasi."
-                                   :en "You can view and modify your application using the link below."
-                                   :sv "Du kan se och redigera din ansökan via länken nedan."}
+   :modify-link-text              {:fi "Ylläolevan linkin kautta voit katsella ja muokata hakemustasi."
+                                   :en "You can view and modify your application using the link above."
+                                   :sv "Du kan se och redigera din ansökan via länken ovan."}
    :best-regards                  {:fi "terveisin"
                                    :sv "Med vänliga hälsningar"
                                    :en "Best Regards"}

--- a/src/cljs/ataru/application_common/application_readonly.cljs
+++ b/src/cljs/ataru/application_common/application_readonly.cljs
@@ -22,11 +22,14 @@
    [:label.application__form-field-label
     (str (-> field-descriptor :label lang) (required-hint field-descriptor))]
    [:div
-    (or
-      (let [values (:value ((answer-key field-descriptor) (:answers application)))]
-        (when (or (seq? values) (vector? values))
-          (into [:ul.application__form-field-list] (for [value values] [:li value]))))
-      (textual-field-value field-descriptor application :lang lang))]])
+    (let [answer       ((answer-key field-descriptor) (:answers application))
+          values       (:value answer)
+          multi-value? (or (seq? values) (vector? values))
+          cannot-edit? (:cannot-edit answer)]
+      (cond
+        cannot-edit? "(ei muokattu)"
+        multi-value? (into [:ul.application__form-field-list] (for [value values] [:li value]))
+        :else (textual-field-value field-descriptor application :lang lang)))]])
 
 (declare field)
 

--- a/src/cljs/ataru/application_common/application_readonly.cljs
+++ b/src/cljs/ataru/application_common/application_readonly.cljs
@@ -10,7 +10,10 @@
             [re-frame.core :refer [subscribe]]
             [ataru.util :as util]
             [ataru.cljs-util :refer [console-log]]
+            [ataru.translations.application-view :refer [application-view-translations]]
+            [ataru.translations.translation-util :refer [get-translations]]
             [cljs.core.match :refer-macros [match]]
+
             [ataru.application-common.application-field-common :refer [answer-key
                                                                        required-hint
                                                                        textual-field-value
@@ -27,7 +30,7 @@
           multi-value? (or (seq? values) (vector? values))
           cannot-edit? (:cannot-edit answer)]
       (cond
-        cannot-edit? "(ei muokattu)"
+        cannot-edit? [:p.application__form-field-not-edited (:not-edited (get-translations lang application-view-translations))]
         multi-value? (into [:ul.application__form-field-list] (for [value values] [:li value]))
         :else (textual-field-value field-descriptor application :lang lang)))]])
 

--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -49,9 +49,15 @@
         hidden-followup-ids (clojure.set/intersection followup-field-ids hidden-field-ids)]
     (remove-keys #(contains? hidden-followup-ids %) answers)))
 
+(defn- remove-uneditable-answers
+  [answers]
+  (remove-vals :cannot-edit answers))
+
 (defn- create-answers-to-submit [answers form ui]
   (let [flat-form-map (form->flat-form-map form)]
-    (for [[ans-key {:keys [value values]}] (remove-invisible-followup-values answers flat-form-map ui)
+    (for [[ans-key {:keys [value values]}] (-> answers
+                                               (remove-uneditable-answers)
+                                               (remove-invisible-followup-values flat-form-map ui))
           :let [field-map  (get flat-form-map (name ans-key))
                 field-type (:fieldType field-map)
                 label      (:label field-map)]

--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -63,13 +63,13 @@
                   ; permit empty dropdown values, because server side validation expects to match form fields to answers
                   (and (empty? value) (= "dropdown" field-type))
                   (and (not-empty value) (not (:exclude-from-answers field-map))))]
-      {:key         (name ans-key)
-       :cannot-edit cannot-edit?
-                    :value (or
-                             value
-                             (map (fn [v] (or (:value v) "")) values))
-                    :fieldType field-type
-                    :label label})))
+      (cond-> {:key       (name ans-key)
+               :value     (or
+                            value
+                            (map (fn [v] (or (:value v) "")) values))
+               :fieldType field-type
+               :label     label}
+              cannot-edit? (assoc :cannot-edit true)))))
 
 (defn create-application-to-submit [application form lang]
   (let [secret (:secret application)]

--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -51,15 +51,13 @@
 
 (defn- create-answers-to-submit [answers form ui]
   (let [flat-form-map (form->flat-form-map form)]
-    (for [[ans-key {:keys [value values]}] (-> answers
-                                               (remove-invisible-followup-values flat-form-map ui))
+    (for [[ans-key {:keys [value values cannot-edit]}] (remove-invisible-followup-values answers flat-form-map ui)
           :let [field-map    (get flat-form-map (name ans-key))
                 field-type   (:fieldType field-map)
-                cannot-edit? (boolean (:cannot-edit field-map))
                 label        (:label field-map)]
           :when (or
                   values
-                  cannot-edit?
+                  cannot-edit
                   ; permit empty dropdown values, because server side validation expects to match form fields to answers
                   (and (empty? value) (= "dropdown" field-type))
                   (and (not-empty value) (not (:exclude-from-answers field-map))))]
@@ -69,7 +67,7 @@
                             (map (fn [v] (or (:value v) "")) values))
                :fieldType field-type
                :label     label}
-              cannot-edit? (assoc :cannot-edit true)))))
+              cannot-edit (assoc :cannot-edit true)))))
 
 (defn create-application-to-submit [application form lang]
   (let [secret (:secret application)]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -449,7 +449,7 @@
                          (dispatch [:application/add-adjacent-fields field-descriptor]))}
             [:i.zmdi.zmdi-plus-square] (str " " (:add-row translations))])]))))
 
-(defn- editing-forbidden-field
+(defn- editing-forbidden-module
   [field-descriptor]
   (let [lang         (subscribe [:application/form-language])
         default-lang (subscribe [:application/default-language])]
@@ -474,7 +474,7 @@
     (fn [field-descriptor & args]
       (let [disabled? (get-in @ui [(keyword (:id field-descriptor)) :disabled?] false)]
         (if (and @editing? (= (:module field-descriptor) "person-info"))
-          [editing-forbidden-field field-descriptor]
+          [editing-forbidden-module field-descriptor]
           (cond-> (match field-descriptor
                          {:fieldClass "wrapperElement"
                           :fieldType  "fieldset"

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -476,7 +476,7 @@
                    (get-in @ui [(keyword id) :visible?] true))]
     (fn [field-descriptor & args]
       (let [disabled? (get-in @ui [(keyword (:id field-descriptor)) :disabled?] false)]
-        (if (and editing? (= (:module field-descriptor) "person-info"))
+        (if (and @editing? (= (:module field-descriptor) "person-info"))
           [editing-forbidden-field field-descriptor]
           (cond-> (match field-descriptor
                          {:fieldClass "wrapperElement"

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -225,6 +225,7 @@
     (fn [field-descriptor children]
       (let [label (non-blank-val (get-in field-descriptor [:label @lang])
                                  (get-in field-descriptor [:label @default-lang]))]
+
         [:div.application__wrapper-element.application__wrapper-element--border
          [:div.application__wrapper-heading
           [:h2 label]
@@ -447,32 +448,55 @@
                          (dispatch [:application/add-adjacent-fields field-descriptor]))}
             [:i.zmdi.zmdi-plus-square] (str " " (:add-row translations))])]))))
 
+(defn- editing-forbidden-field
+  [field-descriptor]
+  (let [lang         (subscribe [:application/form-language])
+        default-lang (subscribe [:application/default-language])
+        content-langs {:fi "Henkilötietoja ei pydee edaa!"
+                       :en "onay ersonalpay infoyay editingyay!"
+                       :sv "Samma på svenska!"}]
+    (fn [field-descriptor]
+      (let [label (non-blank-val (get-in field-descriptor [:label @lang])
+                                 (get-in field-descriptor [:label @default-lang]))
+            content (non-blank-val ((keyword @lang) content-langs)
+                                   ((keyword @default-lang) content-langs))]
+        [:div.application__wrapper-element.application__wrapper-element--border
+         [:div.application__wrapper-heading
+          [:h2 label]
+          [scroll-to-anchor field-descriptor]]
+          [:div.application__wrapper-contents
+           [:div.application__form-info-element.application__form-field
+            [:span content]]]]))))
+
 (defn render-field
   [field-descriptor & args]
   (let [ui       (subscribe [:state-query [:application :ui]])
+        editing? (subscribe [:state-query [:application :editing?]])
         visible? (fn [id]
                    (get-in @ui [(keyword id) :visible?] true))]
     (fn [field-descriptor & args]
       (let [disabled? (get-in @ui [(keyword (:id field-descriptor)) :disabled?] false)]
-        (cond-> (match field-descriptor
-                       {:fieldClass "wrapperElement"
-                        :fieldType  "fieldset"
-                        :children   children} [wrapper-field field-descriptor children]
-                       {:fieldClass "wrapperElement"
-                        :fieldType  "rowcontainer"
-                        :children   children} [row-wrapper children]
-                       {:fieldClass "formField"
-                        :id         (_ :guard (complement visible?))} [:div]
-                       {:fieldClass "formField" :fieldType "textField" :params {:repeatable true}} [repeatable-text-field field-descriptor]
-                       {:fieldClass "formField" :fieldType "textField"} [text-field field-descriptor :disabled disabled?]
-                       {:fieldClass "formField" :fieldType "textArea"} [text-area field-descriptor]
-                       {:fieldClass "formField" :fieldType "dropdown"} [dropdown field-descriptor]
-                       {:fieldClass "formField" :fieldType "multipleChoice"} [multiple-choice field-descriptor]
-                       {:fieldClass "formField" :fieldType "singleChoice"} [single-choice-button field-descriptor]
-                       {:fieldClass "infoElement"} [info-element field-descriptor]
-                       {:fieldClass "wrapperElement" :fieldType "adjacentfieldset"} [adjacent-text-fields field-descriptor])
-                (and (empty? (:children field-descriptor))
-                     (visible? (:id field-descriptor))) (into args))))))
+        (if (and editing? (= (:module field-descriptor) "person-info"))
+          [editing-forbidden-field field-descriptor]
+          (cond-> (match field-descriptor
+                         {:fieldClass "wrapperElement"
+                          :fieldType  "fieldset"
+                          :children   children} [wrapper-field field-descriptor children]
+                         {:fieldClass "wrapperElement"
+                          :fieldType  "rowcontainer"
+                          :children   children} [row-wrapper children]
+                         {:fieldClass "formField"
+                          :id         (_ :guard (complement visible?))} [:div]
+                         {:fieldClass "formField" :fieldType "textField" :params {:repeatable true}} [repeatable-text-field field-descriptor]
+                         {:fieldClass "formField" :fieldType "textField"} [text-field field-descriptor :disabled disabled?]
+                         {:fieldClass "formField" :fieldType "textArea"} [text-area field-descriptor]
+                         {:fieldClass "formField" :fieldType "dropdown"} [dropdown field-descriptor]
+                         {:fieldClass "formField" :fieldType "multipleChoice"} [multiple-choice field-descriptor]
+                         {:fieldClass "formField" :fieldType "singleChoice"} [single-choice-button field-descriptor]
+                         {:fieldClass "infoElement"} [info-element field-descriptor]
+                         {:fieldClass "wrapperElement" :fieldType "adjacentfieldset"} [adjacent-text-fields field-descriptor])
+                  (and (empty? (:children field-descriptor))
+                       (visible? (:id field-descriptor))) (into args)))))))
 
 (defn editable-fields [form-data]
   (when form-data

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -33,7 +33,8 @@
 
 (defn- field-value-valid?
   [field-data value]
-  (if (not-empty (:validators field-data))
+  (if (and (not (:cannot-edit field-data))
+           (not-empty (:validators field-data)))
     (every? true? (map #(validator/validate % value)
                     (:validators field-data)))
     true))

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -452,15 +452,11 @@
 (defn- editing-forbidden-field
   [field-descriptor]
   (let [lang         (subscribe [:application/form-language])
-        default-lang (subscribe [:application/default-language])
-        content-langs {:fi "Henkilötietoja ei pydee edaa!"
-                       :en "onay ersonalpay infoyay editingyay!"
-                       :sv "Samma på svenska!"}]
+        default-lang (subscribe [:application/default-language])]
     (fn [field-descriptor]
-      (let [label (non-blank-val (get-in field-descriptor [:label @lang])
-                                 (get-in field-descriptor [:label @default-lang]))
-            content (non-blank-val ((keyword @lang) content-langs)
-                                   ((keyword @default-lang) content-langs))]
+      (let [label   (non-blank-val (get-in field-descriptor [:label @lang])
+                                   (get-in field-descriptor [:label @default-lang]))
+            content (:cannot-edit-personal-info (get-translations @lang application-view-translations))]
         [:div.application__wrapper-element.application__wrapper-element--border
          [:div.application__wrapper-heading
           [:h2 label]

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -150,28 +150,30 @@
   (-> db
       (update-in [:application :answers]
         (fn [answers]
-          (reduce (fn [answers {:keys [key value] :as answer}]
+          (reduce (fn [answers {:keys [key value cannot-edit] :as answer}]
                     (let [answer-key (keyword key)
                           value      (cond-> value
                                        (vector? value)
                                        (first))]
                       (if (contains? answers answer-key)
-                        (match answer
-                          {:fieldType "multipleChoice"}
-                          (update answers answer-key (partial merge-multiple-choice-option-values value))
+                        (update
+                          (match answer
+                                 {:fieldType "multipleChoice"}
+                                 (update answers answer-key (partial merge-multiple-choice-option-values value))
 
-                          {:fieldType "dropdown"}
-                          (update answers answer-key merge {:valid true :value value})
+                                 {:fieldType "dropdown"}
+                                 (update answers answer-key merge {:valid true :value value})
 
-                          {:fieldType "textField" :value (_ :guard vector?)}
-                          (update answers answer-key merge
-                            {:valid true
-                             :values (mapv (fn [value]
-                                             {:valid true :value value})
-                                       (:value answer))})
+                                 {:fieldType "textField" :value (_ :guard vector?)}
+                                 (update answers answer-key merge
+                                         {:valid  true
+                                          :values (mapv (fn [value]
+                                                          {:valid true :value value})
+                                                        (:value answer))})
 
-                          :else
-                          (update answers answer-key merge {:valid true :value value}))
+                                 :else
+                                 (update answers answer-key merge {:valid true :value value}))
+                          answer-key merge {:cannot-edit cannot-edit})
                         answers)))
                   answers
                   submitted-answers)))

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -22,6 +22,7 @@
                                                  hakukohde
                                                  hakukohde-name]}]]
   {:db       (-> db
+                 (assoc-in [:application :editing?] true)
                  (assoc-in [:application :secret] secret)
                  (assoc-in [:form :selected-language] (keyword lang))
                  (assoc-in [:form :hakukohde-name] hakukohde-name))

--- a/test/cljs/unit/ataru/hakija/application_test.cljs
+++ b/test/cljs/unit/ataru/hakija/application_test.cljs
@@ -160,14 +160,17 @@
                            :answers '({:key "G__14",
                                        :value "Jorma",
                                        :fieldType "textField",
+                                       :cannot-edit false,
                                        :label {:fi "kenttä2", :sv ""}}
                                       {:key "G__2",
                                        :value "16",
                                        :fieldType "textField",
+                                       :cannot-edit false,
                                        :label {:fi "kenttä1", :sv ""}}
                                       {:key "G__25",
                                        :value "Joroinen",
                                        :fieldType "textField",
+                                       :cannot-edit false,
                                        :label {:fi "ulkokenttä", :sv ""}})})
 
 (deftest application-to-submit-is-correct

--- a/test/cljs/unit/ataru/hakija/application_test.cljs
+++ b/test/cljs/unit/ataru/hakija/application_test.cljs
@@ -160,17 +160,14 @@
                            :answers '({:key "G__14",
                                        :value "Jorma",
                                        :fieldType "textField",
-                                       :cannot-edit false,
                                        :label {:fi "kenttä2", :sv ""}}
                                       {:key "G__2",
                                        :value "16",
                                        :fieldType "textField",
-                                       :cannot-edit false,
                                        :label {:fi "kenttä1", :sv ""}}
                                       {:key "G__25",
                                        :value "Joroinen",
                                        :fieldType "textField",
-                                       :cannot-edit false,
                                        :label {:fi "ulkokenttä", :sv ""}})})
 
 (deftest application-to-submit-is-correct


### PR DESCRIPTION
Remove person info module from application editing.

What has been done:

* Dynamically flag person info module questions as "uneditable" when loading application to edit, remove those answers' values
* Don't show those questions in the application edit view
* When submitting the edited application, flag uneditable answers and instead populate them from the previous submitted application.