### PR TITLE
Show useful info about attachments in the Excel export

### DIFF
--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -210,7 +210,8 @@
       (if-let [parent-element (find-parent element fields)]
         (str (-> parent-element :label :fi) " - " header)
         header)
-
+      {:fieldType "attachment"}
+      (str "Liitepyyntö: " (-> element :label :fi))
       :else header)))
 
 (defn- extract-headers-from-applications [applications form]

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -7,6 +7,7 @@
             [ataru.application.review-states :refer [application-review-states]]
             [ataru.applications.application-store :as application-store]
             [ataru.koodisto.koodisto :as koodisto]
+            [ataru.files.file-store :as file-store]
             [ataru.util :as util]
             [clj-time.core :as t]
             [clj-time.format :as f]
@@ -123,7 +124,7 @@
                    first)]
     (get-in koodi [:label lang])))
 
-(defn- koodi-uris->human-readable-value [{:keys [content]} {:keys [lang]} key value]
+(defn- raw-values->human-readable-value [{:keys [content]} {:keys [lang]} key value]
   (let [field-descriptor (get-field-descriptor content key)
         lang             (-> lang clojure.string/lower-case keyword)]
     (if-some [koodisto-source (:koodisto-source field-descriptor)]
@@ -133,7 +134,10 @@
              (mapv koodi-uri->label)
              (interpose "\n")
              (apply str)))
-      value)))
+      (if (= (:fieldType field-descriptor) "attachment")
+        (let [[{:keys [filename size]}] (file-store/get-metadata [value])]
+          (str filename " (" (util/size-bytes->str size) ")"))
+        value))))
 
 (defn- write-application! [writer application headers application-meta-fields form]
   (doseq [meta-field application-meta-fields]
@@ -144,12 +148,12 @@
     (let [column          (:column (first (filter #(= (:label answer) (:header %)) headers)))
           value-or-values (-> (:value answer))
           value           (or
-                           (when (or (seq? value-or-values) (vector? value-or-values))
+                            (when (or (seq? value-or-values) (vector? value-or-values))
                              (->> value-or-values
-                                  (map (partial koodi-uris->human-readable-value form application (:key answer)))
+                                  (map (partial raw-values->human-readable-value form application (:key answer)))
                                   (interpose "\n")
                                   (apply str)))
-                           (koodi-uris->human-readable-value form application (:key answer) value-or-values))]
+                            (raw-values->human-readable-value form application (:key answer) value-or-values))]
       (writer 0 (+ column (count application-meta-fields)) value)))
   (let [application-review  (application-store/get-application-review (:key application))
         beef-header-count   (- (apply max (map :column headers)) (count review-headers))

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -214,7 +214,7 @@
         (str (-> parent-element :label :fi) " - " header)
         header)
       {:fieldType "attachment"}
-      (str "Liitepyyntö: " (-> element :label :fi))
+      (str "Liitepyyntö: " (label/get-language-label-in-preferred-order (:label element)))
       :else header)))
 
 (defn- extract-headers-from-applications [applications form]

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -147,12 +147,11 @@
           :when (some (comp (partial = (:label answer)) :header) headers)]
     (let [column          (:column (first (filter #(= (:label answer) (:header %)) headers)))
           value-or-values (-> (:value answer))
-          value           (or
-                            (when (or (seq? value-or-values) (vector? value-or-values))
-                             (->> value-or-values
-                                  (map (partial raw-values->human-readable-value form application (:key answer)))
-                                  (interpose "\n")
-                                  (apply str)))
+          value           (if (or (seq? value-or-values) (vector? value-or-values))
+                            (->> value-or-values
+                                 (map (partial raw-values->human-readable-value form application (:key answer)))
+                                 (interpose "\n")
+                                 (apply str))
                             (raw-values->human-readable-value form application (:key answer) value-or-values))]
       (writer 0 (+ column (count application-meta-fields)) value)))
   (let [application-review  (application-store/get-application-review (:key application))

--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -3,7 +3,8 @@
             #?(:clj  [clojure.core.match :refer [match]]
                :cljs [cljs.core.match :refer-macros [match]])
             #?(:clj  [taoensso.timbre :refer [spy debug]]
-               :cljs [taoensso.timbre :refer-macros [spy debug]]))
+               :cljs [taoensso.timbre :refer-macros [spy debug]])
+            #?(:cljs [goog.string :as gstring]))
   (:import #?(:clj [java.util UUID])))
 
 (defn map-kv [m f]
@@ -68,3 +69,16 @@
     (->> dropdown-options
         (filter (comp (partial = value) :value))
       (mapcat :followups))))
+
+(def ^:private b-limit 1024)
+(def ^:private kb-limit 102400)
+
+(defn size-bytes->str [bytes]
+  #?(:cljs (condp > bytes
+             b-limit (str bytes "B")
+             kb-limit (gstring/format "%.01fkB" (/ bytes 1024))
+             (gstring/format "%.01fMB" (/ bytes 1024000)))
+     :clj (condp > bytes
+            b-limit (str bytes " B")
+            kb-limit (format "%.2f kB" (float (/ bytes 1024)))
+            (format "%.2f MB" (float (/ bytes 1024000))))))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -9,7 +9,6 @@
             [cemerick.url :as url]
             [camel-snake-kebab.core :refer [->kebab-case-keyword]]
             [camel-snake-kebab.extras :refer [transform-keys]]
-            [goog.string :as gstring]
             [goog.string.format])
   (:import [goog.net Cookies]))
 
@@ -153,12 +152,3 @@
 
 (defn flatten-path [db & parts]
   (flatten [:editor :forms (-> db :editor :selected-form-key) :content [parts]]))
-
-(def ^:private b-limit 1024)
-(def ^:private kb-limit 102400)
-
-(defn size-bytes->str [bytes]
-  (condp > bytes
-    b-limit (str bytes "B")
-    kb-limit (gstring/format "%.01fkB" (/ bytes 1024))
-    (gstring/format "%.01fMB" (/ bytes 1024000))))

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -395,7 +395,7 @@
       [:span.application__form-upload-button-add-text "Lisää tiedosto..."]]]))
 
 (defn- filename->label [{:keys [filename size]}]
-  (str filename " (" (cljs-util/size-bytes->str size) ")"))
+  (str filename " (" (util/size-bytes->str size) ")"))
 
 (defn attachment-view-file [field-descriptor component-id attachment-idx]
   (let [id (str "attachment-" component-id "-" attachment-idx "-update")]

--- a/src/cljs/ataru/hakija/hakija_readonly.cljs
+++ b/src/cljs/ataru/hakija/hakija_readonly.cljs
@@ -9,7 +9,7 @@
   (:require [clojure.string :refer [trim]]
             [re-frame.core :refer [subscribe]]
             [ataru.util :as util]
-            [ataru.cljs-util :refer [console-log size-bytes->str]]
+            [ataru.cljs-util :refer [console-log]]
             [ataru.translations.application-view :refer [application-view-translations]]
             [ataru.translations.translation-util :refer [get-translations]]
             [cljs.core.match :refer-macros [match]]
@@ -43,7 +43,7 @@
      [:div
       (map (fn [{:keys [value]}]
              ^{:key (:key value)}
-             [:ul.application__form-field-list (str (:filename value) " (" (size-bytes->str (:size value)) ")")])
+             [:ul.application__form-field-list (str (:filename value) " (" (util/size-bytes->str (:size value)) ")")])
            values)]]))
 
 (declare field)

--- a/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
+++ b/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
@@ -9,7 +9,7 @@
   (:require [clojure.string :refer [trim]]
             [re-frame.core :refer [subscribe]]
             [ataru.util :as util]
-            [ataru.cljs-util :refer [console-log size-bytes->str]]
+            [ataru.cljs-util :refer [console-log]]
             [ataru.translations.application-view :refer [application-view-translations]]
             [ataru.translations.translation-util :refer [get-translations]]
             [cljs.core.match :refer-macros [match]]
@@ -41,7 +41,7 @@
         (str (-> field-descriptor :label lang) (required-hint field-descriptor))]
        [:div
         (map-indexed (fn attachment->link [idx {file-key :key filename :filename size :size}]
-                       (let [text          (str filename " (" (size-bytes->str size) ")")
+                       (let [text          (str filename " (" (util/size-bytes->str size) ")")
                              component-key (str "attachment-div-" idx)]
                          [:div {:key component-key}
                           [:a {:href (str "/lomake-editori/api/files/content/" file-key)


### PR DESCRIPTION
- Shows "Liitepyyntö: <question>" in the column header.
- Shows "<filename> (<size>)" for each attachment in the cell. If an answer has multiple attachments, they are separated with a newline (still inside the same cell).