### PR TITLE
Fix followup ordering in excel export

### DIFF
--- a/resources/less/virkailija-banner.less
+++ b/resources/less/virkailija-banner.less
@@ -38,11 +38,11 @@
     width: 1px;
     margin: 0 20px 0 20px;
   }
+
   .active-section-arrow {
     position: absolute;
-    top: 3px;
-    left: 33px;
-    font-size: 20px;
+    top: 15px;
+    left: 35px;
   }
 
   .flasher-container {

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -170,15 +170,26 @@
 (defn- hidden-answer? [form-element]
   (:exclude-from-answers form-element))
 
+(defn- pick-label
+  [form-element pick-cond]
+  (when (pick-cond form-element)
+    [[(:id form-element)
+      (label/get-language-label-in-preferred-order (:label form-element))]]))
+
 (defn pick-form-labels
   [form-content pick-cond]
   (->> (reduce
          (fn [acc form-element]
-           (if (< 0 (count (:children form-element)))
-             (into acc (pick-form-labels (:children form-element) pick-cond))
-             (into acc (when (pick-cond form-element)
-                         [[(:id form-element)
-                           (label/get-language-label-in-preferred-order (:label form-element))]]))))
+           (let [followups (remove nil? (mapcat :followups (:options form-element)))]
+             (cond
+               (pos? (count (:children form-element)))
+               (into acc (pick-form-labels (:children form-element) pick-cond))
+
+               (pos? (count followups))
+               (into (into acc (pick-label form-element pick-cond)) (pick-form-labels followups pick-cond))
+
+               :else
+               (into acc (pick-label form-element pick-cond)))))
          []
          form-content)))
 

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -141,17 +141,17 @@
   (doseq [meta-field application-meta-fields]
     (let [meta-value ((or (:format-fn meta-field) identity) ((:field meta-field) application))]
       (writer 0 (:column meta-field) meta-value)))
-  (doseq [answer (:answers application)
-          :when (some (comp (partial = (:label answer)) :header) headers)]
+  (doseq [answer (:answers application)]
     (let [column          (:column (first (filter #(= (:key answer) (:id %)) headers)))
-          value-or-values (-> (:value answer))
+          value-or-values (:value answer)
           value           (if (or (seq? value-or-values) (vector? value-or-values))
                             (->> value-or-values
                                  (map (partial raw-values->human-readable-value form application (:key answer)))
                                  (interpose "\n")
                                  (apply str))
                             (raw-values->human-readable-value form application (:key answer) value-or-values))]
-      (writer 0 (+ column (count application-meta-fields)) value)))
+      (when (and value column)
+        (writer 0 (+ column (count application-meta-fields)) value))))
   (let [application-review  (application-store/get-application-review (:key application))
         beef-header-count   (- (apply max (map :column headers)) (count review-headers))
         prev-header-count   (+ beef-header-count
@@ -236,14 +236,22 @@
                            (vals (select-keys answer [:key :label]))))))
             applications)))
 
+(defn- remove-duplicates-by-field-id
+  [labels-in-form labels-in-applications]
+  (let [form-element-ids (set (map first labels-in-form))]
+    (remove (fn [[key _]]
+              (contains? form-element-ids key))
+            labels-in-applications)))
+
 (defn- extract-headers
   [applications form]
-  (let [labels-in-form         (pick-form-labels (:content form) form-label?)
-        labels-in-applications (extract-headers-from-applications applications form)
-        all-labels             (distinct (concat labels-in-form labels-in-applications (map vector (repeat nil) review-headers)))
-        decorator              (partial decorate (util/flatten-form-fields (:content form)) (:content form))]
+  (let [labels-in-form              (pick-form-labels (:content form) form-label?)
+        labels-in-applications      (extract-headers-from-applications applications form)
+        labels-only-in-applications (remove-duplicates-by-field-id labels-in-form labels-in-applications)
+        all-labels                  (distinct (concat labels-in-form labels-only-in-applications (map vector (repeat nil) review-headers)))
+        decorator                   (partial decorate (util/flatten-form-fields (:content form)) (:content form))]
     (for [[idx [id header]] (map vector (range) all-labels)
-          :when             (string? header)]
+          :when (string? header)]
       {:id               id
        :decorated-header (decorator id header)
        :header           header

--- a/src/cljs/ataru/virkailija/application/handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/handlers.cljs
@@ -232,9 +232,10 @@
         (some? autosave) (assoc :stop-autosave autosave)))))
 
 (reg-event-db
- :application/clear-applications-and-haku-selections
+ :application/clear-applications-haku-and-form-selections
  (fn [db _]
    (-> db
+       (assoc-in [:editor :selected-form-key] nil)
        (assoc-in [:application :applications] nil)
        (assoc-in [:application :search-control :ssn] nil)
        (update-in [:application] dissoc :selected-form-key :selected-haku :selected-hakukohde))))

--- a/src/cljs/ataru/virkailija/routes.cljs
+++ b/src/cljs/ataru/virkailija/routes.cljs
@@ -30,7 +30,7 @@
 
 (defn common-actions-for-applications-route []
   (dispatch [:application/refresh-haut])
-  (dispatch [:application/clear-applications-and-haku-selections])
+  (dispatch [:application/clear-applications-haku-and-form-selections])
   (dispatch [:set-active-panel :application]))
 
 (defn app-routes []

--- a/src/cljs/ataru/virkailija/views/banner.cljs
+++ b/src/cljs/ataru/virkailija/views/banner.cljs
@@ -18,7 +18,7 @@
                    :view-applications "Hakemusten katselu"
                    :edit-applications "Hakemusten arviointi"})
 
-(def active-section-arrow [:span.active-section-arrow {:dangerouslySetInnerHTML {:__html "&#x2304;"}}])
+(def active-section-arrow [:i.active-section-arrow.zmdi.zmdi-chevron-down.zmdi-hc-lg])
 
 (defn section-link [panel-kw]
   (let [active-panel     (subscribe [:active-panel])


### PR DESCRIPTION
Have answers to followup questions appear next to the "parent" question in the Excel export sheets.

There are still some weird corner cases when the original form has fields changed/removed, but they seem more or less inevitable with the myriad different possibilities that arise :(