### PR TITLE
Fix attachment filenames on Safari

### DIFF
--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -3,13 +3,14 @@
             [ataru.config.url-helper :refer [resolve-url]]
             [ataru.config.core :refer [config]]
             [org.httpkit.client :as http]
-            [cheshire.core :as json]))
+            [cheshire.core :as json])
+  (:import (java.text Normalizer Normalizer$Form)))
 
 (defn upload-file [{:keys [tempfile filename]}]
   (let [url  (resolve-url :liiteri.files)
         resp @(http/post url {:multipart [{:name     "file"
                                            :content  tempfile
-                                           :filename filename}]})]
+                                           :filename (Normalizer/normalize filename Normalizer$Form/NFD)}]})]
     (when (= (:status resp) 200)
       (-> (:body resp)
           (json/parse-string true)


### PR DESCRIPTION
Safari likes to send attachment filenames in NFC form, which org.httpkit.client doesn't handle properly. We decompose the name here and things seem to work.