### PR TITLE
Url properties config

### DIFF
--- a/config/defaults.edn
+++ b/config/defaults.edn
@@ -1,18 +1,19 @@
-{:db {:database-name "ataru-dev"
-       :pool-name "ataru-pool"
-       :username "oph"
-       :password "oph"
-       :server-name "localhost"
-       :port-number 5432
-       :schema "public"}
- :session {:timeout 28800}
- :public-config {:applicant {:service_url "http://localhost:8351"}
-                 :virkailija {:service_url "http://localhost:8350/lomake-editori/"}
-                 :environment-name "dev"
-                 :features {:attachment false}}
+{:db             {:database-name "ataru-dev"
+                  :pool-name     "ataru-pool"
+                  :username      "oph"
+                  :password      "oph"
+                  :server-name   "localhost"
+                  :port-number   5432
+                  :schema        "public"}
+ :session        {:timeout 28800}
+ :public-config  {:applicant        {:service_url "http://localhost:8351"}
+                  :virkailija       {:service_url "http://localhost:8350/lomake-editori/"}
+                  :environment-name "dev"
+                  :features         {:attachment false}}
  :background-job {:exec-interval-seconds 15}
- :log {:virkailija-base-path "."
-       :hakija-base-path "."}
- :urls {:virkailija-host "itest-virkailija.oph.ware.fi"
-        :hakija-host "itest-hakija.oph.ware.fi"
-        :liiteri-url "https://virkailija.osdev.oph.ware.fi/liiteri"}}
+ :log            {:virkailija-base-path "."
+                  :hakija-base-path     "."}
+ :urls           {:virkailija-host "itest-virkailija.oph.ware.fi"
+                  :hakija-host     "itest-hakija.oph.ware.fi"
+                  :editor-url      "http://localhost:8350/lomake-editori"
+                  :liiteri-url     "https://virkailija.osdev.oph.ware.fi/liiteri"}}

--- a/config/defaults.edn
+++ b/config/defaults.edn
@@ -6,16 +6,10 @@
        :port-number 5432
        :schema "public"}
  :session {:timeout 28800}
- :email {:email_service_url "https://itest-virkailija.oph.ware.fi"}
- :tarjonta-service {:hakukohde-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/hakukohde/"
-                    :haku-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/haku/"
-                    :koulutus-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/koulutus/"
-                    :forms-in-use-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/haku/ataru/all"}
  :public-config {:applicant {:service_url "http://localhost:8351"}
                  :virkailija {:service_url "http://localhost:8350/lomake-editori/"}
                  :environment-name "dev"
                  :features {:attachment false}}
  :background-job {:exec-interval-seconds 15}
  :log {:virkailija-base-path "."
-       :hakija-base-path "."}
- :liiteri {:url "https://virkailija.osdev.oph.ware.fi/liiteri"}}
+       :hakija-base-path "."}}

--- a/config/defaults.edn
+++ b/config/defaults.edn
@@ -12,4 +12,7 @@
                  :features {:attachment false}}
  :background-job {:exec-interval-seconds 15}
  :log {:virkailija-base-path "."
-       :hakija-base-path "."}}
+       :hakija-base-path "."}
+ :urls {:virkailija-host "itest-virkailija.oph.ware.fi"
+        :hakija-host "itest-hakija.oph.ware.fi"
+        :liiteri-url "https://virkailija.osdev.oph.ware.fi/liiteri"}}

--- a/config/dev.edn
+++ b/config/dev.edn
@@ -1,14 +1,14 @@
-{:server {:allow-db-clear? true}
- :db {:database-name "ataru-test"
-      :pool-name "ataru-pool"
-      :username "oph"
-      :password "oph"
-      :server-name "localhost"
-      :port-number 5433
-      :schema "public"}
- :cas {}
- :public-config {:applicant {:service_url "http://localhost:8351"}
-                 :virkailija {:service_url "http://localhost:8350/lomake-editori/"}
+{:server        {:allow-db-clear? true}
+ :db            {:database-name "ataru-test"
+                 :pool-name     "ataru-pool"
+                 :username      "oph"
+                 :password      "oph"
+                 :server-name   "localhost"
+                 :port-number   5433
+                 :schema        "public"}
+ :cas           {}
+ :public-config {:applicant        {:service_url "http://localhost:8351"}
+                 :virkailija       {:service_url "http://localhost:8350/lomake-editori/"}
                  :environment-name "test"}
- :dev {:fake-dependencies true}}
+ :dev           {:fake-dependencies true}}
 

--- a/config/dev.edn
+++ b/config/dev.edn
@@ -7,15 +7,8 @@
       :port-number 5433
       :schema "public"}
  :cas {}
- :authentication {:opintopolku-login-url "https://itest-virkailija.oph.ware.fi/cas/login?service="
-                  :opintopolku-logout-url  "https://itest-virkailija.oph.ware.fi/cas/logout?service="
-                  :ataru-login-success-url "http://localhost:8350/lomake-editori/auth/cas"
-                  :cas-client-url "https://itest-virkailija.oph.ware.fi"}
- :tarjonta-service {:hakukohde-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/hakukohde/"
-                    :haku-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/haku/"
-                    :koulutus-base-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/koulutus/"
-                    :forms-in-use-url "https://itest-virkailija.oph.ware.fi/tarjonta-service/rest/v1/haku/ataru/all"}
  :public-config {:applicant {:service_url "http://localhost:8351"}
                  :virkailija {:service_url "http://localhost:8350/lomake-editori/"}
                  :environment-name "test"}
  :dev {:fake-dependencies true}}
+

--- a/config/dev.edn
+++ b/config/dev.edn
@@ -10,5 +10,9 @@
  :public-config {:applicant        {:service_url "http://localhost:8351"}
                  :virkailija       {:service_url "http://localhost:8350/lomake-editori/"}
                  :environment-name "test"}
- :dev           {:fake-dependencies true}}
+ :dev           {:fake-dependencies true}
+ :urls          {:virkailija-host "itest-virkailija.oph.ware.fi"
+                 :hakija-host     "itest-hakija.oph.ware.fi"
+                 :editor-url      "http://localhost:8350/lomake-editori"
+                 :liiteri-url     ""}}
 

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -8,10 +8,6 @@
        :schema "public"
        :minimum-idle {{ataru_db_max_pool_size}}
        :maximum-pool-size {{ataru_db_max_pool_size}}}
- :authentication {:opintopolku-login-url "{{ataru_authentication_opintopolku_login_url}}"
-                  :opintopolku-logout-url  "{{ataru_authentication_opintopolku_logout_url}}"
-                  :ataru-login-success-url "{{ataru_authentication_ataru_login_success_url}}"
-                  :cas-client-url "{{ataru_authentication_cas_client_url}}"}
  :ldap {:server "{{host_ldap}}"
         :port 389
         :ssl false
@@ -20,20 +16,14 @@
         :user-right-names {:form-edit         "{{ataru_ldap_editor_user_right_name}}"
                            :view-applications "{{ataru_ldap_view_applications_user_right_name}}"
                            :edit-applications "{{ataru_ldap_edit_applications_user_right_name}}"}}
- :email {:email-service-url "https://{{host_virkailija}}/ryhmasahkoposti-service/email/firewall"}
  :public-config {:applicant {:service_url "{{ataru_applicant_service_url}}"}
                  :virkailija {:service_url "https://{{host_virkailija}}/lomake-editori/"}
                  :environment-name "{{ataru_environment_name}}"
                  :features {:attachment {{ataru_attachment_support_enabled}}}}
  :cas {:username "{{ataru_cas_username}}"
        :password "{{ataru_cas_password}}"}
- :organization-service {:base-address "https://{{host_virkailija}}/organisaatio-service/rest/organisaatio/v2"}
- :authentication-service {:base-address "https://{{host_virkailija}}/authentication-service"}
- :oppijanumerorekisteri-service {:base-address "https://{{host_virkailija}}/oppijanumerorekisteri-service"}
- :tarjonta-service {:hakukohde-base-url "https://{{host_virkailija}}/tarjonta-service/rest/v1/hakukohde/"
-                    :haku-base-url "https://{{host_virkailija}}/tarjonta-service/rest/v1/haku/"
-                    :koulutus-base-url "https://{{host_virkailija}}/tarjonta-service/rest/v1/koulutus/"
-                    :forms-in-use-url "https://{{host_virkailija}}/tarjonta-service/rest/v1/haku/ataru/all"}
  :log {:virkailija-base-path "{{ataru_virkailija_log_path}}"
        :hakija-base-path "{{ataru_hakija_log_path}}"}
- :liiteri {:url "{{liiteri_url}}"}}
+ :urls {:virkailija-host "{{ataru_virkailija_host}}"
+        :hakija-host "{{ataru_hakija_host}}"
+        :liiteri-url "{{ataru_liiteri_url}}"}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -26,4 +26,5 @@
        :hakija-base-path "{{ataru_hakija_log_path}}"}
  :urls {:virkailija-host "{{ataru_virkailija_host}}"
         :hakija-host "{{ataru_hakija_host}}"
-        :liiteri-url "{{ataru_liiteri_url}}"}
+        :liiteri-url "{{ataru_liiteri_url}}"
+        :editor-url  "{{ataru_editor_url}}"}}

--- a/project.clj
+++ b/project.clj
@@ -32,6 +32,7 @@
                  [metosin/compojure-api "1.1.9"]
                  [aleph "0.4.1"]
                  [fi.vm.sade/auditlogger "5.0.0-SNAPSHOT"]
+                 [fi.vm.sade.java-utils/java-properties "0.1.0-SNAPSHOT"]
                  [http-kit "2.2.0"]
                  [ring "1.5.0"]
                  [ring/ring-defaults "0.2.1"]

--- a/resources/ataru-oph.properties
+++ b/resources/ataru-oph.properties
@@ -1,0 +1,38 @@
+# virkailija.opintopolku.fi
+url-virkailija = https://${host-virkailija}
+# opintopolku.fi
+url-hakija = https://${host-hakija}
+
+cas-client = ${url-virkailija}
+
+ataru.login-success = ${url-virkailija}/lomake-editori/auth/cas
+ataru.hakemus-edit = ${url-hakija}/hakemus?modify=$1
+
+opintopolku.login = ${url-virkailija}/cas/login?service=${ataru.login-success}
+opintopolku.logout = ${url-virkailija}/cas/logout?service=${ataru.login-success}
+
+organization-service.base = ${url-virkailija}/organisaatio-service/rest/organisaatio/v2
+organization-service.name = ${organization-service.base}/hae/nimi?aktiiviset=true&suunnitellut=true&lakkautetut=false&oid=$1
+organization-service.plain-hierarchy = ${organization-service.base}/hierarkia/hae/nimi?aktiiviset=true&suunnitellut=true&lakkautetut=false&skipParents=true&oid=$1
+organization-service.groups = ${organization-service.base}/ryhmat
+
+oppijanumerorekisteri-service.base = ${url-virkailija}/oppijanumerorekisteri-service
+oppijanumerorekisteri-service.person-create = ${oppijanumerorekisteri-service.base}/henkilo
+oppijanumerorekisteri-service.upsert-without-hetu = ${oppijanumerorekisteri-service.base}/henkilo/identification?idp=email&id=$1
+oppijanumerorekisteri-service.upsert-with-hetu = ${oppijanumerorekisteri-service.base}/henkilo/hetu=$1
+
+authentication-service.base = ${url-virkailija}/authentication-service"
+authentication-service.legacy-upsert = ${authentication-service.base}/resources/s2s/hakuperusteet
+
+tarjonta-service.base = ${url-virkailija}/tarjonta-service/rest/v1
+tarjonta-service.hakukohde = ${tarjonta-service.base}/hakukohde/$1
+tarjonta-service.haku = ${tarjonta-service.base}/haku/$1
+tarjonta-service.koulutus = ${tarjonta-service.base}/koulutus/$1
+tarjonta-service.forms-in-use = ${tarjonta-service.base}/haku/ataru/all
+
+email-service = ${url_virkailija}/ryhmasahkoposti-service/email/firewall
+
+liiteri.base = https://virkailija.osdev.oph.ware.fi/liiteri/api
+liiteri.file = ${liiteri.base}/files/$1
+liiteri.files = ${liiteri.base}/files
+liiteri.metadata = ${liiteri.base}/files/metadata

--- a/resources/ataru-oph.properties
+++ b/resources/ataru-oph.properties
@@ -1,11 +1,14 @@
-# virkailija.opintopolku.fi
-url-virkailija = https://${host-virkailija}
-# opintopolku.fi
-url-hakija = https://${host-hakija}
+# the following props should be provided via url-helper defaults:
+# - host-virkailija
+# - host-hakija
+# - url-liiteri
+# - url-editor
 
+url-virkailija = https://${host-virkailija}
+url-hakija = https://${host-hakija}
 cas-client = ${url-virkailija}
 
-ataru.login-success = ${url-virkailija}/lomake-editori/auth/cas
+ataru.login-success = ${url-editor}/auth/cas
 ataru.hakemus-edit = ${url-hakija}/hakemus?modify=$1
 
 opintopolku.login = ${url-virkailija}/cas/login?service=${ataru.login-success}
@@ -21,7 +24,7 @@ oppijanumerorekisteri-service.person-create = ${oppijanumerorekisteri-service.ba
 oppijanumerorekisteri-service.upsert-without-hetu = ${oppijanumerorekisteri-service.base}/henkilo/identification?idp=email&id=$1
 oppijanumerorekisteri-service.upsert-with-hetu = ${oppijanumerorekisteri-service.base}/henkilo/hetu=$1
 
-authentication-service.base = ${url-virkailija}/authentication-service"
+authentication-service.base = ${url-virkailija}/authentication-service
 authentication-service.legacy-upsert = ${authentication-service.base}/resources/s2s/hakuperusteet
 
 tarjonta-service.base = ${url-virkailija}/tarjonta-service/rest/v1
@@ -32,7 +35,7 @@ tarjonta-service.forms-in-use = ${tarjonta-service.base}/haku/ataru/all
 
 email-service = ${url_virkailija}/ryhmasahkoposti-service/email/firewall
 
-liiteri.base = https://virkailija.osdev.oph.ware.fi/liiteri/api
+liiteri.base = ${url-liiteri}
 liiteri.file = ${liiteri.base}/files/$1
 liiteri.files = ${liiteri.base}/files
 liiteri.metadata = ${liiteri.base}/files/metadata

--- a/resources/ataru-oph.properties
+++ b/resources/ataru-oph.properties
@@ -33,7 +33,7 @@ tarjonta-service.haku = ${tarjonta-service.base}/haku/$1
 tarjonta-service.koulutus = ${tarjonta-service.base}/koulutus/$1
 tarjonta-service.forms-in-use = ${tarjonta-service.base}/haku/ataru/all
 
-email-service = ${url_virkailija}/ryhmasahkoposti-service/email/firewall
+email-service = ${url-virkailija}/ryhmasahkoposti-service/email/firewall
 
 liiteri.base = ${url-liiteri}
 liiteri.file = ${liiteri.base}/files/$1

--- a/src/clj/ataru/cas/client.clj
+++ b/src/clj/ataru/cas/client.clj
@@ -2,6 +2,7 @@
   (:require
     [org.httpkit.client :as http]
     [clj-util.cas :as cas]
+    [ataru.config.url-helper :refer [resolve-url]]
     [oph.soresu.common.config :refer [config]]
     [cheshire.core :as json]))
 
@@ -9,7 +10,7 @@
   {:pre [(some? (:cas config))]}
   (let [username           (get-in config [:cas :username])
         password           (get-in config [:cas :password])
-        cas-url            (get-in config [:authentication :cas-client-url])
+        cas-url            (resolve-url :cas-client)
         cas-params         (cas/cas-params cas-uri username password)
         cas-client         (cas/cas-client cas-url)]
     {:client cas-client

--- a/src/clj/ataru/config/url_helper.clj
+++ b/src/clj/ataru/config/url_helper.clj
@@ -3,18 +3,20 @@
   (:import (fi.vm.sade.properties OphProperties)))
 
 ; TODO component if not too much work?
-(def ^fi.vm.sade.properties.OphProperties url-config (atom nil))
+(def ^fi.vm.sade.properties.OphProperties url-properties (atom nil))
 
 (defn- load-config
-  [{:keys [virkailija-host hakija-host liiteri-url] :as url-config}]
-  (reset! url-config
-          (doto (OphProperties. (into-array String ["/ataru-oph.properties"]))
-            (.addDefault "host-virkailija" (or virkailija-host "itest-virkailija.oph.ware.fi"))
-            (.addDefault "host-hakija" (or hakija-host "itest-hakija.oph.ware.fi"))
-            (.addDefault "url-liiteri" liiteri-url))))
+  []
+  (let [{:keys [virkailija-host hakija-host editor-url liiteri-url]} (:urls config)]
+    (reset! url-properties
+            (doto (OphProperties. (into-array String ["/ataru-oph.properties"]))
+              (.addDefault "host-virkailija" virkailija-host)
+              (.addDefault "host-hakija" hakija-host)
+              (.addDefault "url-editor" editor-url)
+              (.addDefault "url-liiteri" liiteri-url)))))
 
 (defn resolve-url
   [key & params]
-  (when (nil? @url-config)
-    (load-config (:urls config)))
-  (.url @url-config (name key) (to-array (or params []))))
+  (when (nil? @url-properties)
+    (load-config))
+  (.url @url-properties (name key) (to-array (or params []))))

--- a/src/clj/ataru/config/url_helper.clj
+++ b/src/clj/ataru/config/url_helper.clj
@@ -7,7 +7,8 @@
 
 (defn- load-config
   []
-  (let [{:keys [virkailija-host hakija-host editor-url liiteri-url]} (:urls config)]
+  (let [{:keys [virkailija-host hakija-host editor-url liiteri-url] :or
+               {virkailija-host "" hakija-host "" editor-url "" liiteri-url ""}} (:urls config)]
     (reset! url-properties
             (doto (OphProperties. (into-array String ["/ataru-oph.properties"]))
               (.addDefault "host-virkailija" virkailija-host)

--- a/src/clj/ataru/config/url_helper.clj
+++ b/src/clj/ataru/config/url_helper.clj
@@ -1,19 +1,20 @@
 (ns ataru.config.url-helper
-  (:require [clojure.tools.logging :refer [spy]])
+  (:require [oph.soresu.common.config :refer [config]])
   (:import (fi.vm.sade.properties OphProperties)))
 
 ; TODO component if not too much work?
 (def ^fi.vm.sade.properties.OphProperties url-config (atom nil))
 
 (defn- load-config
-  []
+  [{:keys [virkailija-host hakija-host liiteri-url] :as url-config}]
   (reset! url-config
           (doto (OphProperties. (into-array String ["/ataru-oph.properties"]))
-            (.addDefault "host-virkailija" "itest-virkailija.oph.ware.fi")
-            (.addDefault "host-hakija" "itest-hakija.oph.ware.fi"))))
+            (.addDefault "host-virkailija" (or virkailija-host "itest-virkailija.oph.ware.fi"))
+            (.addDefault "host-hakija" (or hakija-host "itest-hakija.oph.ware.fi"))
+            (.addDefault "url-liiteri" liiteri-url))))
 
 (defn resolve-url
   [key & params]
   (when (nil? @url-config)
-    (load-config))
+    (load-config (:urls config)))
   (.url @url-config (name key) (to-array (or params []))))

--- a/src/clj/ataru/config/url_helper.clj
+++ b/src/clj/ataru/config/url_helper.clj
@@ -1,0 +1,19 @@
+(ns ataru.config.url-helper
+  (:require [clojure.tools.logging :refer [spy]])
+  (:import (fi.vm.sade.properties OphProperties)))
+
+; TODO component if not too much work?
+(def ^fi.vm.sade.properties.OphProperties url-config (atom nil))
+
+(defn- load-config
+  []
+  (reset! url-config
+          (doto (OphProperties. (into-array String ["/ataru-oph.properties"]))
+            (.addDefault "host-virkailija" "itest-virkailija.oph.ware.fi")
+            (.addDefault "host-hakija" "itest-hakija.oph.ware.fi"))))
+
+(defn resolve-url
+  [key & params]
+  (when (nil? @url-config)
+    (load-config))
+  (.url @url-config (name key) (to-array (or params []))))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -1,11 +1,12 @@
 (ns ataru.files.file-store
   (:require [ataru.url :as url]
+            [ataru.config.url-helper :refer [resolve-url]]
             [oph.soresu.common.config :refer [config]]
             [org.httpkit.client :as http]
             [cheshire.core :as json]))
 
 (defn upload-file [{:keys [tempfile filename]}]
-  (let [url  (str (get-in config [:liiteri :url]) "/api/files")
+  (let [url  (resolve-url :liiteri.files)
         resp @(http/post url {:multipart [{:name     "file"
                                            :content  tempfile
                                            :filename filename}]})]
@@ -15,20 +16,21 @@
           (dissoc :version :deleted)))))
 
 (defn delete-file [file-key]
-  (let [url  (str (get-in config [:liiteri :url]) "/api/files/" file-key)
+  (let [url  (resolve-url :liiteri.file file-key)
         resp @(http/delete url)]
     (when (= (:status resp) 200)
       (json/parse-string (:body resp) true))))
 
 (defn get-metadata [file-keys]
   (let [query-part (clojure.string/join (url/items->query-part "key" file-keys))
-        url        (str (get-in config [:liiteri :url]) "/api/files/metadata" query-part)
+        ; TODO: fix query-part to use url.props correctly
+        url        (str (resolve-url :liiteri.metadata) query-part)
         resp       @(http/get url)]
     (when (= (:status resp) 200)
       (json/parse-string (:body resp) true))))
 
 (defn get-file [key]
-  (let [url  (str (get-in config [:liiteri :url]) "/api/files/" key)
+  (let [url  (resolve-url :liiteri.file key)
         resp @(http/get url)]
     (when (= (:status resp) 200)
       (:body resp))))

--- a/src/clj/ataru/hakija/application_email_confirmation.clj
+++ b/src/clj/ataru/hakija/application_email_confirmation.clj
@@ -3,7 +3,6 @@
   (:require
     [taoensso.timbre :as log]
     [selmer.parser :as selmer]
-    [ataru.config.url-helper :refer [resolve-url]]
     [ataru.applications.application-store :as application-store]
     [ataru.background-job.job :as job]
     [ataru.hakija.background-jobs.hakija-jobs :as hakija-jobs]
@@ -25,7 +24,8 @@
                            (get-differing-translations raw-translations translation-mappings))
         subject          (:subject translations)
         recipient        (-> (filter #(= "email" (:key %)) (:answers application)) first :value)
-        application-url  (resolve-url :ataru.hakemus-edit (:secret application))
+        service-url      (get-in config [:public-config :applicant :service_url])
+        application-url  (str service-url "/hakemus?modify=" (:secret application))
         body             (selmer/render-file
                            "templates/email_confirmation_template.html"
                            (merge {:application-url application-url}

--- a/src/clj/ataru/hakija/application_email_confirmation.clj
+++ b/src/clj/ataru/hakija/application_email_confirmation.clj
@@ -3,6 +3,7 @@
   (:require
     [taoensso.timbre :as log]
     [selmer.parser :as selmer]
+    [ataru.config.url-helper :refer [resolve-url]]
     [ataru.applications.application-store :as application-store]
     [ataru.background-job.job :as job]
     [ataru.hakija.background-jobs.hakija-jobs :as hakija-jobs]
@@ -24,8 +25,7 @@
                            (get-differing-translations raw-translations translation-mappings))
         subject          (:subject translations)
         recipient        (-> (filter #(= "email" (:key %)) (:answers application)) first :value)
-        service-url      (get-in config [:public-config :applicant :service_url])
-        application-url  (str service-url "/hakemus?modify=" (:secret application))
+        application-url  (resolve-url :ataru.hakemus-edit (:secret application))
         body             (selmer/render-file
                            "templates/email_confirmation_template.html"
                            (merge {:application-url application-url}

--- a/src/clj/ataru/hakija/background_jobs/email_job.clj
+++ b/src/clj/ataru/hakija/background_jobs/email_job.clj
@@ -1,13 +1,14 @@
 (ns ataru.hakija.background-jobs.email-job
   "You can send any email with this, it's not tied to any particular email-type"
   (:require
-   [taoensso.timbre :as log]
-   [org.httpkit.client :as http]
-   [cheshire.core :as json]
-   [oph.soresu.common.config :refer [config]]))
+    [ataru.config.url-helper :refer [resolve-url]]
+    [taoensso.timbre :as log]
+    [org.httpkit.client :as http]
+    [cheshire.core :as json]
+    [oph.soresu.common.config :refer [config]]))
 
 (defn- viestintapalvelu-address []
-  (get-in config [:email :email-service-url]))
+  (resolve-url :email-service))
 
 (defn- send-email [from recipients subject body]
   (let [url                 (viestintapalvelu-address)

--- a/src/clj/ataru/tarjonta_service/tarjonta_client.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_client.clj
@@ -1,7 +1,7 @@
 (ns ataru.tarjonta-service.tarjonta-client
   (:require
+    [ataru.config.url-helper :refer [resolve-url]]
     [cheshire.core :as json]
-    [oph.soresu.common.config :refer [config]]
     [org.httpkit.client :as http]
     [taoensso.timbre :refer [warn info]]
     [clojure.string :as string]))
@@ -19,25 +19,19 @@
 
 (defn get-hakukohde
   [hakukohde-oid]
-  (do-request (str
-                (get-in config [:tarjonta-service :hakukohde-base-url])
-                hakukohde-oid)))
+  (do-request (resolve-url :tarjonta-service.hakukohde hakukohde-oid)))
 
 (defn get-haku
   [haku-oid]
-  (do-request (str
-                (get-in config [:tarjonta-service :haku-base-url])
-                haku-oid)))
+  (do-request (resolve-url :tarjonta-service.haku haku-oid)))
 
 (defn get-koulutus
   [koulutus-oid]
-  (do-request (str
-                (get-in config [:tarjonta-service :koulutus-base-url])
-                koulutus-oid)))
+  (do-request (resolve-url :tarjonta-service.koulutus koulutus-oid)))
 
 (defn get-forms-in-use
   [organization-oids]
-  (let [url      (get-in config [:tarjonta-service :forms-in-use-url])
+  (let [url      (resolve-url :tarjonta-service.forms-in-use)
         query    (when (< 0 (count organization-oids))
                    (str "?" (string/join "&" (map #(str "oid=" %) organization-oids))))
         response @(http/get (str url query))]

--- a/src/clj/ataru/virkailija/authentication/auth.clj
+++ b/src/clj/ataru/virkailija/authentication/auth.clj
@@ -12,7 +12,7 @@
   (:import (fi.vm.sade.utils.cas CasLogout)))
 
 (defn- redirect-to-logged-out-page []
-  (resp/redirect (resolve-url :opintopolku-login)))
+  (resp/redirect (resolve-url :opintopolku.login)))
 
 (defn- cas-login [ticket virkailija-login-url]
   (let [cas-client (cas/cas-client (resolve-url :cas-client))

--- a/src/clj/ataru/virkailija/authentication/auth_routes.clj
+++ b/src/clj/ataru/virkailija/authentication/auth_routes.clj
@@ -1,5 +1,6 @@
 (ns ataru.virkailija.authentication.auth-routes
   (:require [ataru.virkailija.authentication.auth :refer [login logout cas-initiated-logout]]
+            [ataru.config.url-helper :refer [resolve-url]]
             [oph.soresu.common.config :refer [config]]
             [compojure.api.sweet :as api]
             [environ.core :refer [env]]

--- a/src/clj/ataru/virkailija/authentication/auth_utils.clj
+++ b/src/clj/ataru/virkailija/authentication/auth_utils.clj
@@ -1,8 +1,7 @@
 (ns ataru.virkailija.authentication.auth-utils
-  (:require [oph.soresu.common.config :refer [config]]))
+  (:require
+    [ataru.config.url-helper :refer [resolve-url]]))
 
-(def ^:private opintopolku-login-url (get-in config [:authentication :opintopolku-login-url]))
-(def ^:private ataru-login-success-url (get-in config [:authentication :ataru-login-success-url]))
-
-(defn cas-auth-url []
-  (str opintopolku-login-url ataru-login-success-url))
+(defn cas-auth-url
+  []
+  (resolve-url :opintopolku.login))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -1,5 +1,6 @@
 (ns ataru.virkailija.virkailija-routes
-  (:require [ataru.middleware.cache-control :as cache-control]
+  (:require [ataru.config.url-helper :refer [resolve-url]]
+            [ataru.middleware.cache-control :as cache-control]
             [ataru.middleware.user-feedback :as user-feedback]
             [ataru.middleware.session-store :refer [create-store]]
             [ataru.middleware.session-timeout :as session-timeout]


### PR DESCRIPTION
Use java-utils/url.config to configure integration URLs (the beef is in `resources/ataru-oph.properties`).

Will probably require some tweaks to naming etc. to have the actual graph generation working as it should, but should probably tested in dev/QA first.