### PR TITLE
Tell the browser attachments' real filenames

### DIFF
--- a/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
+++ b/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
@@ -46,7 +46,7 @@
                          [:div.application__virkailija-readonly-attachment-text
                           {:key component-key}
                           [:a {:href (str "/lomake-editori/api/files/content/" file-key)
-                               :download ""}
+                               :download filename}
                            text]]))
                      values)]])))
 


### PR DESCRIPTION
If we don't put the filename in the `download` attribute on the `a` element, browsers will name the downloaded file after the last segment of the download URL, i.e. the UUID of the attachment. With this change, browsers will use the filename we've saved to the database instead.

This requires Chrome, Edge, Safari 10.1 (pre-release) or Firefox. Notably, IE does not support the `download` attribute at all. That means attachments will open inline in the IE window. 