### PR TITLE
Show error when trying to upload a prohibited file type

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -444,7 +444,7 @@ textarea.application__form-text-area__size-large {
   margin-left: 2px;
 
   &.application__form-file-error {
-    background-color: #e44e4e;
+    background-color: @sg-color-red;
     color: white;
   }
 }

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -451,7 +451,7 @@ textarea.application__form-text-area__size-large {
 
 .application__form-attachment-error {
   margin-left: 10px;
-  color: #aeaeae;
+  color: @sg-color-gray;
 }
 
 .application__attachment-filename-list {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -145,8 +145,8 @@
   visibility: hidden;
 }
 .application__invalid-field-status {
-  font-size: 12px;
-  margin-top: 2px;
+  font-size: 14px;
+  margin-top: 4px;
   text-align: center;
   width: 210px;
   position: relative;
@@ -442,6 +442,16 @@ textarea.application__form-text-area__size-large {
   padding: 4px 4px 4px 8px;
   line-height: 19px;
   margin-left: 2px;
+
+  &.application__form-file-error {
+    background-color: #e44e4e;
+    color: white;
+  }
+}
+
+.application__form-attachment-error {
+  margin-left: 10px;
+  color: #aeaeae;
 }
 
 .application__attachment-filename-list {

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -425,6 +425,23 @@
                   (dispatch [:application/remove-attachment field-descriptor component-id attachment-idx]))}
      [:i.zmdi.zmdi-close]]]])
 
+(defn attachment-view-file-error [field-descriptor component-id attachment-idx]
+  [:div
+   [:div.application__form-filename-container.application__form-file-error
+    [:span.application__form-attachment-text
+     (:filename @(subscribe [:state-query [:application :answers (keyword component-id) :values attachment-idx :value]]))
+     [:a.application__form-upload-remove-attachment-link
+      {:href     "#"
+       :on-click (fn remove-attachment [event]
+                   (.preventDefault event)
+                   (dispatch [:application/remove-attachment-error field-descriptor component-id attachment-idx]))}
+      [:i.zmdi.zmdi-close.zmdi-hc-inverse]]]]
+   [:span.application__form-attachment-error
+    (condp = @(subscribe [:application/form-language])
+      :fi "Kielletty tiedostomuoto"
+      :en "File type forbidden"
+      :sv "Förbjudet filformat")]])
+
 (defn attachment-deleting-file [component-id attachment-idx]
   [:div.application__form-filename-container
    [:span.application__form-attachment-text
@@ -441,6 +458,7 @@
     [:li.application__attachment-filename-list-item
      (case status
        :ready [attachment-view-file field-descriptor component-id attachment-idx]
+       :error [attachment-view-file-error field-descriptor component-id attachment-idx]
        :uploading [attachment-uploading-file component-id attachment-idx]
        :deleting [attachment-deleting-file component-id attachment-idx])]))
 

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -427,7 +427,7 @@
 
 (defn attachment-view-file-error [field-descriptor component-id attachment-idx]
   [:div
-   [:div.application__form-filename-container.application__form-file-error
+   [:div.application__form-filename-container.application__form-file-error.animated.shake
     [:span.application__form-attachment-text
      (:filename @(subscribe [:state-query [:application :answers (keyword component-id) :values attachment-idx :value]]))
      [:a.application__form-upload-remove-attachment-link

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -427,6 +427,7 @@
        :http {:method    :post
               :url       "/hakemus/api/files"
               :handler   [:application/handle-attachment-upload field-descriptor component-id attachment-idx]
+              :error-handler [:application/handle-attachment-upload-error field-descriptor component-id attachment-idx name]
               :body      form-data}})))
 
 (reg-event-fx
@@ -469,8 +470,16 @@
   :application/handle-attachment-upload
   (fn [db [_ field-descriptor component-id attachment-idx response]]
     (-> db
-        (update-in [:application :answers (keyword component-id) :values attachment-idx] merge
-                   {:value response :valid true :status :ready})
+        (update-in [:application :answers (keyword component-id) :values attachment-idx]
+                   merge {:value response :valid true :status :ready})
+        (update-attachment-answer-validity field-descriptor component-id))))
+
+(reg-event-db
+  :application/handle-attachment-upload-error
+  (fn [db [_ field-descriptor component-id attachment-idx filename response]]
+    (-> db
+        (update-in [:application :answers (keyword component-id) :values attachment-idx]
+                   merge {:value {:filename filename} :valid false :status :error})
         (update-attachment-answer-validity field-descriptor component-id))))
 
 (reg-event-db
@@ -495,3 +504,10 @@
        :http {:method  :delete
               :url     (str "/hakemus/api/files/" key)
               :handler [:application/handle-attachment-delete field-descriptor component-id key]}})))
+
+(reg-event-db
+  :application/remove-attachment-error
+  (fn [db [_ field-descriptor component-id attachment-idx]]
+    (-> db
+        (update-in [:application :answers (keyword component-id) :values] autil/remove-nth attachment-idx)
+        (update-attachment-answer-validity field-descriptor component-id))))

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -470,16 +470,16 @@
   :application/handle-attachment-upload
   (fn [db [_ field-descriptor component-id attachment-idx response]]
     (-> db
-        (update-in [:application :answers (keyword component-id) :values attachment-idx]
-                   merge {:value response :valid true :status :ready})
+        (update-in [:application :answers (keyword component-id) :values attachment-idx] merge
+                   {:value response :valid true :status :ready})
         (update-attachment-answer-validity field-descriptor component-id))))
 
 (reg-event-db
   :application/handle-attachment-upload-error
   (fn [db [_ field-descriptor component-id attachment-idx filename response]]
     (-> db
-        (update-in [:application :answers (keyword component-id) :values attachment-idx]
-                   merge {:value {:filename filename} :valid false :status :error})
+        (update-in [:application :answers (keyword component-id) :values attachment-idx] merge
+                   {:value {:filename filename} :valid false :status :error})
         (update-attachment-answer-validity field-descriptor component-id))))
 
 (reg-event-db

--- a/src/cljs/ataru/hakija/banner.cljs
+++ b/src/cljs/ataru/hakija/banner.cljs
@@ -30,10 +30,15 @@
         [:div.application__invalid-field-status
          [:span.application__invalid-field-status-title
           {:on-click toggle-show-details}
-          (str (count (:invalid-fields valid-status)) (case @lang
-                                                        :fi " pakollista tietoa puuttuu"
-                                                        :sv " obligatoriska uppgifter saknas"
-                                                        :en " mandatory fields are missing"))]
+          (case @lang
+            :fi "Tarkista "
+            :en "Check "
+            :sv "Kontrollera ")
+          [:b (count (:invalid-fields valid-status))]
+          (case @lang
+            :fi " tietoa"
+            :en " answers"
+            :sv " uppgifter")]
          (when @show-details
            [:div
             [:div.application__invalid-fields-arrow-up]


### PR DESCRIPTION
The error looks like this:

<img width="302" alt="screen shot 2017-04-10 at 15 46 26" src="https://cloud.githubusercontent.com/assets/42124/24862344/f607af92-1e04-11e7-9a02-191bc5375e66.png">

The error invalidates the form until the user clicks on the X to remove the file:

<img width="225" alt="screen shot 2017-04-10 at 16 17 05" src="https://cloud.githubusercontent.com/assets/42124/24863360/2c982c22-1e09-11e7-9d01-f91544431830.png">

The validation text below the submit button was changed to better indicate the type of content in the popup: some fields are required and some fields can be optional but invalid. The attachment is listed in the popup with its label like any other question:

<img width="230" alt="screen shot 2017-04-10 at 15 46 37" src="https://cloud.githubusercontent.com/assets/42124/24862412/26d14e26-1e05-11e7-8c15-b1d537c333a9.png">
