### PR TITLE
Inform about insufficient rights

### DIFF
--- a/resources/less/virkailija-common.less
+++ b/resources/less/virkailija-common.less
@@ -1,3 +1,5 @@
+@import "vars";
+@import "mixins";
 
 .close-details-button {
   align-items: center;
@@ -33,8 +35,8 @@
   background-color: #def2ff;
   text-align: center;
   display: block;
-  color: #2a2a2a;
-  font-weight: 600;
+  color: @text-color;
+  .semibold;
   margin-top: 8px;
   padding: 16px 64px;
 }

--- a/resources/less/virkailija-common.less
+++ b/resources/less/virkailija-common.less
@@ -23,3 +23,19 @@
 .close-details-button:hover > .close-details-button-mark {
   color: white;
 }
+
+.privilege-info-outer {
+  position: relative;
+  padding: 0 10px 0 10px;
+}
+
+.privilege-info-inner {
+  background-color: #def2ff;
+  text-align: center;
+  display: block;
+  color: #2a2a2a;
+  font-weight: 600;
+  margin-top: 8px;
+  margin-top: .5rem;
+  padding: 16px 64px;
+}

--- a/resources/less/virkailija-common.less
+++ b/resources/less/virkailija-common.less
@@ -36,6 +36,5 @@
   color: #2a2a2a;
   font-weight: 600;
   margin-top: 8px;
-  margin-top: .5rem;
   padding: 16px 64px;
 }

--- a/resources/less/virkailija-site.less
+++ b/resources/less/virkailija-site.less
@@ -2,6 +2,6 @@
 @import "vars";
 @import "mixins";
 @import "virkailija-banner";
-@import "virkailija-close-details";
+@import "virkailija-common";
 @import "editor";
 @import "virkailija-application";

--- a/src/cljs/ataru/virkailija/views.cljs
+++ b/src/cljs/ataru/virkailija/views.cljs
@@ -7,10 +7,28 @@
               [ataru.virkailija.editor.view :refer [editor]]
               [taoensso.timbre :refer-macros [spy]]))
 
+(def panel-components
+  {:editor editor :application application})
+
+(defn no-privileges []
+  [:div "Ei oikeuksia"])
+
+(defn some-right-exists-for-user? [rights orgs]
+  (boolean (some rights (->> orgs (map :rights) flatten (map keyword)))))
+
+(defn privileged-panel [panel rights]
+  (let [organizations (re-frame/subscribe [:state-query [:editor :user-info :organizations]])]
+    (fn [panel rights]
+      (if (some-right-exists-for-user? rights @organizations)
+        [(get panel-components panel)]
+        [no-privileges]))))
+
 (defmulti panels identity)
-(defmethod panels :application [] [application])
-(defmethod panels :editor [] [editor])
-(defmethod panels :default [] [:div])
+(defmethod panels :application []
+  [privileged-panel :application #{:view-applications :edit-applications}])
+(defmethod panels :editor []
+  [privileged-panel :editor #{:form-edit}])
+(defmethod panels :default [])
 
 (defn main-panel []
   (let [active-panel (re-frame/subscribe [:active-panel])]

--- a/src/cljs/ataru/virkailija/views.cljs
+++ b/src/cljs/ataru/virkailija/views.cljs
@@ -11,7 +11,7 @@
   {:editor editor :application application})
 
 (defn no-privileges []
-  [:div "Ei oikeuksia"])
+  [:div.privilege-info-outer [:div.privilege-info-inner "Ei oikeuksia"]])
 
 (defn some-right-exists-for-user? [rights orgs]
   (boolean (some rights (->> orgs (map :rights) flatten (map keyword)))))


### PR DESCRIPTION
User sees  a "Ei oikeuksia" text-box instead of the tab content when there is no direct organization containing the required privileges to do anything useful in that tab (or "panel")
