### PR TITLE
Fix varsious navigation issues in application handling

### DIFF
--- a/src/cljs/ataru/virkailija/application/application_search_control.cljs
+++ b/src/cljs/ataru/virkailija/application/application_search_control.cljs
@@ -6,7 +6,10 @@
 
 (defn haku-tab [tab-id selected-tab link-url label-text]
   [:div.application__search-control-tab-selector-wrapper
-   [:a {:href link-url}
+   [:a {:href link-url
+        :on-click (fn [event]
+                    (.preventDefault event)
+                    (dispatch [:navigate link-url]))}
     [:div.application__search-control-tab-selector
      {:class (when (= tab-id selected-tab) "application__search-control-selected-tab")}
      label-text]]
@@ -39,7 +42,10 @@
 (defn search-ssn-tab [tab-id selected-tab link-url label-text]
   (let [tab-selected (when (= tab-id selected-tab) "application__search-control-selected-tab-with-input")]
     [:div.application__search-control-tab-selector-wrapper
-     [:a {:href link-url}
+     [:a {:href link-url
+          :on-click (fn [event]
+                      (.preventDefault event)
+                      (dispatch [:navigate link-url]))}
       [:div.application__search-control-tab-selector
        {:class (when tab-selected "application__search-control-selected-tab-with-input")}
        (if tab-selected

--- a/src/cljs/ataru/virkailija/application/application_search_control.cljs
+++ b/src/cljs/ataru/virkailija/application/application_search_control.cljs
@@ -36,7 +36,7 @@
        :on-change   (fn [evt] (dispatch [:application/ssn-search (-> evt .-target .-value)]))}]
      (when-not (clojure.string/blank? @ssn-value)
        [:span.application__search-control-clear-ssn
-        {:on-click #(dispatch [:application/clear-ssn])}
+        {:on-click #(dispatch [:application/clear-applications-haku-and-form-selections])}
         [:i.zmdi.zmdi-close]])]))
 
 (defn search-ssn-tab [tab-id selected-tab link-url label-text]

--- a/src/cljs/ataru/virkailija/application/application_search_control_handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/application_search_control_handlers.cljs
@@ -25,11 +25,6 @@
  (fn [db]
    (assoc-in db show-path nil)))
 
-(reg-event-db
- :application/clear-ssn
- (fn [db]
-   (assoc-in db [:application :search-control :ssn] nil)))
-
 (reg-event-fx
  :application/ssn-search
  (fn [{:keys [db]} [_ potential-ssn]]

--- a/src/cljs/ataru/virkailija/application/application_search_control_handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/application_search_control_handlers.cljs
@@ -40,9 +40,6 @@
                                    (assoc-in [:application :search-control :ssn :value] potential-ssn)
                                    (assoc-in [:application :search-control :ssn :show-error] show-error))]
      (cond
-       (= potential-ssn previous-ssn-value)
-       nil
-
        (ssn/ssn? ucase-potential-ssn)
        {:db db-with-potential-ssn
         :dispatch [:application/fetch-applications-by-ssn ucase-potential-ssn]}

--- a/src/cljs/ataru/virkailija/application/application_search_control_handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/application_search_control_handlers.cljs
@@ -29,7 +29,6 @@
  :application/ssn-search
  (fn [{:keys [db]} [_ potential-ssn]]
    (let [ucase-potential-ssn   (clojure.string/upper-case potential-ssn)
-         previous-ssn-value    (get-in db [:application :search-control :ssn :value])
          show-error            (if (= 11 (count ucase-potential-ssn)) (not (ssn/ssn? ucase-potential-ssn)) false)
          db-with-potential-ssn (-> db
                                    (assoc-in [:application :search-control :ssn :value] potential-ssn)

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -307,7 +307,7 @@
      [:div.application-handling__review-area-main-heading-container
       [:h2.application-handling__review-area-main-heading (str pref-name " " last-name ", " ssn)]
       (when (> applications-count 1)
-        [:a.application-handling__review-area-main-heading-applications-link.animated.flash
+        [:a.application-handling__review-area-main-heading-applications-link
          {:on-click (fn [_]
                       (dispatch [:application/navigate-with-callback
                                  "/lomake-editori/applications/search-ssn/"


### PR DESCRIPTION
* Don't do full page reloads when user repeatedly clicks on the tab buttons ("käsittelemättä olevat haut", "etsi henkilötunnuksella" and "käsitellyt haut").
* Clear search results too when current SSN is cleared from the search by SSN input field.