### PR TITLE
Upgrade dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,6 +40,7 @@
                  [bk/ring-gzip "0.2.1"]
                  [buddy/buddy-auth "1.4.1"]
                  [yesql "0.5.3"]
+                 ; Flyway 4 breaks our migrations
                  [org.flywaydb/flyway-core "3.2.1" :upgrade false]
                  [camel-snake-kebab "0.4.0"]
                  [environ "1.1.0"]
@@ -56,8 +57,10 @@
                  ;; Used by clj-util below. Without these, we would not be able to
                  ;; authenticate to /oppijanumerorekisteri-service, we would just get:
                  ;; BadResponse Response lacks status Reason  [trace missing]
-                 [org.http4s/blaze-http_2.11 "0.13.0"]
-                 [org.http4s/http4s-json4s-native_2.11 "0.15.9"]
+                 ;; We can't upgrade these either. Looks like Cas requires a specific
+                 ;; version, and it's this one.
+                 [org.http4s/blaze-http_2.11 "0.10.1" :upgrade false]
+                 [org.http4s/http4s-json4s-native_2.11 "0.10.1" :upgrade false]
                  ;; And naturally this exclusion is important as well
                  [oph/clj-util "0.1.0" :exclusions [org.http4s/blaze-http_2.11]]
                  [ring.middleware.logger "0.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -2,74 +2,74 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
 
                  ; clojurescript
-                 [org.clojure/clojurescript "1.9.293"]
-                 [reagent "0.6.0"]                          ; react in clojure
-                 [re-frame "0.9.1"]                         ; flux for re-agent
+                 [org.clojure/clojurescript "1.9.521"]
+                 [reagent "0.6.1"]                          ; react in clojure
+                 [re-frame "0.9.2"]                         ; flux for re-agent
                  [secretary "1.2.3"]                        ; routing
                  [com.andrewmcveigh/cljs-time "0.4.0"]
                  [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
-                 [cljs-ajax "0.5.8"]
-                 [binaryage/devtools "0.8.3"]
-                 [re-frisk "0.3.2"]                         ; will only be used in development side
-                 [venantius/accountant "0.1.7"]
+                 [cljs-ajax "0.5.9"]
+                 [binaryage/devtools "0.9.4"]
+                 [re-frisk "0.4.4"]                         ; will only be used in development side
+                 [venantius/accountant "0.1.9"]
                  [com.cemerick/url "0.1.1"]
 
                  ;clojure/clojurescript
-                 [prismatic/schema "1.1.3"]
-                 [com.taoensso/timbre "4.8.0"]
-                 [org.clojure/core.async "0.2.395"]
+                 [prismatic/schema "1.1.5"]
+                 [com.taoensso/timbre "4.10.0"]
+                 [org.clojure/core.async "0.3.442"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [metosin/schema-tools "0.9.0"]
-                 [medley "0.8.4"]
-                 [markdown-clj "0.9.97"]
+                 [medley "1.0.0"]
+                 [markdown-clj "0.9.99"]
 
                  ;clojure
-                 [compojure "1.5.1"]
+                 [compojure "1.5.2"]
                  [crypto-random "1.2.0"]
                  [com.github.fge/json-patch "1.9"]
                  [com.stuartsierra/component "0.3.2"]
-                 [metosin/compojure-api "1.1.9"]
-                 [aleph "0.4.1"]
+                 [metosin/compojure-api "1.1.10"]
+                 [aleph "0.4.3"]
                  [fi.vm.sade/auditlogger "5.0.0-SNAPSHOT"]
                  [fi.vm.sade.java-utils/java-properties "0.1.0-SNAPSHOT"]
                  [http-kit "2.2.0"]
-                 [ring "1.5.0"]
-                 [ring/ring-defaults "0.2.1"]
+                 [ring "1.5.1"]
+                 [ring/ring-defaults "0.2.3"]
                  [ring/ring-json "0.4.0"]
                  [ring-ratelimit "0.2.2"]
-                 [bk/ring-gzip "0.2.0"]
-                 [buddy/buddy-auth "1.3.0"]
+                 [bk/ring-gzip "0.2.1"]
+                 [buddy/buddy-auth "1.4.1"]
                  [yesql "0.5.3"]
-                 [org.flywaydb/flyway-core "3.2.1"]
+                 [org.flywaydb/flyway-core "4.1.2"]
                  [camel-snake-kebab "0.4.0"]
                  [environ "1.1.0"]
-                 [org.clojure/core.async "0.2.395"]
+                 [org.clojure/core.async "0.3.442"]
                  [org.clojure/java.jdbc "0.6.1"]
-                 [org.postgresql/postgresql "9.4.1212"]
+                 [org.postgresql/postgresql "42.0.0"]
                  [clj-time "0.13.0"]
                  [cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
-                 [cheshire/cheshire "5.6.3"]
-                 [selmer "1.10.3"]
-                 [metosin/ring-http-response "0.8.0"]
+                 [cheshire/cheshire "5.7.1"]
+                 [selmer "1.10.7"]
+                 [metosin/ring-http-response "0.8.2"]
                  ;; These two explicit dependencies are required to force
                  ;; newer, fixed versions of those which come with Scala Cas Client
                  ;; Used by clj-util below. Without these, we would not be able to
                  ;; authenticate to /oppijanumerorekisteri-service, we would just get:
                  ;; BadResponse Response lacks status Reason  [trace missing]
-                 [org.http4s/blaze-http_2.11 "0.10.1"]
-                 [org.http4s/http4s-json4s-native_2.11 "0.10.1"]
+                 [org.http4s/blaze-http_2.11 "0.10.1" :upgrade false]
+                 [org.http4s/http4s-json4s-native_2.11 "0.10.1" :upgrade false]
                  ;; And naturally this exclusion is important as well
                  [oph/clj-util "0.1.0" :exclusions [org.http4s/blaze-http_2.11]]
                  [ring.middleware.logger "0.5.0"]
                  [ring/ring-session-timeout "0.2.0"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [org.apache.poi/poi-ooxml "3.15"]
+                 [org.apache.poi/poi-ooxml "3.16"]
                  [org.clojars.pntblnk/clj-ldap "0.0.12"]
                  [org.clojure/core.cache "0.6.5"]
-                 [org.clojure/tools.nrepl "0.2.12"]
-                 [com.hazelcast/hazelcast "3.7.5"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [com.hazelcast/hazelcast "3.8.1"]
                  [pandect "0.6.1"]
-                 [hikari-cp "1.3.0" :exclusions [prismatic/schema]]]
+                 [hikari-cp "1.7.5" :exclusions [prismatic/schema]]]
 
   :min-lein-version "2.5.3"
 
@@ -93,7 +93,7 @@
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-doo "0.1.7"]
-            [lein-figwheel "0.5.8"]
+            [lein-figwheel "0.5.10"]
             [lein-less "1.7.5"]
             [lein-ancient "0.6.10"]
             [lein-environ "1.1.0"]
@@ -190,14 +190,14 @@
 
   :profiles {:repl           {:plugins [[cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]]}
              :dev            {:dependencies   [[com.cemerick/piggieback "0.2.1"]
-                                               [figwheel-sidecar "0.5.8"]
-                                               [refactor-nrepl "2.2.0"]
+                                               [figwheel-sidecar "0.5.10"]
+                                               [refactor-nrepl "2.3.0"]
                                                [snipsnap "0.2.0" :exclusions [org.clojure/clojure]]
                                                [reloaded.repl "0.2.3"]
                                                [ring/ring-mock "0.3.0"]
                                                [speclj "3.3.2"]
                                                [speclj-junit "0.0.11-20151116.130002-1"]]
-                              :plugins        [[refactor-nrepl "2.2.0"]
+                              :plugins        [[refactor-nrepl "2.3.0"]
                                                [cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
                                                [lein-cljfmt "0.5.6"]
                                                [lein-kibit "0.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -2,74 +2,74 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
 
                  ; clojurescript
-                 [org.clojure/clojurescript "1.9.293"]
-                 [reagent "0.6.0"]                          ; react in clojure
-                 [re-frame "0.9.1"]                         ; flux for re-agent
+                 [org.clojure/clojurescript "1.9.521"]
+                 [reagent "0.6.1"]                          ; react in clojure
+                 [re-frame "0.9.2"]                         ; flux for re-agent
                  [secretary "1.2.3"]                        ; routing
                  [com.andrewmcveigh/cljs-time "0.4.0"]
                  [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
-                 [cljs-ajax "0.5.8"]
-                 [binaryage/devtools "0.8.3"]
-                 [re-frisk "0.3.2"]                         ; will only be used in development side
-                 [venantius/accountant "0.1.7"]
+                 [cljs-ajax "0.5.9"]
+                 [binaryage/devtools "0.9.4"]
+                 [re-frisk "0.4.4"]                         ; will only be used in development side
+                 [venantius/accountant "0.1.9"]
                  [com.cemerick/url "0.1.1"]
 
                  ;clojure/clojurescript
-                 [prismatic/schema "1.1.3"]
-                 [com.taoensso/timbre "4.8.0"]
-                 [org.clojure/core.async "0.2.395"]
+                 [prismatic/schema "1.1.5"]
+                 [com.taoensso/timbre "4.10.0"]
+                 [org.clojure/core.async "0.3.442"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [metosin/schema-tools "0.9.0"]
-                 [medley "0.8.4"]
-                 [markdown-clj "0.9.97"]
+                 [medley "1.0.0"]
+                 [markdown-clj "0.9.99"]
 
                  ;clojure
-                 [compojure "1.5.1"]
+                 [compojure "1.5.2"]
                  [crypto-random "1.2.0"]
                  [com.github.fge/json-patch "1.9"]
                  [com.stuartsierra/component "0.3.2"]
-                 [metosin/compojure-api "1.1.9"]
-                 [aleph "0.4.1"]
+                 [metosin/compojure-api "1.1.10"]
+                 [aleph "0.4.3"]
                  [fi.vm.sade/auditlogger "5.0.0-SNAPSHOT"]
                  [fi.vm.sade.java-utils/java-properties "0.1.0-SNAPSHOT"]
                  [http-kit "2.2.0"]
-                 [ring "1.5.0"]
-                 [ring/ring-defaults "0.2.1"]
+                 [ring "1.5.1"]
+                 [ring/ring-defaults "0.2.3"]
                  [ring/ring-json "0.4.0"]
                  [ring-ratelimit "0.2.2"]
-                 [bk/ring-gzip "0.2.0"]
-                 [buddy/buddy-auth "1.3.0"]
+                 [bk/ring-gzip "0.2.1"]
+                 [buddy/buddy-auth "1.4.1"]
                  [yesql "0.5.3"]
                  [org.flywaydb/flyway-core "3.2.1" :upgrade false]
                  [camel-snake-kebab "0.4.0"]
                  [environ "1.1.0"]
-                 [org.clojure/core.async "0.2.395"]
+                 [org.clojure/core.async "0.3.442"]
                  [org.clojure/java.jdbc "0.6.1"]
-                 [org.postgresql/postgresql "9.4.1212"]
+                 [org.postgresql/postgresql "42.0.0"]
                  [clj-time "0.13.0"]
                  [cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
-                 [cheshire/cheshire "5.6.3"]
-                 [selmer "1.10.3"]
-                 [metosin/ring-http-response "0.8.0"]
+                 [cheshire/cheshire "5.7.1"]
+                 [selmer "1.10.7"]
+                 [metosin/ring-http-response "0.8.2"]
                  ;; These two explicit dependencies are required to force
                  ;; newer, fixed versions of those which come with Scala Cas Client
                  ;; Used by clj-util below. Without these, we would not be able to
                  ;; authenticate to /oppijanumerorekisteri-service, we would just get:
                  ;; BadResponse Response lacks status Reason  [trace missing]
-                 [org.http4s/blaze-http_2.11 "0.10.1"]
-                 [org.http4s/http4s-json4s-native_2.11 "0.10.1"]
+                 [org.http4s/blaze-http_2.11 "0.13.0"]
+                 [org.http4s/http4s-json4s-native_2.11 "0.15.9"]
                  ;; And naturally this exclusion is important as well
                  [oph/clj-util "0.1.0" :exclusions [org.http4s/blaze-http_2.11]]
                  [ring.middleware.logger "0.5.0"]
                  [ring/ring-session-timeout "0.2.0"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [org.apache.poi/poi-ooxml "3.15"]
+                 [org.apache.poi/poi-ooxml "3.16"]
                  [org.clojars.pntblnk/clj-ldap "0.0.12"]
                  [org.clojure/core.cache "0.6.5"]
-                 [org.clojure/tools.nrepl "0.2.12"]
-                 [com.hazelcast/hazelcast "3.7.5"]
+                 [org.clojure/tools.nrepl "0.2.13"]
+                 [com.hazelcast/hazelcast "3.8.1"]
                  [pandect "0.6.1"]
-                 [hikari-cp "1.3.0" :exclusions [prismatic/schema]]]
+                 [hikari-cp "1.7.5" :exclusions [prismatic/schema]]]
 
   :min-lein-version "2.5.3"
 
@@ -93,7 +93,7 @@
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-doo "0.1.7"]
-            [lein-figwheel "0.5.8"]
+            [lein-figwheel "0.5.10"]
             [lein-less "1.7.5"]
             [lein-ancient "0.6.10"]
             [lein-environ "1.1.0"]
@@ -190,14 +190,14 @@
 
   :profiles {:repl           {:plugins [[cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]]}
              :dev            {:dependencies   [[com.cemerick/piggieback "0.2.1"]
-                                               [figwheel-sidecar "0.5.8"]
-                                               [refactor-nrepl "2.2.0"]
+                                               [figwheel-sidecar "0.5.10"]
+                                               [refactor-nrepl "2.3.0"]
                                                [snipsnap "0.2.0" :exclusions [org.clojure/clojure]]
                                                [reloaded.repl "0.2.3"]
                                                [ring/ring-mock "0.3.0"]
                                                [speclj "3.3.2"]
                                                [speclj-junit "0.0.11-20151116.130002-1"]]
-                              :plugins        [[refactor-nrepl "2.2.0"]
+                              :plugins        [[refactor-nrepl "2.3.0"]
                                                [cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
                                                [lein-cljfmt "0.5.6"]
                                                [lein-kibit "0.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -2,55 +2,55 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
 
                  ; clojurescript
-                 [org.clojure/clojurescript "1.9.521"]
-                 [reagent "0.6.1"]                          ; react in clojure
-                 [re-frame "0.9.2"]                         ; flux for re-agent
+                 [org.clojure/clojurescript "1.9.293"]
+                 [reagent "0.6.0"]                          ; react in clojure
+                 [re-frame "0.9.1"]                         ; flux for re-agent
                  [secretary "1.2.3"]                        ; routing
                  [com.andrewmcveigh/cljs-time "0.4.0"]
                  [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
-                 [cljs-ajax "0.5.9"]
-                 [binaryage/devtools "0.9.4"]
-                 [re-frisk "0.4.4"]                         ; will only be used in development side
-                 [venantius/accountant "0.1.9"]
+                 [cljs-ajax "0.5.8"]
+                 [binaryage/devtools "0.8.3"]
+                 [re-frisk "0.3.2"]                         ; will only be used in development side
+                 [venantius/accountant "0.1.7"]
                  [com.cemerick/url "0.1.1"]
 
                  ;clojure/clojurescript
-                 [prismatic/schema "1.1.5"]
-                 [com.taoensso/timbre "4.10.0"]
-                 [org.clojure/core.async "0.3.442"]
+                 [prismatic/schema "1.1.3"]
+                 [com.taoensso/timbre "4.8.0"]
+                 [org.clojure/core.async "0.2.395"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [metosin/schema-tools "0.9.0"]
-                 [medley "1.0.0"]
-                 [markdown-clj "0.9.99"]
+                 [medley "0.8.4"]
+                 [markdown-clj "0.9.97"]
 
                  ;clojure
-                 [compojure "1.5.2"]
+                 [compojure "1.5.1"]
                  [crypto-random "1.2.0"]
                  [com.github.fge/json-patch "1.9"]
                  [com.stuartsierra/component "0.3.2"]
-                 [metosin/compojure-api "1.1.10"]
-                 [aleph "0.4.3"]
+                 [metosin/compojure-api "1.1.9"]
+                 [aleph "0.4.1"]
                  [fi.vm.sade/auditlogger "5.0.0-SNAPSHOT"]
                  [fi.vm.sade.java-utils/java-properties "0.1.0-SNAPSHOT"]
                  [http-kit "2.2.0"]
-                 [ring "1.5.1"]
-                 [ring/ring-defaults "0.2.3"]
+                 [ring "1.5.0"]
+                 [ring/ring-defaults "0.2.1"]
                  [ring/ring-json "0.4.0"]
                  [ring-ratelimit "0.2.2"]
-                 [bk/ring-gzip "0.2.1"]
-                 [buddy/buddy-auth "1.4.1"]
+                 [bk/ring-gzip "0.2.0"]
+                 [buddy/buddy-auth "1.3.0"]
                  [yesql "0.5.3"]
-                 [org.flywaydb/flyway-core "4.1.2" :upgrade false]
+                 [org.flywaydb/flyway-core "3.2.1" :upgrade false]
                  [camel-snake-kebab "0.4.0"]
                  [environ "1.1.0"]
-                 [org.clojure/core.async "0.3.442"]
+                 [org.clojure/core.async "0.2.395"]
                  [org.clojure/java.jdbc "0.6.1"]
-                 [org.postgresql/postgresql "42.0.0"]
+                 [org.postgresql/postgresql "9.4.1212"]
                  [clj-time "0.13.0"]
                  [cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
-                 [cheshire/cheshire "5.7.1"]
-                 [selmer "1.10.7"]
-                 [metosin/ring-http-response "0.8.2"]
+                 [cheshire/cheshire "5.6.3"]
+                 [selmer "1.10.3"]
+                 [metosin/ring-http-response "0.8.0"]
                  ;; These two explicit dependencies are required to force
                  ;; newer, fixed versions of those which come with Scala Cas Client
                  ;; Used by clj-util below. Without these, we would not be able to
@@ -63,13 +63,13 @@
                  [ring.middleware.logger "0.5.0"]
                  [ring/ring-session-timeout "0.2.0"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [org.apache.poi/poi-ooxml "3.16"]
+                 [org.apache.poi/poi-ooxml "3.15"]
                  [org.clojars.pntblnk/clj-ldap "0.0.12"]
                  [org.clojure/core.cache "0.6.5"]
-                 [org.clojure/tools.nrepl "0.2.13"]
-                 [com.hazelcast/hazelcast "3.8.1"]
+                 [org.clojure/tools.nrepl "0.2.12"]
+                 [com.hazelcast/hazelcast "3.7.5"]
                  [pandect "0.6.1"]
-                 [hikari-cp "1.7.5" :exclusions [prismatic/schema]]]
+                 [hikari-cp "1.3.0" :exclusions [prismatic/schema]]]
 
   :min-lein-version "2.5.3"
 
@@ -93,7 +93,7 @@
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-doo "0.1.7"]
-            [lein-figwheel "0.5.10"]
+            [lein-figwheel "0.5.8"]
             [lein-less "1.7.5"]
             [lein-ancient "0.6.10"]
             [lein-environ "1.1.0"]
@@ -190,14 +190,14 @@
 
   :profiles {:repl           {:plugins [[cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]]}
              :dev            {:dependencies   [[com.cemerick/piggieback "0.2.1"]
-                                               [figwheel-sidecar "0.5.10"]
-                                               [refactor-nrepl "2.3.0"]
+                                               [figwheel-sidecar "0.5.8"]
+                                               [refactor-nrepl "2.2.0"]
                                                [snipsnap "0.2.0" :exclusions [org.clojure/clojure]]
                                                [reloaded.repl "0.2.3"]
                                                [ring/ring-mock "0.3.0"]
                                                [speclj "3.3.2"]
                                                [speclj-junit "0.0.11-20151116.130002-1"]]
-                              :plugins        [[refactor-nrepl "2.3.0"]
+                              :plugins        [[refactor-nrepl "2.2.0"]
                                                [cider/cider-nrepl "0.15.0-SNAPSHOT" :exclusions [org.clojure/clojure]]
                                                [lein-cljfmt "0.5.6"]
                                                [lein-kibit "0.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [bk/ring-gzip "0.2.1"]
                  [buddy/buddy-auth "1.4.1"]
                  [yesql "0.5.3"]
-                 [org.flywaydb/flyway-core "4.1.2"]
+                 [org.flywaydb/flyway-core "4.1.2" :upgrade false]
                  [camel-snake-kebab "0.4.0"]
                  [environ "1.1.0"]
                  [org.clojure/core.async "0.3.442"]
@@ -56,8 +56,8 @@
                  ;; Used by clj-util below. Without these, we would not be able to
                  ;; authenticate to /oppijanumerorekisteri-service, we would just get:
                  ;; BadResponse Response lacks status Reason  [trace missing]
-                 [org.http4s/blaze-http_2.11 "0.10.1" :upgrade false]
-                 [org.http4s/http4s-json4s-native_2.11 "0.10.1" :upgrade false]
+                 [org.http4s/blaze-http_2.11 "0.10.1"]
+                 [org.http4s/http4s-json4s-native_2.11 "0.10.1"]
                  ;; And naturally this exclusion is important as well
                  [oph/clj-util "0.1.0" :exclusions [org.http4s/blaze-http_2.11]]
                  [ring.middleware.logger "0.5.0"]


### PR DESCRIPTION
This needs to be tested in an actual environment. Tests do pass.

I added `:upgrade false` annotations to dependencies we can't upgrade at the moment, so this PR documents that nicely. `lein ancient` will take those into account.

What works:

- [x] Migrations (after running `rm -rf ~/.m2 ~/.lein && lein clean`)
- [x] virkailija-dev
- [x] hakija-dev
- [ ] Tarjonta
- [ ] Henkilöpalvelut
- [ ] Login/logout