### PR TITLE
Handle attachments that are too large

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -499,12 +499,12 @@ textarea.application__form-text-area__size-large {
 
 .application__form-upload-button-error {
   font-size: 14px;
-  color: rgb(228, 78, 78);
+  color: @sg-color-red;
 }
 
 .application__form-upload-button-info {
   font-size: 14px;
-  color: rgb(174, 174, 174);
+  color: @sg-color-gray;
 }
 
 .application__form-upload-attachment-container {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -484,6 +484,7 @@ textarea.application__form-text-area__size-large {
   height: 43px;
   justify-content: center;
   width: 211px;
+  margin-right: 18px;
 }
 
 .application__form-upload-uploading-spinner {
@@ -496,8 +497,20 @@ textarea.application__form-text-area__size-large {
   margin-left: 10px;
 }
 
+.application__form-upload-button-error {
+  font-size: 14px;
+  color: rgb(228, 78, 78);
+}
+
+.application__form-upload-button-info {
+  font-size: 14px;
+  color: rgb(174, 174, 174);
+}
+
 .application__form-upload-attachment-container {
   margin-top: 6px;
+  display: flex;
+  align-items: baseline;
 }
 
 .application__error-display {

--- a/resources/less/vars.less
+++ b/resources/less/vars.less
@@ -29,5 +29,5 @@
 @modal-shadow: 0 1px 3px 0 rgba(0,0,0,0.30);
 @separator-color: #E6E6E6;
 
-@sg-color-red: rgb(228, 78, 78);
-@sg-color-gray: rgb(174, 174, 174);
+@sg-color-red: #e44e4e;
+@sg-color-gray: #aeaeae;

--- a/resources/less/vars.less
+++ b/resources/less/vars.less
@@ -28,3 +28,6 @@
 @input-font: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 @modal-shadow: 0 1px 3px 0 rgba(0,0,0,0.30);
 @separator-color: #E6E6E6;
+
+@sg-color-red: rgb(228, 78, 78);
+@sg-color-gray: rgb(174, 174, 174);

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -406,7 +406,7 @@
      (let [file-size-info-text (case language
                                  :fi "Tiedoston maksimikoko on 10 MB"
                                  :en "Maximum file size is 10 MB"
-                                 :sv "BÖÖ BÄÄ GUU")]
+                                 :sv "Den maximala filstorleken är 10 MB")]
        (if @(subscribe [:state-query [:application :answers (keyword component-id) :too-big]])
          [:span.application__form-upload-button-error file-size-info-text]
          [:span.application__form-upload-button-info file-size-info-text]))]))

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -408,7 +408,7 @@
                                  :en "Maximum file size is 10 MB"
                                  :sv "Den maximala filstorleken är 10 MB")]
        (if @(subscribe [:state-query [:application :answers (keyword component-id) :too-big]])
-         [:span.application__form-upload-button-error file-size-info-text]
+         [:span.application__form-upload-button-error.animated.shake file-size-info-text]
          [:span.application__form-upload-button-info file-size-info-text]))]))
 
 (defn- filename->label [{:keys [filename size]}]

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -84,6 +84,11 @@
     {:db (-> (update (:db cofx) :application dissoc :submit-status)
              (assoc :error {:message "Tapahtui virhe " :detail response}))}))
 
+(reg-event-db
+  :application/show-attachment-too-big-error
+  (fn [db [_ component-id]]
+    (assoc-in db [:application :answers (keyword component-id) :too-big] true)))
+
 (reg-event-fx
   :application/submit
   (fn [{:keys [db]} _]
@@ -440,7 +445,8 @@
                                                 :valid  false
                                                 :status :uploading}))
                                            db'))
-                              (assoc-in db' [:application :answers (keyword component-id) :valid] false))]
+                              (assoc-in db' [:application :answers (keyword component-id) :valid] false)
+                              (assoc-in db' [:application :answers (keyword component-id) :too-big] false))]
       {:db         db
        :dispatch-n dispatch-list})))
 


### PR DESCRIPTION
Tell the user in the upload UI how large attachments we support, and change the text color to red if the user tries to upload an attachment that is too large.