### PR TITLE
Fix project.clj so that `lein ancient` works

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,7 @@
                  [org.http4s/blaze-http_2.11 "0.10.1"]
                  [org.http4s/http4s-json4s-native_2.11 "0.10.1"]
                  ;; And naturally this exclusion is important as well
-                 [oph/clj-util "0.1.0" :exclusions [org.http4s/blaze-http_2.11/clojure]]
+                 [oph/clj-util "0.1.0" :exclusions [org.http4s/blaze-http_2.11]]
                  [ring.middleware.logger "0.5.0"]
                  [ring/ring-session-timeout "0.2.0"]
                  [org.clojure/tools.logging "0.3.1"]


### PR DESCRIPTION
I don't know what the `/clojure` suffix was doing there. I tested that oppijanumerorekisteri integration still seems to work locally for me.