### PR TITLE
Feedback form

### DIFF
--- a/resources/db/migration/V1_49__Add_application_feedback_table.sql
+++ b/resources/db/migration/V1_49__Add_application_feedback_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE application_feedback (
+  id           BIGSERIAL PRIMARY KEY,
+  created_time TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  form_key     VARCHAR(40) NOT NULL,
+  form_id      BIGINT REFERENCES forms (id),
+  stars        INTEGER     NOT NULL,
+  feedback     TEXT        NULL,
+  user_agent   TEXT        NULL
+);
+

--- a/resources/db/migration/V1_49__Add_application_feedback_table.sql
+++ b/resources/db/migration/V1_49__Add_application_feedback_table.sql
@@ -3,8 +3,10 @@ CREATE TABLE application_feedback (
   created_time TIMESTAMP WITH TIME ZONE DEFAULT now(),
   form_key     VARCHAR(40) NOT NULL,
   form_id      BIGINT REFERENCES forms (id),
+  form_name    VARCHAR(1024),
   stars        INTEGER     NOT NULL,
   feedback     TEXT        NULL,
-  user_agent   TEXT        NULL
+  user_agent   TEXT        NULL,
+  extra_data   JSONB
 );
 

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -845,6 +845,8 @@ and (max-width: @desktop-content-width) {
 .application-feedback-form__close-button {
   position: absolute;
   right: 20px;
+  color: @gray-of-the-beast;
+  font-size: 1.5em;
 }
 
 .application-feedback-form__header {
@@ -880,6 +882,7 @@ and (max-width: @desktop-content-width) {
 .application-feedback-form__rating-text {
   color: @gold;
   margin-bottom: 10px;
+  font-size: 20px;
 }
 
 .application-feedback-form-container {
@@ -910,7 +913,7 @@ and (max-width: @desktop-content-width) {
   display: flex;
   height: 41px;
   justify-content: center;
-  padding: 0 40px;
+  padding: 0 30px;
   color: @white;
 }
 
@@ -924,6 +927,21 @@ and (max-width: @desktop-content-width) {
   &:hover {
     background-color: @button-blue;
   }
+}
+
+.application__thanks {
+  color: @opintopolku-green;
+}
+
+.application__thanks-text {
+  display: inline-block;
+  margin-bottom: 4px;
+  font-size: 24px;
+}
+
+.application__thanks-icon {
+  margin-right: 10px;
+  font-size: 2em;
 }
 
 

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -808,19 +808,38 @@ and (max-width: @desktop-content-width) {
   }
 
   100% {
-    bottom: 0;
+    bottom: 20px;
+  }
+}
+
+@media only screen and (max-width: @desktop-content-width) {
+  @keyframes slide-from-bottom {
+    0% {
+      bottom: -200px;
+    }
+
+    100% {
+      bottom: 0;
+    }
   }
 }
 
 .application-feedback-form {
   animation: slide-from-bottom 1s;
-  bottom: 0;
+  bottom: 20px;
   position: fixed;
   left: 10%;
   right: 10%;
-  padding: 20px;
+  padding: 10px 20px;
   background-color: @white;
   border: 1px solid @separator-color;
+  box-shadow: @modal-shadow;
+
+  @media only screen and (max-width: @desktop-content-width) {
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
 }
 
 .application-feedback-form__close-button {
@@ -828,15 +847,22 @@ and (max-width: @desktop-content-width) {
   right: 20px;
 }
 
+.application-feedback-form__header {
+  .semibold;
+  margin: 10px 0;
+}
+
 .application-feedback-form__disclaimer {
   color: @sg-gray-lighten-3;
   font-style: italic;
   margin-top: 10px;
+  font-size: 14px;
 }
 
 .application-feedback-form__rating-star {
-  font-size: 5em;
+  font-size: 4em;
   cursor: pointer;
+  padding: 0 3px;
 
   @media only screen and (max-width: @desktop-content-width) {
     font-size: 3em;
@@ -862,6 +888,12 @@ and (max-width: @desktop-content-width) {
   align-items: center;
   justify-content: center;
   flex-direction: column;
+  .placeholder-color();
+}
+
+.application-feedback-form-container textarea {
+  height: 100px;
+  padding: 10px;
 }
 
 .application-feedback-form__text-feedback-container {
@@ -869,24 +901,31 @@ and (max-width: @desktop-content-width) {
   max-width: 600px;
   display: flex;
   flex-direction: column;
-  margin-bottom: 20px;
+  margin-bottom: 14px;
 }
 
 .application__send-feedback-button {
   align-items: center;
   border-radius: 3px;
-  color: @white;
   display: flex;
   height: 41px;
   justify-content: center;
-  margin-left: 10px;
-  width: 133px;
+  padding: 0 40px;
+  color: @white;
+}
+
+.application__send-feedback-button--disabled {
+  background-color: @sg-gray-lighten-3;
+}
+
+.application__send-feedback-button--enabled {
   background-color: @pale-blue;
 
   &:hover {
     background-color: @button-blue;
   }
 }
+
 
 @media print {
   .application__banner-container {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -804,7 +804,7 @@ and (max-width: @desktop-content-width) {
 
 @keyframes slide-from-bottom {
   0% {
-    bottom: -100px;
+    bottom: -200px;
   }
 
   100% {
@@ -834,14 +834,21 @@ and (max-width: @desktop-content-width) {
   margin-top: 10px;
 }
 
+.application-feedback-form__rating-star {
+  font-size: 5em;
+  cursor: pointer;
+
+  @media only screen and (max-width: @desktop-content-width) {
+    font-size: 3em;
+  }
+}
+
 .application-feedback-form__rating-star--inactive {
   color: @sg-gray-lighten-3;
-  cursor: pointer;
 }
 
 .application-feedback-form__rating-star--active {
   color: @gold;
-  cursor: pointer;
 }
 
 .application-feedback-form__rating-text {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -828,6 +828,12 @@ and (max-width: @desktop-content-width) {
   right: 20px;
 }
 
+.application-feedback-form__disclaimer {
+  color: @sg-gray-lighten-3;
+  font-style: italic;
+  margin-top: 10px;
+}
+
 .application-feedback-form__rating-star--inactive {
   color: @sg-gray-lighten-3;
   cursor: pointer;

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -828,12 +828,35 @@ and (max-width: @desktop-content-width) {
   right: 20px;
 }
 
+.application-feedback-form__rating-star--inactive {
+  color: @sg-gray-lighten-3;
+  cursor: pointer;
+}
+
+.application-feedback-form__rating-star--active {
+  color: @gold;
+  cursor: pointer;
+}
+
+.application-feedback-form__rating-text {
+  color: @gold;
+  margin-bottom: 10px;
+}
+
 .application-feedback-form-container {
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
+}
+
+.application-feedback-form__text-feedback-container {
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 20px;
 }
 
 .application__send-feedback-button {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -802,6 +802,56 @@ and (max-width: @desktop-content-width) {
   }
 }
 
+@keyframes slide-from-bottom {
+  0% {
+    bottom: -100px;
+  }
+
+  100% {
+    bottom: 0;
+  }
+}
+
+.application-feedback-form {
+  animation: slide-from-bottom 1s;
+  bottom: 0;
+  position: fixed;
+  left: 10%;
+  right: 10%;
+  padding: 20px;
+  background-color: @white;
+  border: 1px solid @separator-color;
+}
+
+.application-feedback-form__close-button {
+  position: absolute;
+  right: 20px;
+}
+
+.application-feedback-form-container {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.application__send-feedback-button {
+  align-items: center;
+  border-radius: 3px;
+  color: @white;
+  display: flex;
+  height: 41px;
+  justify-content: center;
+  margin-left: 10px;
+  width: 133px;
+  background-color: @pale-blue;
+
+  &:hover {
+    background-color: @button-blue;
+  }
+}
+
 @media print {
   .application__banner-container {
     display: none;
@@ -820,3 +870,4 @@ and (max-width: @desktop-content-width) {
 .application__form-add-new-row {
   font-size: 14px;
 }
+

--- a/resources/less/mixins.less
+++ b/resources/less/mixins.less
@@ -83,3 +83,28 @@ span, p {
     transform:rotate(360deg);
   }
 }
+
+.placeholder-color(@color: @sg-color-gray-2) {
+  ::-webkit-input-placeholder { /* WebKit, Blink, Edge */
+    color:    @color;
+    font-style: italic;
+  }
+  :-moz-placeholder { /* Mozilla Firefox 4 to 18 */
+    color:    @color;
+    opacity:  1;
+    font-style: italic;
+  }
+  ::-moz-placeholder { /* Mozilla Firefox 19+ */
+    color:    @color;
+    opacity:  1;
+    font-style: italic;
+  }
+  :-ms-input-placeholder { /* Internet Explorer 10-11 */
+    color:    @color;
+    font-style: italic;
+  }
+  ::-ms-input-placeholder { /* Microsoft Edge */
+    color:    @color;
+    font-style: italic;
+  }
+}

--- a/resources/less/vars.less
+++ b/resources/less/vars.less
@@ -35,3 +35,4 @@
 @sg-color-gray-2: #aeaeae;
 @sg-gray-lighten-3: #ccc;
 @gold: #F6A623;
+@opintopolku-green: #A2BE43;

--- a/resources/less/vars.less
+++ b/resources/less/vars.less
@@ -34,3 +34,4 @@
 @sg-color-gray: #666666;
 @sg-color-gray-2: #aeaeae;
 @sg-gray-lighten-3: #ccc;
+@gold: #F6A623;

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -384,6 +384,6 @@ FROM latest_applications la
 GROUP BY f.name, f.key;
 
 -- name: yesql-add-application-feedback<!
-INSERT INTO application_feedback (created_time, form_key, form_id, stars, feedback, user_agent)
+INSERT INTO application_feedback (created_time, form_key, form_id, form_name, stars, feedback, user_agent)
 VALUES
-  (now(), :form_key, :form_id, :rating, left(:feedback, 2000), :user_agent);
+  (now(), :form_key, :form_id, :form_name, :rating, left(:feedback, 2000), :user_agent);

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -382,3 +382,8 @@ FROM latest_applications la
   JOIN latest_forms lf ON lf.key = la.form_key
   JOIN forms f ON f.id = lf.max_id
 GROUP BY f.name, f.key;
+
+-- name: yesql-add-application-feedback<!
+INSERT INTO application_feedback (created_time, form_key, form_id, stars, feedback, user_agent)
+VALUES
+  (now(), :form_key, :form_id, :rating, left(:feedback, 2000), :user_agent);

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -345,3 +345,7 @@
                                  {:incomplete_states incomplete-states
                                   :query_type "ALL"
                                   :authorized_organization_oids [""]})))
+
+(defn add-application-feedback!
+  [feedback]
+  (exec-db :db yesql-add-application-feedback<! (transform-keys ->snake_case feedback)))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -348,4 +348,5 @@
 
 (defn add-application-feedback!
   [feedback]
-  (exec-db :db yesql-add-application-feedback<! (transform-keys ->snake_case feedback)))
+  (->kebab-case-kw
+    (exec-db :db yesql-add-application-feedback<! (transform-keys ->snake_case feedback))))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -346,7 +346,7 @@
                                   :query_type "ALL"
                                   :authorized_organization_oids [""]})))
 
-(defn add-application-feedback!
+(defn add-application-feedback
   [feedback]
   (->kebab-case-kw
     (exec-db :db yesql-add-application-feedback<! (transform-keys ->snake_case feedback))))

--- a/src/clj/ataru/flowdock/flowdock_client.clj
+++ b/src/clj/ataru/flowdock/flowdock_client.clj
@@ -1,0 +1,38 @@
+(ns ataru.flowdock.flowdock-client
+  (:require
+    [ataru.config.core :refer [config]]
+    [org.httpkit.client :as http]
+    [cheshire.core :as json]
+    [taoensso.timbre :as log])
+  (:import [java.util UUID]))
+
+(def title-max-length 130)
+
+(defn- build-flowdock-request
+  [feedback flow-token]
+  {:flow_token         flow-token
+   :event              "activity"
+   :title              (str
+                         (apply str (repeat (:stars feedback) "*"))
+                         " "
+                         (if (< (count (:feedback feedback)) title-max-length)
+                           (:feedback feedback)
+                           (str (subs (:feedback feedback) 0 title-max-length) "...")))
+   :external_thread_id (str (UUID/randomUUID))
+   :author             {:name "anonyymi"}
+   :tags               ["#palaute"]
+   :thread             {:title  (str "Palaute lomakkeelle " (:form-key feedback))
+                        :body   (:feedback feedback)
+                        :fields [{:label "Rating" :value (:stars feedback)}
+                                 {:label "User-Agent" :value (:user-agent feedback)}
+                                 {:label "Form" :value (str "Key: " (:form-key feedback) ", ID: " (:form-id feedback))}
+                                 {:label "Submitted" :value (:created-time feedback)}
+                                 {:label "Feedback ID" :value (:id feedback)}]}})
+
+(defn send-application-feedback
+  [feedback]
+  (when-let [token (:flowdock-application-feedback-token config)]
+    (log/info "Sending feedback to Flowdock" feedback)
+    @(http/post "https://api.flowdock.com/messages"
+                {:headers {"content-type" "application/json"}
+                 :body    (json/generate-string (build-flowdock-request feedback token))})))

--- a/src/clj/ataru/flowdock/flowdock_client.clj
+++ b/src/clj/ataru/flowdock/flowdock_client.clj
@@ -21,7 +21,7 @@
    :external_thread_id (str (UUID/randomUUID))
    :author             {:name "anonyymi"}
    :tags               ["#palaute"]
-   :thread             {:title  (str "Palaute lomakkeelle " (:form-key feedback))
+   :thread             {:title  (str "Palaute: " (:form-name feedback))
                         :body   (:feedback feedback)
                         :fields [{:label "Rating" :value (:stars feedback)}
                                  {:label "User-Agent" :value (:user-agent feedback)}
@@ -35,4 +35,7 @@
     (log/info "Sending feedback to Flowdock" feedback)
     @(http/post "https://api.flowdock.com/messages"
                 {:headers {"content-type" "application/json"}
-                 :body    (json/generate-string (build-flowdock-request feedback token))})))
+                 :body    (-> feedback
+                              (build-flowdock-request token)
+                              (json/generate-string))})))
+

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -146,4 +146,4 @@
 (defn save-application-feedback
   [feedback]
   (log/info "Saving feedback" feedback)
-  (application-store/add-application-feedback! feedback))
+  (application-store/add-application-feedback feedback))

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -142,3 +142,8 @@
         (application-email/start-email-edit-confirmation-job application-id)
         {:passed? true :id application-id})
       validation-result)))
+
+(defn save-application-feedback
+  [feedback]
+  (log/info "Saving feedback" feedback)
+  (application-store/add-application-feedback! feedback))

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -99,6 +99,12 @@
       (if-let [form (form-service/fetch-form-by-key key)]
         (response/ok form)
         (response/not-found)))
+    (api/POST "/feedback" []
+      :summary "Add feedback sent by applicant"
+      :body [feedback ataru-schema/ApplicationFeedback]
+      (if-let [saved-application (application-service/save-application-feedback feedback)]
+        (response/ok {:id (:id saved-application)})
+        (response/bad-request)))
     (api/POST "/application" []
       :summary "Submit application"
       :body [application ataru-schema/Application]

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -23,7 +23,8 @@
             [selmer.parser :as selmer]
             [taoensso.timbre :refer [info warn error]]
             [cheshire.core :as json]
-            [ataru.config.core :refer [config]])
+            [ataru.config.core :refer [config]]
+            [ataru.flowdock.flowdock-client :as flowdock-client])
   (:import [ring.swagger.upload Upload]
            [java.io InputStream]))
 
@@ -103,7 +104,9 @@
       :summary "Add feedback sent by applicant"
       :body [feedback ataru-schema/ApplicationFeedback]
       (if-let [saved-application (application-service/save-application-feedback feedback)]
-        (response/ok {:id (:id saved-application)})
+        (do
+          (flowdock-client/send-application-feedback saved-application)
+          (response/ok {:id (:id saved-application)}))
         (response/bad-request)))
     (api/POST "/application" []
       :summary "Submit application"

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -232,6 +232,7 @@
 
 (s/defschema ApplicationFeedback {:form-key   s/Str
                                   :form-id    s/Int
+                                  :form-name  s/Str
                                   :user-agent s/Str
                                   :rating     s/Int
                                   :feedback   (s/maybe s/Str)})

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -229,3 +229,9 @@
 
 (s/defschema Haut {:tarjonta-haut    [TarjontaHaku]
                    :direct-form-haut [DirectFormHaku]})
+
+(s/defschema ApplicationFeedback {:form-key   s/Str
+                                  :form-id    s/Int
+                                  :user-agent s/Str
+                                  :rating     s/Int
+                                  :feedback   (s/maybe s/Str)})

--- a/src/cljc/ataru/translations/application_view.cljc
+++ b/src/cljc/ataru/translations/application_view.cljc
@@ -36,8 +36,8 @@
                                             3 "OK"
                                             4 "Good"
                                             5 "Excellent"}}
-   :feedback-text-placeholder         {:fi "Anna halutessasi kehitysideoita tai kommentteja hakijan palvelusta"
-                                       :en "Feel free to also share your comments or ideas regarding the service"}
+   :feedback-text-placeholder         {:fi "Anna halutessasi kommentteja hakulomakkeesta."
+                                       :en "Feel free to also share your comments regarding the application form."}
    :feedback-send                     {:fi "Lähetä palaute"
                                        :en "Send feedback"}
    :feedback-thanks                   {:fi "Kiitos palautteestasi!"

--- a/src/cljc/ataru/translations/application_view.cljc
+++ b/src/cljc/ataru/translations/application_view.cljc
@@ -21,7 +21,4 @@
                                        :en "Remove row"}
    :add-more                          {:fi "Lisää..."
                                        :sv "Lägg till..."
-                                       :en "Add more..."}
-   :cannot-edit-personal-info         {:fi "Jos haluat muuttaa henkilötietojasi, ota yhteyttä hakemaasi oppilaitokseen."
-                                       :en "To update your personal information, please contact the institution you're applying to."
-                                       :sv "Om du vill ändra dina kontaktuppgifter, ta då kontakt med den läroanstalt som du har sökt till."}})
+                                       :en "Add more..."}})

--- a/src/cljc/ataru/translations/application_view.cljc
+++ b/src/cljc/ataru/translations/application_view.cljc
@@ -21,4 +21,24 @@
                                        :en "Remove row"}
    :add-more                          {:fi "Lisää..."
                                        :sv "Lägg till..."
-                                       :en "Add more..."}})
+                                       :en "Add more..."}
+   :feedback-header                   {:fi "Hei, kerro vielä mitä pidit hakulomakkeesta!"
+                                       :en "Hi! Care to take a moment to rate our application form?"}
+   :feedback-disclaimer               {:fi "Yhteystietojasi ei käytetä tai yhdistetä palautteen tietoihin."
+                                       :en "Your personal information is not sent or associated with the feedback given."}
+   :feedback-ratings                  {:fi {1 "Huono"
+                                            2 "Välttävä"
+                                            3 "Tyydyttävä"
+                                            4 "Hyvä"
+                                            5 "Kiitettävä"}
+                                       :en {1 "Poor"
+                                            2 "Passable"
+                                            3 "OK"
+                                            4 "Good"
+                                            5 "Excellent"}}
+   :feedback-text-placeholder         {:fi "Anna halutessasi kehitysideoita tai kommentteja hakijan palvelusta"
+                                       :en "Feel free to also share your comments or ideas regarding the service"}
+   :feedback-send                     {:fi "Lähetä palaute"
+                                       :en "Send feedback"}
+   :feedback-thanks                   {:fi "Kiitos palautteestasi!"
+                                       :en "Thank you for your feedback!"}})

--- a/src/cljc/ataru/translations/application_view.cljc
+++ b/src/cljc/ataru/translations/application_view.cljc
@@ -23,9 +23,11 @@
                                        :sv "Lägg till..."
                                        :en "Add more..."}
    :feedback-header                   {:fi "Hei, kerro vielä mitä pidit hakulomakkeesta!"
-                                       :en "Hi! Care to take a moment to rate our application form?"}
+                                       :en "Hi! Care to take a moment to rate our application form?"
+                                       :sv "Hej, berätta ännu vad du tyckte om ansökningsblanketten?"}
    :feedback-disclaimer               {:fi "Yhteystietojasi ei käytetä tai yhdistetä palautteen tietoihin."
-                                       :en "Your personal information is not sent or associated with the feedback given."}
+                                       :en "Your personal information is not sent or associated with the feedback given."
+                                       :sv "Dina kontaktuppgifter används inte och kopplas inte heller ihop med responsuppgifterna."}
    :feedback-ratings                  {:fi {1 "Huono"
                                             2 "Välttävä"
                                             3 "Tyydyttävä"
@@ -35,10 +37,18 @@
                                             2 "Passable"
                                             3 "OK"
                                             4 "Good"
-                                            5 "Excellent"}}
+                                            5 "Excellent"}
+                                       :sv {1 "Dålig"
+                                            2 "Försvarlig"
+                                            3 "Nöjaktig"
+                                            4 "Bra"
+                                            5 "Berömlig"}}
    :feedback-text-placeholder         {:fi "Anna halutessasi kommentteja hakulomakkeesta."
-                                       :en "Feel free to also share your comments regarding the application form."}
+                                       :en "Feel free to also share your comments regarding the application form."
+                                       :sv "Om du vill kan du ge kommentarer om ansökningsblanketten."}
    :feedback-send                     {:fi "Lähetä palaute"
-                                       :en "Send feedback"}
+                                       :en "Send feedback"
+                                       :sv "Skicka respons"}
    :feedback-thanks                   {:fi "Kiitos palautteestasi!"
-                                       :en "Thank you for your feedback!"}})
+                                       :en "Thank you for your feedback!"
+                                       :sv "Tack för din respons!"}})

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -556,11 +556,14 @@
   (fn [{:keys [db]}]
     (let [new-db    (assoc-in db [:application :feedback :status] :feedback-submitted)
           feedback  (-> db :application :feedback)
+          text (:text feedback)
           post-data {:form-key   (-> db :form :key)
                      :form-id    (-> db :form :id)
+                     :form-name  (-> db :form :name)
                      :user-agent (.-userAgent js/navigator)
                      :rating     (:stars feedback)
-                     :feedback   (-> feedback :text (subs 0 2000))}]
+                     :feedback   (when text
+                                   (subs text 0 2000))}]
       {:db   new-db
        :http {:method    :post
               :post-data post-data

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -533,3 +533,30 @@
     (-> db
         (update-in [:application :answers (keyword component-id) :values] autil/remove-nth attachment-idx)
         (update-attachment-answer-validity field-descriptor component-id))))
+
+(reg-event-db
+  :application/rating-hover
+  (fn [db [_ star-number]]
+    (assoc-in db [:application :feedback :star-hovered] star-number)))
+
+(reg-event-db
+  :application/rating-submit
+  (fn [db [_ star-number]]
+    (-> db
+        (assoc-in [:application :feedback :stars] star-number)
+        (assoc-in [:application :feedback :status] :rating-given))))
+
+(reg-event-db
+  :application/rating-update-feedback
+  (fn [db [_ feedback-text]]
+    (assoc-in db [:application :feedback :text] feedback-text)))
+
+(reg-event-db
+  :application/rating-feedback-submit
+  (fn [db _]
+    (assoc-in db [:application :feedback :status] :feedback-submitted)))
+
+(reg-event-db
+  :application/rating-form-toggle
+  (fn [db _]
+    (update-in db [:application :feedback :hidden?] not)))

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -125,9 +125,8 @@
             {:on-click #(dispatch [:application/rating-form-toggle])}
             [:i.zmdi.zmdi-close.close-details-button-mark]]
            [:div.application-feedback-form-container
-            (when (and (not submitted?)
-                       (not rated?))
-              [:h2.application-feedback-form__header (:feedback-header translations)])
+            (when (not submitted?)
+              [:h3.application-feedback-form__header (:feedback-header translations)])
             (when (not submitted?)
               [:div.application-feedback-form__rating-container
                {:on-click      #(dispatch [:application/rating-submit (star-number-from-event %)])
@@ -148,19 +147,25 @@
                           (< 0 stars-selected 6))
                    (get (:feedback-ratings translations) stars-selected)
                    (gstring/unescapeEntities "&nbsp;")))])
-            (when rated?
+            (when (not submitted?)
               [:div.application-feedback-form__text-feedback-container
                [:textarea.application__form-text-input.application__form-text-area.application__form-text-area__size-medium
                 {:on-change   #(dispatch [:application/rating-update-feedback (.-value (.-target %))])
                  :placeholder (:feedback-text-placeholder translations)
                  :max-length  2000}]])
-            (when rated?
-              [:a.application__send-feedback-button
+            (when (and (not submitted?)
+                     rated?)
+              [:a.application__send-feedback-button.application__send-feedback-button--enabled
                {:on-click (fn [evt]
                             (.preventDefault evt)
-                            (dispatch [:application/rating-feedback-submit]))} (:feedback-send translations)])
+                            (dispatch [:application/rating-feedback-submit]))}
+               (:feedback-send translations)])
+            (when (and (not submitted?)
+                       (not rated?))
+              [:a.application__send-feedback-button.application__send-feedback-button--disabled
+               (:feedback-send translations)])
             (when (not submitted?)
-              [:div.application-feedback-form__disclaimer (:feedback-disclaimer translations)])
+              [:div.application-feedback-form__disclaimer ])
             (when submitted?
               [:div (:feedback-thanks translations)])]])))))
 

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -126,7 +126,7 @@
             [:i.zmdi.zmdi-close.close-details-button-mark]]
            [:div.application-feedback-form-container
             (when (not submitted?)
-              [:h3.application-feedback-form__header (:feedback-header translations)])
+              [:h2.application-feedback-form__header (:feedback-header translations)])
             (when (not submitted?)
               [:div.application-feedback-form__rating-container
                {:on-click      #(dispatch [:application/rating-submit (star-number-from-event %)])
@@ -165,9 +165,9 @@
               [:a.application__send-feedback-button.application__send-feedback-button--disabled
                (:feedback-send translations)])
             (when (not submitted?)
-              [:div.application-feedback-form__disclaimer ])
+              [:div.application-feedback-form__disclaimer (:feedback-disclaimer translations)])
             (when submitted?
-              [:div (:feedback-thanks translations)])]])))))
+              [:div.application__thanks [:i.zmdi.zmdi-thumb-up.application__thanks-icon] [:span.application__thanks-text (:feedback-thanks translations)]])]])))))
 
 (defn error-display []
   (let [error-message (subscribe [:state-query [:error :message]])

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -12,7 +12,8 @@
             [cljs.core.match :refer-macros [match]]
             [cljs-time.format :refer [unparse formatter]]
             [cljs-time.coerce :refer [from-long]]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [goog.string :as gstring]))
 
 (def ^:private language-names
   {:fi "Suomeksi"
@@ -97,6 +98,60 @@
        (when @can-apply?
          [render-fields @form])])))
 
+(defn- star-number-from-event
+  [event]
+  (js/parseInt (.-starN (.-dataset (.-target event))) 10))
+
+(defn feedback-form
+  []
+  (let [submit-status (subscribe [:state-query [:application :submit-status]])
+        star-hovered  (subscribe [:state-query [:application :feedback :star-hovered]])
+        stars         (subscribe [:state-query [:application :feedback :stars]])
+        hidden?       (subscribe [:state-query [:application :feedback :hidden?]])
+        rating-status (subscribe [:state-query [:application :feedback :status]])]
+    (fn []
+      (when (and
+              (= :submitted @submit-status)
+              (not @hidden?))
+        [:div.application-feedback-form
+         [:a.application-feedback-form__close-button
+          {:on-click #(dispatch [:application/rating-form-toggle])}
+          [:i.zmdi.zmdi-close.close-details-button-mark]]
+         [:div.application-feedback-form-container
+          [:h1.application-feedback-form__header "Hei, kerro vielä mitä pidit hakulomakkeesta!"]
+          [:div.application-feedback-form__rating-container
+           {:on-click      #(dispatch [:application/rating-submit (star-number-from-event %)])
+            :on-mouse-out  #(dispatch [:application/rating-hover 0])
+            :on-mouse-over #(dispatch [:application/rating-hover (star-number-from-event %)])}
+           (let [stars-active (or @stars @star-hovered 0)]
+             (map (fn [n]
+                    (let [star-classes (if (< n stars-active)
+                                         :i.zmdi.zmdi-star.zmdi-hc-5x
+                                         :i.zmdi.zmdi-star-outline.zmdi-hc-5x)]
+                      [star-classes
+                       {:key         (str "rating-star-" n)
+                        :data-star-n (inc n)}])) (range 5)))]
+          [:div.application-feedback-form__rating-text
+           (case @star-hovered
+             1 ":'("
+             2 ":("
+             3 ":|"
+             4 ":)"
+             5 ":D"
+             (gstring/unescapeEntities "&nbsp;"))]
+          (when (= :rating-given @rating-status)
+            [:div.application-feedback-form__text-feedback-container
+             [:textarea.application__form-text-input.application__form-text-area.application__form-text-area__size-medium
+              {:on-change   #(dispatch [:application/rating-update-feedback (.-value (.-target %))])
+               :placeholder "Anna lisäpalautetta!"}]])
+          (when (= :rating-given @rating-status)
+            [:a.application__send-feedback-button
+             {:on-click (fn [evt]
+                          (.preventDefault evt)
+                          (dispatch [:application/rating-feedback-submit]))} "Lähetä palaute"])
+          (when (= :feedback-submitted @rating-status)
+            [:div "Kiitos palautteestasi!"])]]))))
+
 (defn error-display []
   (let [error-message (subscribe [:state-query [:error :message]])
         detail (subscribe [:state-query [:error :detail]])]
@@ -108,4 +163,5 @@
   [:div
    [banner]
    [error-display]
-   [application-contents]])
+   [application-contents]
+   [feedback-form]])

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -125,8 +125,9 @@
             {:on-click #(dispatch [:application/rating-form-toggle])}
             [:i.zmdi.zmdi-close.close-details-button-mark]]
            [:div.application-feedback-form-container
-            (when (not submitted?)
-              [:h1.application-feedback-form__header (:feedback-header translations)])
+            (when (and (not submitted?)
+                       (not rated?))
+              [:h2.application-feedback-form__header (:feedback-header translations)])
             (when (not submitted?)
               [:div.application-feedback-form__rating-container
                {:on-click      #(dispatch [:application/rating-submit (star-number-from-event %)])
@@ -135,8 +136,8 @@
                (let [stars-active (or @stars @star-hovered 0)]
                  (map (fn [n]
                         (let [star-classes (if (< n stars-active)
-                                             :i.application-feedback-form__rating-star--active.zmdi.zmdi-star.zmdi-hc-5x
-                                             :i.application-feedback-form__rating-star--inactive.zmdi.zmdi-star-outline.zmdi-hc-5x)]
+                                             :i.application-feedback-form__rating-star.application-feedback-form__rating-star--active.zmdi.zmdi-star
+                                             :i.application-feedback-form__rating-star.application-feedback-form__rating-star--inactive.zmdi.zmdi-star-outline)]
                           [star-classes
                            {:key         (str "rating-star-" n)
                             :data-star-n (inc n)}])) (range 5)))])

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -119,7 +119,6 @@
                            translations/application-view-translations)
             rated?       (= :rating-given @rating-status)
             submitted?   (= :feedback-submitted @rating-status)]
-        (println "trans" (keyword (:selected-language @form)) translations)
         (when @show-feedback?
           [:div.application-feedback-form
            [:a.application-feedback-form__close-button

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -147,7 +147,8 @@
             [:div.application-feedback-form__text-feedback-container
              [:textarea.application__form-text-input.application__form-text-area.application__form-text-area__size-medium
               {:on-change   #(dispatch [:application/rating-update-feedback (.-value (.-target %))])
-               :placeholder "Anna halutessasi kehitysideoita tai kommentteja hakijan palvelusta"}]])
+               :placeholder "Anna halutessasi kehitysideoita tai kommentteja hakijan palvelusta"
+               :max-length  2000}]])
           (when (= :rating-given @rating-status)
             [:a.application__send-feedback-button
              {:on-click (fn [evt]

--- a/src/cljs/ataru/hakija/hakija_readonly.cljs
+++ b/src/cljs/ataru/hakija/hakija_readonly.cljs
@@ -55,14 +55,6 @@
         :when (get-in ui [(keyword (:id child)) :visible?] true)]
     [field child application lang]))
 
-(defn- person-info-uneditable-wrapper [content lang]
-  [:div.application__wrapper-element.application__wrapper-element--border
-   [:div.application__wrapper-heading
-    [:h2 (-> content :label lang)]
-    [scroll-to-anchor content]]
-   [:div.application__form-field
-    [:div.application__form-field--person-info-note (:cannot-edit-personal-info (get-translations lang application-view-translations))]]])
-
 (defn wrapper [content application lang children]
   (let [ui (subscribe [:state-query [:application :ui]])]
     (fn [content application lang children]


### PR DESCRIPTION
Implemets a feedback form, shown after an application is submitted (should maybe have a possibility to send feedback also before submitting). Things to note:

* Posts to Flowdock, needs flow tokens configured for each environment (currently there exists only a test flow for test environments)
* Does not have Swedish localizations yet – need to be added before production use
