### PR TITLE
Do not close the application list when closing a single application

### DIFF
--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -20,6 +20,16 @@
   ^{:key value}
   [:li value])
 
+(defn- predefined-value-answer?
+  "Does the answer have predefined values? Form elements like dropdowns
+   and single and multi-choice buttons have fixed, predefined values, as
+   opposed to a text input field where an user can provide anything as
+   the answer."
+  [{:keys [fieldClass fieldType options]}]
+  (and (= fieldClass "formField")
+       (some #{fieldType} ["dropdown" "singleChoice" "multipleChoice"])
+       (not-empty options)))
+
 (defn textual-field-value [field-descriptor application & {:keys [lang]}]
   (let [key                (answer-key field-descriptor)
         value-or-koodi-uri (:value (get (:answers application) key))
@@ -34,6 +44,12 @@
           (first values)
           [:ul.application__form-field-list
            (map wrap-value values)]))
+
+      (predefined-value-answer? field-descriptor)
+      (let [option (->> (:options field-descriptor)
+                        (filter (comp (partial = value-or-koodi-uri) :value))
+                        (first))]
+        (get-in option [:label lang]))
 
       (and (sequential? split-values) (< 1 (count split-values)))
       [:ul.application__form-field-list

--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -49,7 +49,7 @@
       (let [option (->> (:options field-descriptor)
                         (filter (comp (partial = value-or-koodi-uri) :value))
                         (first))]
-        (get-in option [:label lang]))
+        (get-in option [:label lang] value-or-koodi-uri))
 
       (and (sequential? split-values) (< 1 (count split-values)))
       [:ul.application__form-field-list

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -324,7 +324,9 @@
 
 (defn close-application []
   [:a {:href     "#"
-       :on-click (fn [event] (dispatch [:application/close-application]))}
+       :on-click (fn [event]
+                   (.preventDefault event)
+                   (dispatch [:application/close-application]))}
    [:div.close-details-button
     [:i.zmdi.zmdi-close.close-details-button-mark]]])
 


### PR DESCRIPTION
When user searches applications eg. by date of birth, selects one application from the search results list and then closes this application using the close check mark on the left side of the view, do not lose all the search results.