### PR TITLE
Fix virkailija view of attachments

### DIFF
--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -131,6 +131,7 @@
    :filename                 s/Str
    :size                     s/Int
    :virus-scan-status        s/Str
+   :final                    s/Bool
    :uploaded                 #?(:clj  org.joda.time.DateTime
                                 :cljs #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
    (s/optional-key :deleted) (s/maybe #?(:clj  org.joda.time.DateTime


### PR DESCRIPTION
This was broken when we added the `final` key to attachments. 