### PR TITLE
Fix koodisto dropdown/multi-choice/single-choice as followup question

### DIFF
--- a/spec/ataru/util_spec.clj
+++ b/spec/ataru/util_spec.clj
@@ -35,4 +35,11 @@
   (it "gets field-descriptor from a child list"
     (should= field-descriptor (util/get-field-descriptor [{:id "invalid"
                                                            :children [field-descriptor]}]
+                                                         field-descriptor-id)))
+
+  (it "gets field-descriptor from a list with followup questions"
+    (should= field-descriptor (util/get-field-descriptor [{:id "invalid"
+                                                           :options [{:label {:fi "Dropdown question"}
+                                                                      :value "Dropdown question"
+                                                                      :followups [field-descriptor]}]}]
                                                          field-descriptor-id))))

--- a/spec/ataru/util_spec.clj
+++ b/spec/ataru/util_spec.clj
@@ -19,3 +19,20 @@
           second
           (map keys)
           flatten))))
+
+(def field-descriptor-id "64d4a625-370b-4814-ae4f-d5956e8881be")
+(def field-descriptor {:id         field-descriptor-id
+                       :label      {:fi "Pohjakoulutuksesi?" :sv ""}
+                       :fieldType  "textField"
+                       :fieldClass "formField"})
+
+(describe "get-field-descriptor"
+  (tags :get-fd)
+
+  (it "gets field-descriptor from simple list"
+    (should= field-descriptor (util/get-field-descriptor [field-descriptor] field-descriptor-id)))
+
+  (it "gets field-descriptor from a child list"
+    (should= field-descriptor (util/get-field-descriptor [{:id "invalid"
+                                                           :children [field-descriptor]}]
+                                                         field-descriptor-id))))

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -17,9 +17,18 @@
 
 (defn- extract-koodisto-fields [field-descriptor-list]
   (reduce
-    (fn [result {:keys [children id koodisto-source]}]
-      (if (some? children)
+    (fn [result {:keys [children id koodisto-source options followups]}]
+      (cond
+        (some? children)
         (merge result (extract-koodisto-fields children))
+
+        (some :followups options)
+        (merge result (extract-koodisto-fields options))
+
+        (not-empty followups)
+        (merge result (extract-koodisto-fields followups))
+
+        :else
         (cond-> result
           (every? some? [id koodisto-source])
           (assoc id (select-keys koodisto-source [:uri :version])))))

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -108,16 +108,6 @@
   (doseq [header headers]
     (writer 0 (+ (:column header) (count meta-fields)) (:decorated-header header))))
 
-(defn- get-field-descriptor [field-descriptors key]
-  (loop [field-descriptors field-descriptors]
-    (if-let [field-descriptor (first field-descriptors)]
-      (let [ret (if (contains? field-descriptor :children)
-                  (get-field-descriptor (:children field-descriptor) key)
-                  field-descriptor)]
-        (if (= key (:id ret))
-          ret
-          (recur (next field-descriptors)))))))
-
 (defn- get-label [koodisto lang koodi-uri]
   (let [koodi (->> koodisto
                    (filter (fn [{:keys [value]}]
@@ -126,7 +116,7 @@
     (get-in koodi [:label lang])))
 
 (defn- raw-values->human-readable-value [{:keys [content]} {:keys [lang]} key value]
-  (let [field-descriptor (get-field-descriptor content key)
+  (let [field-descriptor (util/get-field-descriptor content key)
         lang             (-> lang clojure.string/lower-case keyword)]
     (if-some [koodisto-source (:koodisto-source field-descriptor)]
       (let [koodisto         (koodisto/get-koodisto-options (:uri koodisto-source) (:version koodisto-source))

--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -91,9 +91,17 @@
 (defn get-field-descriptor [field-descriptors key]
   (loop [field-descriptors field-descriptors]
     (if-let [field-descriptor (first field-descriptors)]
-      (let [ret (if (contains? field-descriptor :children)
-                  (get-field-descriptor (:children field-descriptor) key)
-                  field-descriptor)]
-        (if (= key (:id ret))
+      (let [ret (cond (contains? field-descriptor :children)
+                      (get-field-descriptor (:children field-descriptor) key)
+
+                      (contains? field-descriptor :followups)
+                      (get-field-descriptor (:followups field-descriptor) key)
+
+                      (some :followups (:options field-descriptor))
+                      (get-field-descriptor (:options field-descriptor) key)
+
+                      :else
+                      field-descriptor)]
+        (if (= (:id ret) key)
           ret
           (recur (next field-descriptors)))))))

--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -87,3 +87,13 @@
   "remove nth elem in vector"
   [v n]
   (vec (concat (subvec v 0 n) (subvec v (inc n)))))
+
+(defn get-field-descriptor [field-descriptors key]
+  (loop [field-descriptors field-descriptors]
+    (if-let [field-descriptor (first field-descriptors)]
+      (let [ret (if (contains? field-descriptor :children)
+                  (get-field-descriptor (:children field-descriptor) key)
+                  field-descriptor)]
+        (if (= key (:id ret))
+          ret
+          (recur (next field-descriptors)))))))


### PR DESCRIPTION
When a dropdown/multi-choice/single-choice had a koodisto based field as a followup question, both application browsing and excel export weren't able to convert the id representing the answer from database to a human-readable label.

This PR fixes the issue.