### PR TITLE
Fix attachment download on IE

### DIFF
--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -33,4 +33,6 @@
   (let [url  (resolve-url :liiteri.file key)
         resp @(http/get url)]
     (when (= (:status resp) 200)
-      (:body resp))))
+      (clojure.pprint/pprint (:headers resp))
+      {:body (:body resp)
+       :content-disposition (-> resp :headers :content-disposition)})))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -33,6 +33,5 @@
   (let [url  (resolve-url :liiteri.file key)
         resp @(http/get url)]
     (when (= (:status resp) 200)
-      (clojure.pprint/pprint (:headers resp))
       {:body (:body resp)
        :content-disposition (-> resp :headers :content-disposition)})))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -279,8 +279,10 @@
                    (api/GET "/content/:key" []
                      :path-params [key :- (api/describe s/Str "File key")]
                      :summary "Download a file"
-                     (if-let [file-stream (file-store/get-file key)]
-                       (header (ok file-stream) "Content-Disposition" (str "attachment; filename=\"" "foo" "\""))
+                     (if-let [file-response (file-store/get-file key)]
+                       (header (ok (:body file-response))
+                               "Content-Disposition"
+                               (:content-disposition file-response))
                        (not-found))))))
 
 (api/defroutes resource-routes

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -34,7 +34,7 @@
             [ring.middleware.session :as ring-session]
             [ring.middleware.logger :refer [wrap-with-logger] :as middleware-logger]
             [ring.util.http-response :refer [ok internal-server-error not-found bad-request content-type set-cookie]]
-            [ring.util.response :refer [redirect]]
+            [ring.util.response :refer [redirect header]]
             [schema.core :as s]
             [selmer.parser :as selmer]
             [taoensso.timbre :refer [spy debug error warn info]]
@@ -280,7 +280,7 @@
                      :path-params [key :- (api/describe s/Str "File key")]
                      :summary "Download a file"
                      (if-let [file-stream (file-store/get-file key)]
-                       (ok file-stream)
+                       (header (ok file-stream) "Content-Disposition" (str "attachment; filename=\"" "foo" "\""))
                        (not-found))))))
 
 (api/defroutes resource-routes

--- a/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
+++ b/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
@@ -45,8 +45,7 @@
                              component-key (str "attachment-div-" idx)]
                          [:div.application__virkailija-readonly-attachment-text
                           {:key component-key}
-                          [:a {:href (str "/lomake-editori/api/files/content/" file-key)
-                               :download filename}
+                          [:a {:href (str "/lomake-editori/api/files/content/" file-key)}
                            text]]))
                      values)]])))
 


### PR DESCRIPTION
IE doesn't support the `<a download="filename.jpg">` HTML5 attribute, so we need to tell IE that the attachment should be downloaded and its name is `filename.jpg` via the Content-Disposition HTTP header. 

Depends on https://github.com/Opetushallitus/liiteri/pull/11 (merged)