### PR TITLE
Restore application editing

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -299,22 +299,18 @@
 .application__form-select {
   transition: border-color 0.2s;
   width: @form-select-width;
-
   padding-left: 10px;
   border-radius: 2px;
   height: 43px;
   font-size: 16px;
-  color: @text-color;
-  background-color: #fff;
-  background-image: linear-gradient(-180deg, #f0f0f0  0%, #FFFFFF  9%);
   border: 1px solid #C1C1C1;
   border-radius: 2px;
 }
 
-.application__form-select--disabled {
-  color: @disabled-gray;
-  background-color: @disabled-gray-background;
-  background-image: none;
+.application__form-select--enabled {
+  color: @text-color;
+  background-color: #fff;
+  background-image: linear-gradient(-180deg, #f0f0f0  0%, #FFFFFF  9%);
 }
 
 .application__form-select-arrow {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -311,6 +311,12 @@
   border-radius: 2px;
 }
 
+.application__form-select--disabled {
+  color: @disabled-gray;
+  background-color: @disabled-gray-background;
+  background-image: none;
+}
+
 .application__form-select-arrow {
   background: #fff;
   left: 260px;

--- a/resources/less/vars.less
+++ b/resources/less/vars.less
@@ -30,5 +30,3 @@
 @separator-color: #E6E6E6;
 @sg-color-red: #e44e4e;
 @sg-color-gray: #aeaeae;
-@disabled-gray: #9b9b9b;
-@disabled-gray-background: #f4f4f4;

--- a/resources/less/vars.less
+++ b/resources/less/vars.less
@@ -28,6 +28,7 @@
 @input-font: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 @modal-shadow: 0 1px 3px 0 rgba(0,0,0,0.30);
 @separator-color: #E6E6E6;
-
 @sg-color-red: #e44e4e;
 @sg-color-gray: #aeaeae;
+@disabled-gray: #9b9b9b;
+@disabled-gray-background: #f4f4f4;

--- a/resources/spec/hakijaEditSpec.js
+++ b/resources/spec/hakijaEditSpec.js
@@ -22,7 +22,7 @@
         })
       )
       it('with complete form', function () {
-        expect(formFields().length).to.equal(14)
+        expect(formFields().length).to.equal(25)
         expect(submitButton().prop('disabled')).to.equal(false)
         expect(formHeader().text()).to.equal('Testilomake')
         expect(submitButton().prop('disabled')).to.equal(false)
@@ -35,6 +35,16 @@
           return $(e).val()
         })
         var expectedTestInputValues = [
+          "Etunimi",
+          "Etunimi",
+          "Sukunimi",
+          "***********",
+          "test@example.com",
+          "0123456789",
+          "Katutie 12 B",
+          "40100",
+          "JYVÄSKYLÄ",
+          "Jyväskylä",
           "Tekstikentän vastaus",
           "Toistuva vastaus 1",
           "Toistuva vastaus 3",
@@ -51,6 +61,8 @@
           return $(e).text()
         })
         var expectedDropdownInputValues = [
+          "Suomi",
+          "suomi",
           "Kolmas vaihtoehto",
           "Lisensiaatin tutkinto",
           ""
@@ -69,8 +81,8 @@
 
     describe('changing values to be invalid', function () {
       before(
-        setNthFieldValue(9, 'textarea', ''),
-        clickNthFieldRadio(12, 'Ensimmäinen vaihtoehto')
+        setNthFieldValue(20, 'textarea', ''),
+        clickNthFieldRadio(23, 'Ensimmäinen vaihtoehto')
       )
 
       it('shows invalidity errors', function () {
@@ -83,8 +95,8 @@
 
     describe('change values and save', function () {
       before(
-        setNthFieldValue(9, 'textarea', 'Muokattu vastaus'),
-        clickNthFieldRadio(12, 'Toinen vaihtoehto'),
+        setNthFieldValue(20, 'textarea', 'Muokattu vastaus'),
+        clickNthFieldRadio(23, 'Toinen vaihtoehto'),
         clickElement(function () {
           return submitButton()
         }),
@@ -98,7 +110,18 @@
           return $(e).text()
         })
         var expectedValues = [
-          "Jos haluat muuttaa henkilötietojasi, ota yhteyttä hakemaasi oppilaitokseen.",
+          "Etunimi",
+          "Etunimi",
+          "Sukunimi",
+          "Suomi",
+          "***********",
+          "test@example.com",
+          "0123456789",
+          "Katutie 12 B",
+          "40100",
+          "JYVÄSKYLÄ",
+          "Jyväskylä",
+          "suomi",
           "Tekstikentän vastaus",
           "Toistuva vastaus 1Toistuva vastaus 3",
           "Pakollisen tekstialueen vastaus",

--- a/spec/ataru/browser_tests.clj
+++ b/spec/ataru/browser_tests.clj
@@ -75,8 +75,8 @@
                                 "bin/phantomjs-runner.js" "hakija" (:key latest-form))]
                   (println (:out results))
                   (.println System/err (:err results))
-                  (should= 0 (:exit results))))
-              (throw (Exception. "No test form found.")))
+                  (should= 0 (:exit results)))
+                (throw (Exception. "No test form found."))))
 
           (it "can edit an application successfully"
               (if-let [latest-application (first (application-store/get-application-list-by-form (:key (get-latest-form))))]

--- a/spec/ataru/browser_tests.clj
+++ b/spec/ataru/browser_tests.clj
@@ -67,27 +67,31 @@
           (around-all [specs]
                       (run-specs-in-hakija-system specs))
           (it "can fill a form successfully"
-              (let [results (sh-timeout
-                              120
-                              "node_modules/phantomjs-prebuilt/bin/phantomjs"
-                              "--web-security" "false"
-                              "bin/phantomjs-runner.js" "hakija" (:key (get-latest-form)))]
-                (println (:out results))
-                (.println System/err (:err results))
-                (should= 0 (:exit results))))
+              (if-let [latest-form (get-latest-form)]
+                (let [results (sh-timeout
+                                120
+                                "node_modules/phantomjs-prebuilt/bin/phantomjs"
+                                "--web-security" "false"
+                                "bin/phantomjs-runner.js" "hakija" (:key latest-form))]
+                  (println (:out results))
+                  (.println System/err (:err results))
+                  (should= 0 (:exit results))))
+              (throw (Exception. "No test form found.")))
+
           (it "can edit an application successfully"
-              (let [latest-application (first (application-store/get-application-list-by-form (:key (get-latest-form))))
-                    secret (-> latest-application
-                               :id
-                               (application-store/get-application)
-                               :secret)
-                    results            (sh-timeout
-                                         120
-                                         "node_modules/phantomjs-prebuilt/bin/phantomjs"
-                                         "--web-security" "false"
-                                         "bin/phantomjs-runner.js" "hakija-edit" secret)]
-                (println (:out results))
-                (.println System/err (:err results))
-                (should= 0 (:exit results)))))
+              (if-let [latest-application (first (application-store/get-application-list-by-form (:key (get-latest-form))))]
+                (let [secret  (-> latest-application
+                                  :id
+                                  (application-store/get-application)
+                                  :secret)
+                      results (sh-timeout
+                                120
+                                "node_modules/phantomjs-prebuilt/bin/phantomjs"
+                                "--web-security" "false"
+                                "bin/phantomjs-runner.js" "hakija-edit" secret)]
+                  (println (:out results))
+                  (.println System/err (:err results))
+                  (should= 0 (:exit results)))
+                (throw (Exception. "No test application found.")))))
 
 (run-specs)

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -9,7 +9,8 @@
     [ataru.forms.form-store :as form-store]
     [ataru.hakija.validator :as validator]
     [ataru.applications.application-store :as application-store]
-    [ataru.hakija.forbidden-fields :refer [viewing-forbidden-person-info-field-ids editing-forbidden-person-info-field-ids]]))
+    [ataru.hakija.editing-forbidden-fields :refer [viewing-forbidden-person-info-field-ids
+                                                   editing-forbidden-person-info-field-ids]]))
 
 (defn- store-and-log [application store-fn]
   (let [application-id (store-fn application)]

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -1,17 +1,15 @@
 (ns ataru.hakija.hakija-application-service
   (:require
-   [taoensso.timbre :as log]
-   [ataru.background-job.job :as job]
-   [ataru.hakija.background-jobs.hakija-jobs :as hakija-jobs]
-   [ataru.hakija.application-email-confirmation :as application-email]
-   [ataru.person-service.person-integration :as person-integration]
-   [ataru.tarjonta-service.hakuaika :as hakuaika]
-   [ataru.forms.form-store :as form-store]
-   [ataru.hakija.validator :as validator]
-   [ataru.applications.application-store :as application-store]))
-
-(def ^:private viewing-forbidden-person-info-field-ids #{:ssn :birth-date})
-(def ^:private editing-forbidden-person-info-field-ids #{:nationality :have-finnish-ssn})
+    [taoensso.timbre :as log]
+    [ataru.background-job.job :as job]
+    [ataru.hakija.background-jobs.hakija-jobs :as hakija-jobs]
+    [ataru.hakija.application-email-confirmation :as application-email]
+    [ataru.person-service.person-integration :as person-integration]
+    [ataru.tarjonta-service.hakuaika :as hakuaika]
+    [ataru.forms.form-store :as form-store]
+    [ataru.hakija.validator :as validator]
+    [ataru.applications.application-store :as application-store]
+    [ataru.hakija.forbidden-fields :refer [viewing-forbidden-person-info-field-ids editing-forbidden-person-info-field-ids]]))
 
 (defn- store-and-log [application store-fn]
   (let [application-id (store-fn application)]

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -51,8 +51,9 @@
 (defn- merge-uneditable-answers-from-previous
   [old-application new-application]
   (let [new-answers                 (:answers new-application)
-        uneditable-answers          (filter :cannot-edit new-answers)
-        editable-answers            (remove :cannot-edit new-answers)
+        uneditable-or-unviewable    #(or (:cannot-edit %) (:cannot-view %))
+        uneditable-answers          (filter uneditable-or-unviewable new-answers)
+        editable-answers            (remove uneditable-or-unviewable new-answers)
         merged-answers              (into editable-answers
                                           (uneditable-answers-with-labels-from-new
                                             uneditable-answers

--- a/src/cljc/ataru/hakija/editing_forbidden_fields.cljc
+++ b/src/cljc/ataru/hakija/editing_forbidden_fields.cljc
@@ -1,4 +1,4 @@
-(ns ataru.hakija.forbidden-fields)
+(ns ataru.hakija.editing-forbidden-fields)
 
 (def viewing-forbidden-person-info-field-ids #{:ssn :birth-date})
 (def editing-forbidden-person-info-field-ids #{:nationality :have-finnish-ssn})

--- a/src/cljc/ataru/hakija/forbidden_fields.cljc
+++ b/src/cljc/ataru/hakija/forbidden_fields.cljc
@@ -1,0 +1,4 @@
+(ns ataru.hakija.forbidden-fields)
+
+(def viewing-forbidden-person-info-field-ids #{:ssn :birth-date})
+(def editing-forbidden-person-info-field-ids #{:nationality :have-finnish-ssn})

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -150,6 +150,7 @@
                                                                   "singleChoice"
                                                                   "attachment"])
                      (s/optional-key :cannot-edit) s/Bool
+                     (s/optional-key :cannot-view) s/Bool
                      (s/optional-key :label)       (s/maybe (s/cond-pre
                                                               LocalizedString
                                                               s/Str))})

--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -57,13 +57,14 @@
 
 (defn- create-answers-to-submit [answers form ui]
   (let [flat-form-map (form->flat-form-map form)]
-    (for [[ans-key {:keys [value values cannot-edit]}] (remove-invisible-followup-values answers flat-form-map ui)
+    (for [[ans-key {:keys [value values cannot-edit cannot-view]}] (remove-invisible-followup-values answers flat-form-map ui)
           :let [field-map    (get flat-form-map (name ans-key))
                 field-type   (:fieldType field-map)
                 label        (:label field-map)]
           :when (or
                   values
                   cannot-edit
+                  cannot-view
                   ; permit empty dropdown values, because server side validation expects to match form fields to answers
                   (and (empty? value) (= "dropdown" field-type))
                   (and (not-empty value) (not (:exclude-from-answers field-map))))]
@@ -73,7 +74,8 @@
                             (map (partial value->str field-map) values))
                :fieldType field-type
                :label     label}
-        cannot-edit (assoc :cannot-edit true)))))
+              cannot-edit (assoc :cannot-edit true)
+              cannot-view (assoc :cannot-view true)))))
 
 (defn create-application-to-submit [application form lang]
   (let [secret (:secret application)]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -19,7 +19,7 @@
             [taoensso.timbre :refer-macros [spy debug]]
             [ataru.feature-config :as fc]
             [clojure.string :as string]
-            [ataru.hakija.forbidden-fields :refer [viewing-forbidden-person-info-field-ids editing-forbidden-person-info-field-ids]])
+            [ataru.hakija.editing-forbidden-fields :refer [viewing-forbidden-person-info-field-ids editing-forbidden-person-info-field-ids]])
   (:import (goog.html.sanitizer HtmlSanitizer)))
 
 (defonce builder (new HtmlSanitizer.Builder))
@@ -268,7 +268,8 @@
         default-lang (subscribe [:application/default-language])
         secret       (subscribe [:state-query [:application :secret]])
         disabled?    (reaction (or
-                                 (contains? editing-forbidden-person-info-field-ids (keyword (:id field-descriptor)))
+                                 (and @editing
+                                      (contains? editing-forbidden-person-info-field-ids (keyword (:id field-descriptor))))
                                  (->
                                    (:answers @application)
                                    (get (answer-key field-descriptor))

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -40,7 +40,9 @@
 
 (defn- field-value-valid?
   [field-data value]
-  (if (and (not (:cannot-edit field-data))
+  (if (and (not (or
+                  (:cannot-view field-data)
+                  (:cannot-edit field-data)))
            (not-empty (:validators field-data)))
     (every? true? (map #(validator/validate % value)
                     (:validators field-data)))
@@ -108,10 +110,9 @@
       (when-let [info (@language (some-> field-descriptor :params :info-text :label))]
         [markdown-paragraph info]))))
 
-(defn text-field [field-descriptor & {:keys [div-kwd disabled] :or {div-kwd :div.application__form-field disabled false}}]
+(defn text-field [field-descriptor & {:keys [div-kwd disabled editing] :or {div-kwd :div.application__form-field disabled false editing false}}]
   (let [id           (keyword (:id field-descriptor))
-        value        (subscribe [:state-query [:application :answers id :value]])
-        valid?       (subscribe [:state-query [:application :answers id :valid]])
+        answer        (subscribe [:state-query [:application :answers id]])
         lang         (subscribe [:application/form-language])
         default-lang (subscribe [:application/default-language])
         size-class (text-field-size->class (get-in field-descriptor [:params :size]))]
@@ -120,18 +121,19 @@
        [label field-descriptor]
        [:div.application__form-text-input-info-text
         [info-text field-descriptor]]
-       [:input.application__form-text-input
-        (merge {:id          id
-                :type        "text"
-                :placeholder (when-let [input-hint (-> field-descriptor :params :placeholder)]
-                               (non-blank-val (get input-hint @lang)
-                                              (get input-hint @default-lang)))
-                :class       (str size-class (if (show-text-field-error-class? field-descriptor @value @valid?)
-                                               " application__form-field-error"
-                                               " application__form-text-input--normal"))
-                :value       @value
-                :on-change   (partial textual-field-change field-descriptor)}
-          (when disabled {:disabled true}))]])))
+       (let [cannot-view? (and editing (:cannot-view @answer))]
+         [:input.application__form-text-input
+          (merge {:id          id
+                  :type        "text"
+                  :placeholder (when-let [input-hint (-> field-descriptor :params :placeholder)]
+                                 (non-blank-val (get input-hint @lang)
+                                                (get input-hint @default-lang)))
+                  :class       (str size-class (if (show-text-field-error-class? field-descriptor (:value @answer) (:valid @answer))
+                                                 " application__form-field-error"
+                                                 " application__form-text-input--normal"))
+                  :value       (if cannot-view? "***********" (:value @answer))
+                  :on-change   (partial textual-field-change field-descriptor)}
+                 (when (or disabled cannot-view?) {:disabled true}))])])))
 
 (defn repeatable-text-field [field-descriptor & {:keys [div-kwd] :or {div-kwd :div.application__form-field}}]
   (let [id         (keyword (:id field-descriptor))
@@ -259,17 +261,21 @@
                                       [render-field followup]]))))})))
 
 (defn dropdown
-  [field-descriptor & {:keys [div-kwd] :or {div-kwd :div.application__form-field}}]
+  [field-descriptor & {:keys [div-kwd editing] :or {div-kwd :div.application__form-field editing false}}]
   (let [application  (subscribe [:state-query [:application]])
         lang         (subscribe [:application/form-language])
         default-lang (subscribe [:application/default-language])
         secret       (subscribe [:state-query [:application :secret]])
+        disabled?    (reaction (->
+                                 (:answers @application)
+                                 (get (answer-key field-descriptor))
+                                 :cannot-edit))
         value        (reaction
                        (or (->
                              (:answers @application)
                              (get (answer-key field-descriptor))
                              :value)
-                         ""))]
+                           ""))]
     (r/create-class
       {:component-did-mount (partial init-dropdown-value field-descriptor @lang @secret)
        :reagent-render      (fn [field-descriptor]
@@ -281,21 +287,23 @@
                                   [:div.application__form-text-input-info-text
                                    [info-text field-descriptor]]
                                   [:div.application__form-select-wrapper
-                                   [:span.application__form-select-arrow]
-                                   [:select.application__form-select
-                                    {:value @value
-                                     :on-change (partial textual-field-change field-descriptor)}
+                                   (when (not @disabled?)
+                                     [:span.application__form-select-arrow])
+                                   [(keyword (str "select.application__form-select" (when @disabled? ".application__form-select--disabled")))
+                                    {:value     @value
+                                     :on-change (partial textual-field-change field-descriptor)
+                                     :disabled  @disabled?}
                                     (concat
                                       (when
-                                          (and
-                                            (nil? (:koodisto-source field-descriptor))
-                                            (not (:no-blank-option field-descriptor))
-                                            (not= "" (:value (first (:options field-descriptor)))))
+                                        (and
+                                          (nil? (:koodisto-source field-descriptor))
+                                          (not (:no-blank-option field-descriptor))
+                                          (not= "" (:value (first (:options field-descriptor)))))
                                         [^{:key (str "blank-" (:id field-descriptor))} [:option {:value ""} ""]])
                                       (map-indexed
                                         (fn [idx option]
                                           (let [label        (non-blank-val (get-in option [:label lang])
-                                                               (get-in option [:label default-lang]))
+                                                                            (get-in option [:label default-lang]))
                                                 option-value (:value option)]
                                             ^{:key idx}
                                             [:option {:value option-value} label]))
@@ -547,22 +555,6 @@
                          (dispatch [:application/add-adjacent-fields field-descriptor]))}
             [:i.zmdi.zmdi-plus-square] (str " " (:add-row translations))])]))))
 
-(defn- editing-forbidden-module
-  [field-descriptor]
-  (let [lang         (subscribe [:application/form-language])
-        default-lang (subscribe [:application/default-language])]
-    (fn [field-descriptor]
-      (let [label   (non-blank-val (get-in field-descriptor [:label @lang])
-                                   (get-in field-descriptor [:label @default-lang]))
-            content (:cannot-edit-personal-info (get-translations @lang application-view-translations))]
-        [:div.application__wrapper-element.application__wrapper-element--border
-         [:div.application__wrapper-heading
-          [:h2 label]
-          [scroll-to-anchor field-descriptor]]
-          [:div.application__wrapper-contents
-           [:div.application__form-info-element.application__form-field
-            [:span content]]]]))))
-
 (defn- feature-enabled? [{:keys [fieldType]}]
   (or (not= fieldType "attachment")
       (fc/feature-enabled? :attachment)))
@@ -576,28 +568,26 @@
     (fn [field-descriptor & args]
       (if (feature-enabled? field-descriptor)
         (let [disabled? (get-in @ui [(keyword (:id field-descriptor)) :disabled?] false)]
-          (if (and @editing? (= (:module field-descriptor) "person-info"))
-            [editing-forbidden-module field-descriptor]
-            (cond-> (match field-descriptor
-                           {:fieldClass "wrapperElement"
-                            :fieldType  "fieldset"
-                            :children   children} [wrapper-field field-descriptor children]
-                           {:fieldClass "wrapperElement"
-                            :fieldType  "rowcontainer"
-                            :children   children} [row-wrapper children]
-                           {:fieldClass "formField"
-                            :id         (_ :guard (complement visible?))} [:div]
-                           {:fieldClass "formField" :fieldType "textField" :params {:repeatable true}} [repeatable-text-field field-descriptor]
-                           {:fieldClass "formField" :fieldType "textField"} [text-field field-descriptor :disabled disabled?]
-                           {:fieldClass "formField" :fieldType "textArea"} [text-area field-descriptor]
-                           {:fieldClass "formField" :fieldType "dropdown"} [dropdown field-descriptor]
-                           {:fieldClass "formField" :fieldType "multipleChoice"} [multiple-choice field-descriptor]
-                           {:fieldClass "formField" :fieldType "singleChoice"} [single-choice-button field-descriptor]
-                           {:fieldClass "formField" :fieldType "attachment"} [attachment field-descriptor]
-                           {:fieldClass "infoElement"} [info-element field-descriptor]
-                           {:fieldClass "wrapperElement" :fieldType "adjacentfieldset"} [adjacent-text-fields field-descriptor])
-              (and (empty? (:children field-descriptor))
-                   (visible? (:id field-descriptor))) (into args))))
+          (cond-> (match field-descriptor
+                         {:fieldClass "wrapperElement"
+                          :fieldType  "fieldset"
+                          :children   children} [wrapper-field field-descriptor children]
+                         {:fieldClass "wrapperElement"
+                          :fieldType  "rowcontainer"
+                          :children   children} [row-wrapper children]
+                         {:fieldClass "formField"
+                          :id         (_ :guard (complement visible?))} [:div]
+                         {:fieldClass "formField" :fieldType "textField" :params {:repeatable true}} [repeatable-text-field field-descriptor]
+                         {:fieldClass "formField" :fieldType "textField"} [text-field field-descriptor :disabled disabled? :editing editing?]
+                         {:fieldClass "formField" :fieldType "textArea"} [text-area field-descriptor]
+                         {:fieldClass "formField" :fieldType "dropdown"} [dropdown field-descriptor :editing editing?]
+                         {:fieldClass "formField" :fieldType "multipleChoice"} [multiple-choice field-descriptor]
+                         {:fieldClass "formField" :fieldType "singleChoice"} [single-choice-button field-descriptor]
+                         {:fieldClass "formField" :fieldType "attachment"} [attachment field-descriptor]
+                         {:fieldClass "infoElement"} [info-element field-descriptor]
+                         {:fieldClass "wrapperElement" :fieldType "adjacentfieldset"} [adjacent-text-fields field-descriptor])
+                  (and (empty? (:children field-descriptor))
+                       (visible? (:id field-descriptor))) (into args)))
         [:div]))))
 
 (defn editable-fields [form-data]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -293,7 +293,7 @@
                                   [:div.application__form-select-wrapper
                                    (when (not @disabled?)
                                      [:span.application__form-select-arrow])
-                                   [(keyword (str "select.application__form-select" (when @disabled? ".application__form-select--disabled")))
+                                   [(keyword (str "select.application__form-select" (when (not @disabled?) ".application__form-select--enabled")))
                                     {:value     @value
                                      :on-change (partial textual-field-change field-descriptor)
                                      :disabled  @disabled?}

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -18,7 +18,8 @@
             [reagent.core :as r]
             [taoensso.timbre :refer-macros [spy debug]]
             [ataru.feature-config :as fc]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [ataru.hakija.forbidden-fields :refer [viewing-forbidden-person-info-field-ids editing-forbidden-person-info-field-ids]])
   (:import (goog.html.sanitizer HtmlSanitizer)))
 
 (defonce builder (new HtmlSanitizer.Builder))
@@ -266,10 +267,12 @@
         lang         (subscribe [:application/form-language])
         default-lang (subscribe [:application/default-language])
         secret       (subscribe [:state-query [:application :secret]])
-        disabled?    (reaction (->
-                                 (:answers @application)
-                                 (get (answer-key field-descriptor))
-                                 :cannot-edit))
+        disabled?    (reaction (or
+                                 (contains? editing-forbidden-person-info-field-ids (keyword (:id field-descriptor)))
+                                 (->
+                                   (:answers @application)
+                                   (get (answer-key field-descriptor))
+                                   :cannot-edit)))
         value        (reaction
                        (or (->
                              (:answers @application)

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -163,7 +163,7 @@
   (-> db
       (update-in [:application :answers]
         (fn [answers]
-          (reduce (fn [answers {:keys [key value cannot-edit] :as answer}]
+          (reduce (fn [answers {:keys [key value cannot-edit cannot-view] :as answer}]
                     (let [answer-key (keyword key)
                           value      (cond-> value
                                              (and (vector? value)
@@ -189,7 +189,7 @@
 
                                  :else
                                  (update answers answer-key merge {:valid true :value value}))
-                          answer-key merge {:cannot-edit cannot-edit})
+                          answer-key merge {:cannot-edit cannot-edit :cannot-view cannot-view})
                         answers)))
                   answers
                   submitted-answers)))

--- a/src/cljs/ataru/hakija/hakija_readonly.cljs
+++ b/src/cljs/ataru/hakija/hakija_readonly.cljs
@@ -21,10 +21,11 @@
 
 (defn text [field-descriptor application lang]
   (let [answer ((answer-key field-descriptor) (:answers application))]
-    (when-not (:cannot-edit answer)
-      [:div.application__form-field
-       [:label.application__form-field-label
-        (str (-> field-descriptor :label lang) (required-hint field-descriptor))]
+    [:div.application__form-field
+     [:label.application__form-field-label
+      (str (-> field-descriptor :label lang) (required-hint field-descriptor))]
+     (if (:cannot-view answer)
+       [:div "***********"]
        [:div
         (let [repeatable?  (-> field-descriptor :params :repeatable)
               values       (if repeatable? (map :value (:values answer)) (:value answer))
@@ -33,7 +34,7 @@
                              (or (seq? values) (vector? values)))]
           (cond
             multi-value? (into [:ul.application__form-field-list] (for [value values] [:li value]))
-            :else (textual-field-value field-descriptor application :lang lang)))]])))
+            :else (textual-field-value field-descriptor application :lang lang)))])]))
 
 (defn attachment [field-descriptor application lang]
   (let [answer-key (keyword (answer-key field-descriptor))
@@ -138,9 +139,7 @@
 (defn field
   [content application lang]
   (match content
-         {:fieldClass "wrapperElement" :module "person-info" :children children} (if (:editing? application)
-                                                                                   [person-info-uneditable-wrapper content lang]
-                                                                                   [wrapper content application lang children])
+         {:fieldClass "wrapperElement" :module "person-info" :children children} [wrapper content application lang children]
          {:fieldClass "wrapperElement" :fieldType "fieldset" :children children} [wrapper content application lang children]
          {:fieldClass "wrapperElement" :fieldType "rowcontainer" :children children} [row-container application lang children]
          {:fieldClass "wrapperElement" :fieldType "adjacentfieldset" :children children} [fieldset content application lang children]


### PR DESCRIPTION
Make application editing great again!

Can now edit person info fields, except for:

* SSN
* Nationality
* Birth date

Fields can not be flagged as `cannot-view` whose values cannot be seen when editing an application and `cannot-edit` whose values can be seen but not changed.
