### PR TITLE
Fix adding a file, removing it, and adding it again

### DIFF
--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -382,6 +382,7 @@
       {:id        id
        :type      "file"
        :multiple  "multiple"
+       :key       (str "upload-button-" component-id "-" attachment-count)
        :on-change (fn [event]
                     (.preventDefault event)
                     (let [file-list (or (some-> event .-dataTransfer .-files)


### PR DESCRIPTION
## How to reproduce

1. Add an attachment
2. Remove it
3. Add the same file again
4. → Nothing happens
5. Be sad 😢 

## Expected behaviour

The file is added again.

## Why it's broken

This doesn't work on master because the HTML5 `input` component maintains its own `FileList` state. We need to make the element is re-rendered (and the internal state discarded) whenever we change our own state of attachments. 

## Solution

I added a `key` to the element, based on its component-id and the count of attachment. This seems to fix things. I _think_ this is safe, because you can't update/replace attachments anymore, so all changes to the list of attachments inside this component means the count attachments changes. 

Please verify my logic 😨 