### PR TITLE
Support followup questions in single choice list

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -588,6 +588,11 @@ textarea.application__form-text-area__size-large {
   position: relative;
 }
 
+.application__form-multi-choice-followups-container {
+  width: 100%;
+  max-width: 610px;
+}
+
 .application__form-multi-choice-followups-container .application__form-field {
   margin-left: 0px;
   width: 100%;

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -642,6 +642,22 @@ th.application__readonly-adjacent--header {
   min-width: 100px;
 }
 
+.application__form-single-choice-followups-indicator {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 9px solid @section-header-text;
+  top: 43px;
+  left: 40px;
+  z-index: 1;
+}
+
+.application__form-single-choice-button-inner-container {
+  position: relative;
+}
+
 .application__form-single-choice-button-inner-container:first-child label {
   border-radius: 3px 0 0 3px;
 }

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -586,9 +586,6 @@ textarea.application__form-text-area__size-large {
   flex-flow: column nowrap;
   padding: 20px;
   position: relative;
-}
-
-.application__form-multi-choice-followups-container {
   width: 100%;
   max-width: 610px;
 }

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -573,12 +573,6 @@ textarea.application__form-text-area__size-large {
   color: @white;
 }
 
-.application__form-checkbox:checked + label::before {
-  content: url('../../images/icon_check.png');
-  margin-bottom: 2px;
-  margin-right: 6px;
-}
-
 .application__form-multi-choice-followups-container {
   align-items: flex-start;
   background-color: #FAFAFA;
@@ -677,14 +671,6 @@ th.application__readonly-adjacent--header {
 .application__form-single-choice-button:checked + label {
   color: @white;
   background-color: @section-header-text;
-}
-
-.application__form-single-choice-button:checked + label::before {
-  content: url('/hakemus/images/icon_check.png');
-  margin-bottom: 2px;
-  margin-right: 6px;
-  margin-left: -20px;
-  padding-left: 7px;
 }
 
 .application__form-adjacent-text-fields-wrapper {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -573,6 +573,10 @@ textarea.application__form-text-area__size-large {
   color: @white;
 }
 
+.application__form-multi-choice-followups-outer-container {
+  position: relative;
+}
+
 .application__form-multi-choice-followups-container {
   align-items: flex-start;
   background-color: #FAFAFA;
@@ -605,6 +609,7 @@ textarea.application__form-text-area__size-large {
   border-top: 9px solid @section-header-text;
   top: -1px;
   left: 52px;
+  z-index: 1;
 }
 
 .application__readonly-adjacent{

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -586,8 +586,7 @@ textarea.application__form-text-area__size-large {
   flex-flow: column nowrap;
   padding: 20px;
   position: relative;
-  width: 100%;
-  max-width: 610px;
+  max-width: 600px;
 }
 
 .application__form-multi-choice-followups-container .application__form-field {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -802,6 +802,9 @@ and (max-width: @desktop-content-width) {
   .application__form-adjacent-row--desktop-only {
     display: none;
   }
+  .application__form-multi-choice-followups-container {
+    margin-right: 10px;
+  }
 }
 
 @media print {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -594,6 +594,10 @@ textarea.application__form-text-area__size-large {
   width: 100%;
 }
 
+.application__form-multi-choice-followups-container .application__form-field:last-child {
+  margin-bottom: 0;
+}
+
 .application__form-multi-choice-followups-container .application__form-text-input__size-large,.application__form-text-area {
   width: auto;
 }

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -764,6 +764,14 @@ and (max-width: @desktop-content-width) {
     margin-right: 10px;
   }
 
+  .application__form-multi-choice-followups-container
+  .application__form-text-input__size-large,
+  .application__form-text-area__size-small,
+  .application__form-text-area__size-medium,
+  .application__form-text-area__size-large {
+    margin-right: 0;
+  }
+
   .application__form-adjacent-text-fields-wrapper {
     flex-flow: column wrap;
     margin-bottom: 20px;

--- a/resources/spec/hakijaEditSpec.js
+++ b/resources/spec/hakijaEditSpec.js
@@ -22,7 +22,7 @@
         })
       )
       it('with complete form', function () {
-        expect(formFields().length).to.equal(27)
+        expect(formFields().length).to.equal(28)
         expect(submitButton().prop('disabled')).to.equal(false)
         expect(formHeader().text()).to.equal('Testilomake')
         expect(submitButton().prop('disabled')).to.equal(false)
@@ -69,14 +69,20 @@
           ""
         ]
 
-        var checkboxInputValues = _.map(testFrame().find('input.application__form-checkbox:checked'), function (e) {
+        var checkboxInputValues = _.map(testFrame().find('input.application__form-checkbox:checked').not('.application__form-multi-choice-followups-container .application__form-checkbox'), function (e) {
           return $(e).val()
         })
         var expectedCheckboxInputValues = ["Toinen vaihtoehto", "139"]
 
+        var followupCheckboxInputValues = _.map(testFrame().find('.application__form-multi-choice-followups-container input.application__form-checkbox:checked'), function (e) {
+          return $(e).val()
+        })
+        var expectedFollowupCheckboxInputValues = ['Jatkokysymys A']
+
         expect(textInputValues).to.eql(expectedTestInputValues)
         expect(dropdownInputValues).to.eql(expectedDropdownInputValues)
         expect(checkboxInputValues).to.eql(expectedCheckboxInputValues)
+        expect(followupCheckboxInputValues).to.eql(expectedFollowupCheckboxInputValues)
       })
     })
 

--- a/resources/spec/hakijaSpec.js
+++ b/resources/spec/hakijaSpec.js
@@ -91,8 +91,10 @@
         clickNthFieldRadio(21, 'Arkkitehti', true),
         setNthFieldValue(22, 'textarea', 'Toisen pakollisen tekstialueen vastaus'),
         clickNthFieldRadio(25, 'Ensimmäinen vaihtoehto'),
-        setNthFieldSubInputValue(26, 0, 'Vasen vierekkäinen'),
-        setNthFieldSubInputValue(26, 1, 'Oikea vierekkäinen')
+        clickNthFieldRadio(26, 'Jatkokysymys A'),
+        clickNthFieldRadio(26, 'Jatkokysymys B'),
+        setNthFieldSubInputValue(27, 0, 'Vasen vierekkäinen'),
+        setNthFieldSubInputValue(27, 1, 'Oikea vierekkäinen')
 
       )
       it('works and validates correctly', function() {
@@ -138,7 +140,8 @@
                               "Toisen pakollisen tekstialueen vastaus",
                               "",
                               "",
-                              "Ensimmäinen vaihtoehto"]
+                              "Ensimmäinen vaihtoehto",
+                              "Jatkokysymys AJatkokysymys B"]
 
         var tabularValues = _.map(testFrame().find('.application__form-field table td'), function(e) { return $(e).text() })
         var expectedTabularValues = ["Vasen vierekkäinen", "Oikea vierekkäinen"]

--- a/resources/spec/virkailijaEditorSpec.js
+++ b/resources/spec/virkailijaEditorSpec.js
@@ -307,14 +307,22 @@
           clickElement(function() { return formComponents().eq(11).find('.editor-form__add-dropdown-item a') }),
           setTextFieldValue(function () { return formComponents().eq(11).find('.editor-form__text-field:last') }, 'Ensimmäinen vaihtoehto'),
           clickElement(function() { return formComponents().eq(11).find('.editor-form__add-dropdown-item a') }),
-          setTextFieldValue(function () { return formComponents().eq(11).find('.editor-form__text-field:last') }, 'Toinen vaihtoehto')
+          setTextFieldValue(function () { return formComponents().eq(11).find('.editor-form__text-field:last') }, 'Toinen vaihtoehto'),
+          clickElement(function() { return formComponents().eq(11).find('.editor-form__followup-question:eq(0) a:contains("Lisäkysymykset")') }),
+          clickElement(function() { return formComponents().eq(11).find('.editor-form__followup-question-overlay a:contains("Lista, monta valittavissa")') }),
+          setTextFieldValue(function() { return formComponents().eq(11).find('.editor-form__followup-question-overlay input.editor-form__text-field') }, "Monivalinta jatkokysymyksenä"),
+          clickElement(function() { return formComponents().eq(11).find('.editor-form__followup-question-overlay .editor-form__checkbox + .editor-form__checkbox-label') }),
+          clickElement(function() { return formComponents().eq(11).find('.editor-form__followup-question-overlay .editor-form__add-dropdown-item a:contains("Lisää")') }),
+          setTextFieldValue(function() { return formComponents().eq(11).find('.editor-form__followup-question-overlay .editor-form__multi-option-wrapper .editor-form__text-field:eq(0)') }, 'Jatkokysymys A'),
+          clickElement(function() { return formComponents().eq(11).find('.editor-form__followup-question-overlay .editor-form__add-dropdown-item a:contains("Lisää")') }),
+          setTextFieldValue(function() { return formComponents().eq(11).find('.editor-form__followup-question-overlay .editor-form__multi-option-wrapper .editor-form__text-field:eq(1)') }, 'Jatkokysymys B')
         )
         it('has expected contents', function() {
           expect(formComponents()).to.have.length(12)
           expect(formComponents().eq(11).find('.editor-form__text-field:first').val()).to.equal('Lyhyen listan kysymys')
           expect(formComponents().eq(11).find('.editor-form__checkbox-container input').prop('checked')).to.equal(true)
-          expect(formComponents().eq(11).find('.editor-form__multi-options-container > div:nth-child(1) .editor-form__text-field').val()).to.equal('Ensimmäinen vaihtoehto')
-          expect(formComponents().eq(11).find('.editor-form__multi-options-container > div:nth-child(2) .editor-form__text-field').val()).to.equal('Toinen vaihtoehto')
+          expect(formComponents().eq(11).find('.editor-form__multi-options-container > div:nth-child(1) .editor-form__text-field').not('.editor-form__followup-question-overlay input').val()).to.equal('Ensimmäinen vaihtoehto')
+          expect(formComponents().eq(11).find('.editor-form__multi-options-container > div:nth-child(2) .editor-form__text-field').not('.editor-form__followup-question-overlay input').val()).to.equal('Toinen vaihtoehto')
         })
       })
 

--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -28,7 +28,7 @@
          :children   children}
         (flatten-form-fields children)
 
-        {:fieldType (:or "dropdown" "multipleChoice")
+        {:fieldType (:or "dropdown" "multipleChoice" "singleChoice")
          :options options}
         (cons field
           (->> options

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -421,7 +421,7 @@
     (r/create-class
       {:reagent-render       (fn [parent-id options]
                                (when (not-empty @followups)
-                                 [:div
+                                 [:div.application__form-multi-choice-followups-container
                                   (map (fn [followup]
                                          ^{:key (str (:id followup))}
                                          [render-field followup])

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -389,12 +389,12 @@
                                       (get-in option [:label @default-lang]))
         option-value   (:value option)
         option-id      (util/component-id)
-        selected-value (subscribe [:state-query [:application :answers parent-id :value]])]
+        checked?       (subscribe [:application/single-choice-option-checked? parent-id option-value])]
     [:div.application__form-single-choice-button-inner-container {:key option-id}
      [:input.application__form-single-choice-button
       {:id        option-id
        :type      "checkbox"
-       :checked   (= option-value @selected-value)
+       :checked   @checked?
        :value     option-value
        :on-change (fn [event]
                     (let [value (.. event -target -value)]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -403,6 +403,15 @@
       {:for option-id}
       label]]))
 
+(defn- hide-followups [db {:keys [followups]}]
+  (reduce (fn hide-followup [db followup]
+            (update-in db [:application :ui (answer-key followup)] assoc :visible? false))
+          db
+          followups))
+
+(defn- show-followup [db followup]
+  (update-in db [:application :ui (answer-key followup)] assoc :visible? true))
+
 (defn- single-choice-followups [parent-id options]
   (let [single-choice-value (subscribe [:state-query [:application :answers parent-id :value]])
         followups           (reaction (->> options
@@ -421,16 +430,10 @@
                                (dispatch [:state-update
                                           (fn [db]
                                             (as-> db db'
-                                                  (reduce (fn [db option]
-                                                            (let [followups (:followups option)]
-                                                              (reduce (fn [db followup]
-                                                                        (update-in db [:application :ui (answer-key followup)] assoc :visible? false))
-                                                                      db
-                                                                      followups)))
+                                                  (reduce hide-followups
                                                           db'
                                                           (filter (comp (partial not= @single-choice-value) :value) options))
-                                                  (reduce (fn [db followup]
-                                                            (update-in db [:application :ui (answer-key followup)] assoc :visible? true))
+                                                  (reduce show-followup
                                                           db'
                                                           @followups)))]))})))
 

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -401,7 +401,9 @@
                       (dispatch [:application/select-single-choice-button parent-id value validators])))}]
      [:label
       {:for option-id}
-      label]]))
+      label]
+     (when (and @checked? (not-empty (:followups option)))
+       [:div.application__form-single-choice-followups-indicator])]))
 
 (defn- hide-followups [db {:keys [followups]}]
   (reduce (fn hide-followup [db followup]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -427,6 +427,9 @@
                                          [render-field followup])
                                        @followups)]))
        :component-did-update (fn []
+                               ; Setting visible? state to true/false determines answer's visibility
+                               ; in the "required answers" list on the header, below the submit application
+                               ; button
                                (dispatch [:state-update
                                           (fn [db]
                                             (as-> db db'

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -383,13 +383,13 @@
                     (:options field-descriptor))]]))
 
 (defn- single-choice-option [option parent-id validators]
-  (let [lang           (subscribe [:application/form-language])
-        default-lang   (subscribe [:application/default-language])
-        label          (non-blank-val (get-in option [:label @lang])
-                                      (get-in option [:label @default-lang]))
-        option-value   (:value option)
-        option-id      (util/component-id)
-        checked?       (subscribe [:application/single-choice-option-checked? parent-id option-value])]
+  (let [lang         (subscribe [:application/form-language])
+        default-lang (subscribe [:application/default-language])
+        label        (non-blank-val (get-in option [:label @lang])
+                                    (get-in option [:label @default-lang]))
+        option-value (:value option)
+        option-id    (util/component-id)
+        checked?     (subscribe [:application/single-choice-option-checked? parent-id option-value])]
     [:div.application__form-single-choice-button-inner-container {:key option-id}
      [:input.application__form-single-choice-button
       {:id        option-id

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -270,7 +270,7 @@
                                (when-let [followups (resolve-followups @value)]
                                  (into [:div.application__form-dropdown-followups]
                                    (for [followup followups]
-                                     [:div.application__form-dropdown-followup
+                                     [:div.application__form-dropdown-followups.animated.fadeIn
                                       [render-field followup]]))))})))
 
 (defn dropdown
@@ -339,12 +339,13 @@
                                                  followups))]))
      :reagent-render      (fn [followups parent-checked?]
                             (when (and parent-checked? (not-empty followups))
-                              [:div.application__form-multi-choice-followups-container
+                              [:div.application__form-multi-choice-followups-outer-container
                                [:div.application__form-multi-choice-followups-indicator]
-                               (map (fn [followup]
-                                      ^{:key (:id followup)}
-                                      [render-field followup])
-                                    followups)]))}))
+                               [:div.application__form-multi-choice-followups-container.animated.fadeIn
+                                (map (fn [followup]
+                                       ^{:key (:id followup)}
+                                       [render-field followup])
+                                     followups)]]))}))
 
 (defn- multiple-choice-option [option parent-id validators]
   (let [lang         (subscribe [:application/form-language])
@@ -423,7 +424,7 @@
     (r/create-class
       {:reagent-render       (fn [parent-id options]
                                (when (not-empty @followups)
-                                 [:div.application__form-multi-choice-followups-container
+                                 [:div.application__form-multi-choice-followups-container.animated.fadeIn
                                   (map (fn [followup]
                                          ^{:key (str (:id followup))}
                                          [render-field followup])

--- a/src/cljs/ataru/hakija/hakija_readonly.cljs
+++ b/src/cljs/ataru/hakija/hakija_readonly.cljs
@@ -145,7 +145,7 @@
          {:fieldClass "wrapperElement" :fieldType "adjacentfieldset" :children children} [fieldset content application lang children]
          {:fieldClass "formField" :exclude-from-answers true} nil
          {:fieldClass "infoElement"} nil
-         {:fieldClass "formField" :fieldType (:or "dropdown" "multipleChoice") :options (options :guard util/followups?)}
+         {:fieldClass "formField" :fieldType (:or "dropdown" "multipleChoice" "singleChoice") :options (options :guard util/followups?)}
          [followups (mapcat :followups options) content application lang]
          {:fieldClass "formField" :fieldType (:or "textField" "textArea" "dropdown" "multipleChoice" "singleChoice")} (text content application lang)
          {:fieldClass "formField" :fieldType "attachment"} [attachment content application lang]))

--- a/src/cljs/ataru/hakija/subs.cljs
+++ b/src/cljs/ataru/hakija/subs.cljs
@@ -56,3 +56,9 @@
   (fn [db [_ parent-id option-value]]
     (let [options (get-in db [:application :answers parent-id :options])]
       (true? (get options option-value)))))
+
+(re-frame/reg-sub
+  :application/single-choice-option-checked?
+  (fn [db [_ parent-id option-value]]
+    (let [value (get-in db [:application :answers parent-id :value])]
+      (= option-value value))))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -338,7 +338,7 @@
                   ^{:key "options-input"}
                   [:div.editor-form__multi-options-container
                    (map-indexed (fn [idx _]
-                                  (dropdown-option idx path languages :include-followup? (some #{field-type} ["dropdown" "multipleChoice"])))
+                                  (dropdown-option idx path languages :include-followup? (some #{field-type} ["dropdown" "multipleChoice" "singleChoice"])))
                      (:options @value))]
                   ^{:key "options-input-add"}
                   [:div.editor-form__add-dropdown-item

--- a/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
+++ b/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
@@ -146,7 +146,7 @@
          {:fieldClass "wrapperElement" :fieldType "adjacentfieldset" :children children} [fieldset content application lang children]
          {:fieldClass "formField" :exclude-from-answers true} nil
          {:fieldClass "infoElement"} nil
-         {:fieldClass "formField" :fieldType (:or "dropdown" "multipleChoice") :options (options :guard util/followups?)}
+         {:fieldClass "formField" :fieldType (:or "dropdown" "multipleChoice" "singleChoice") :options (options :guard util/followups?)}
          [followups (mapcat :followups options) content application lang]
          {:fieldClass "formField" :fieldType (:or "textField" "textArea" "dropdown" "multipleChoice" "singleChoice")} (text content application lang)
          {:fieldClass "formField" :fieldType "attachment"} [attachment content application lang]))


### PR DESCRIPTION
Includes:

* Support followup questions in a single choice list.
* Animations for all followup questions (fade in when opened).

Does not include:

* Fix for the adjacent text fields as followup question.