### PR TITLE
Fix person field excel when editing english application

### DIFF
--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -65,11 +65,11 @@
                             application)
         validation-result (validator/valid-application? final-application form)]
     (cond
-      (not (:passed? validation-result))
-      validation-result
-
       (not allowed)
       not-allowed-reply
+
+      (not (:passed? validation-result))
+      validation-result
 
       :else
       (store-and-log final-application store-fn))))

--- a/src/clj/ataru/util/language_label.clj
+++ b/src/clj/ataru/util/language_label.clj
@@ -2,16 +2,18 @@
 
 (defn lang-label [lang label-map]
   (let [label-string (lang label-map)]
-    (if (or
-         (not label-string)
-         (empty? (clojure.string/trim label-string)))
+    (if (clojure.string/blank? label-string)
       nil
       label-string)))
 
 (defn get-language-label-in-preferred-order
   "Returns a label of any language, preferring fi, then sv and then en"
   [label]
-  (or
-   (lang-label :fi label)
-   (lang-label :sv label)
-   (lang-label :en label)))
+  (if (and (string? label)
+           (not (clojure.string/blank? label)))
+    ; some broken applications have bare string labels
+    (clojure.string/trim label)
+    (or
+      (lang-label :fi label)
+      (lang-label :sv label)
+      (lang-label :en label))))


### PR DESCRIPTION
Fixes a bug where when editing application, the labels for uneditable fields (= person info module) were not stored correctly (turns out that in the database the format in answers is `{:label "Label for field"}` instead of `{:label {:en {"Label for field"}}}`).

Now store the labels for new answers correctly and also support the alternative/broken (but supported by form schema) format. 