### PR TITLE
Use Markdown + HtmlSanitizer to format form info fields

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [metosin/schema-tools "0.9.0"]
                  [medley "0.8.4"]
+                 [markdown-clj "0.9.97"]
 
                  ;clojure
                  [compojure "1.5.1"]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -2,10 +2,11 @@
   (:require [clojure.string :refer [trim]]
             [re-frame.core :refer [subscribe dispatch dispatch-sync]]
             [reagent.ratom :refer-macros [reaction]]
-            [cemerick.url :as url]
+            [markdown.core :refer [md->html]]
             [cljs.core.match :refer-macros [match]]
             [ataru.translations.translation-util :refer [get-translations]]
             [ataru.translations.application-view :refer [application-view-translations]]
+            [ataru.cljs-util :as cljs-util :refer [console-log]]
             [ataru.application-common.application-field-common
              :refer
              [answer-key
@@ -16,8 +17,10 @@
             [ataru.util :as util]
             [reagent.core :as r]
             [taoensso.timbre :refer-macros [spy debug]]
-            [ataru.cljs-util :as cljs-util]
-            [ataru.feature-config :as fc]))
+            [ataru.feature-config :as fc])
+  (:import (goog.html.sanitizer HtmlSanitizer)))
+
+(defonce html-sanitizer (HtmlSanitizer.))
 
 (declare render-field)
 
@@ -85,37 +88,19 @@
     (some #(= % "required") (:validators field-descriptor))
     (validator/validate "required" value)))
 
-(defn- link-detected-paragraph [text]
-  (let [words   (for [word (clojure.string/split text #"\s")
-                      :let [as-url (url/url word)]]
-                  (if (not-empty (:host as-url))
-                    [:a {:key    (str as-url)
-                         :href   (str as-url)
-                         :target "_blank"}
-                     (:host as-url)]
-                    (if (empty? word)
-                      [:br]
-                      word)))
-        reducer (fn [acc word-or-url]
-                  (if (string? word-or-url)
-                    (update acc :words str
-                      (str word-or-url " "))
-                    (->
-                      (update acc :result concat [(:words acc) word-or-url " "])
-                      (dissoc :words))))]
-    (vec
-      (cons :p.no-margin
-        (->
-          (reduce reducer {} words)
-          (as-> reduction
-              [(:result reduction) (:words reduction)]))))))
-
+(defn- markdown-paragraph
+  [md-text]
+  (let [sanitized-html (->> md-text
+                            (md->html)
+                            (.sanitize html-sanitizer)
+                            (.getTypedStringValue))]
+    [:div.application__form-info-text {:dangerouslySetInnerHTML {:__html sanitized-html}}]))
 
 (defn info-text [field-descriptor]
   (let [language (subscribe [:application/form-language])]
     (fn [field-descriptor]
       (when-let [info (@language (some-> field-descriptor :params :info-text :label))]
-        [:div.application__form-info-text [link-detected-paragraph info]]))))
+        [markdown-paragraph info]))))
 
 (defn text-field [field-descriptor & {:keys [div-kwd disabled] :or {div-kwd :div.application__form-field disabled false}}]
   (let [id           (keyword (:id field-descriptor))
@@ -458,7 +443,7 @@
     [:div.application__form-info-element.application__form-field
      (when (not-empty header)
        [:label.application__form-field-label [:span header]])
-     [link-detected-paragraph text]]))
+     [markdown-paragraph text]]))
 
 (defn- adjacent-field-input-change [field-descriptor row-idx event]
   (let [value  (some-> event .-target .-value)
@@ -491,7 +476,7 @@
         [:div.application__form-field
          [label field-descriptor]
          (when-let [info (@language (some-> field-descriptor :params :info-text :label))]
-           [:div.application__form-info-text [link-detected-paragraph info]])
+           [:div.application__form-info-text [markdown-paragraph info]])
          [:div
           (->> (range row-amount)
                (map (fn adjacent-text-fields-row [row-idx]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -429,7 +429,7 @@
       [:div.application__form-field
        [label field-descriptor]
        (when-not (clojure.string/blank? @text)
-         [link-detected-paragraph @text])
+         [markdown-paragraph @text])
        (->> (range @attachment-count)
             (map (fn [attachment-idx]
                    ^{:key (str "attachment-" id "-" attachment-idx)}

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -20,7 +20,8 @@
             [ataru.feature-config :as fc])
   (:import (goog.html.sanitizer HtmlSanitizer)))
 
-(defonce html-sanitizer (HtmlSanitizer.))
+(defonce builder (new HtmlSanitizer.Builder))
+(defonce html-sanitizer (.build builder))
 
 (declare render-field)
 


### PR DESCRIPTION
Fixes issues with informational elements on form: react warnings + line breaks.

Now uses Markdown for _all the things_, also HtmlSanitizer to remove dangerous HTML.

Some instructions for usage should probably be provided.