### PR TITLE
Fix browser tests emitting error log messages

### DIFF
--- a/spec/ataru/fixtures/db/browser_test_db.clj
+++ b/spec/ataru/fixtures/db/browser_test_db.clj
@@ -58,7 +58,10 @@
                            :value "Kuikeloinen"}
                           {:fieldType "textField",
                            :key "ssn",
-                           :value "020202A0202"}]})
+                           :value "020202A0202"}
+                          {:fieldType "textField",
+                           :key "email",
+                           :value "seija.kuikeloinen@gmail.com"}]})
 
 (def application2 {:form 1,
                    :lang "fi",
@@ -75,7 +78,10 @@
                            :value "Vatanen"}
                           {:fieldType "textField",
                            :key "ssn",
-                           :value "141196-933S"}]})
+                           :value "141196-933S"}
+                          {:fieldType "textField",
+                           :key "email",
+                           :value "ari.vatanen@iki.fi"}]})
 
 (defn init-db-fixture []
   (form-store/create-form-or-increment-version! form1)


### PR DESCRIPTION
Without this change:

~~~
17-03-10 11:35:50 l991.core.reaktor.fi ERROR [ataru.log.audit-log:111] - Failed to create an audit log entry
                                clojure.core/partial/fn                                    core.clj: 2514
                    ataru.browser-tests/eval36180/fn/fn                spec/ataru/browser_tests.clj:   48
     ataru.browser-tests/run-specs-in-virkailija-system                spec/ataru/browser_tests.clj:   22
      ataru.fixtures.db.browser-test-db/init-db-fixture  spec/ataru/fixtures/db/browser_test_db.clj:   83
                      clojure.java.jdbc/db-transaction*                                    jdbc.clj:  598
                      clojure.java.jdbc/db-transaction*                                    jdbc.clj:  629
                      clojure.java.jdbc/db-transaction*                                    jdbc.clj:  613
   ataru.fixtures.db.browser-test-db/init-db-fixture/fn  spec/ataru/fixtures/db/browser_test_db.clj:   85
   ataru.applications.application-store/add-application                       application_store.clj:   69
                      clojure.java.jdbc/db-transaction*                                    jdbc.clj:  598
                      clojure.java.jdbc/db-transaction*                                    jdbc.clj:  629
                      clojure.java.jdbc/db-transaction*                                    jdbc.clj:  613
ataru.applications.application-store/add-application/fn                       application_store.clj:   73
                                ataru.log.audit-log/log                               audit_log.clj:  109
                             ataru.log.audit-log/do-log                               audit_log.clj:   78
java.lang.AssertionError: Assert failed: (not-blank? id)
~~~

happens twice when running UI tests.