### PR TITLE
Virkailija dashboard

### DIFF
--- a/resources/sql/statistics-queries.sql
+++ b/resources/sql/statistics-queries.sql
@@ -1,7 +1,14 @@
 -- name: yesql-get-application-stats
 SELECT
-  form_id,
-  created_time
-FROM applications
-WHERE created_time > :start_time
-ORDER BY created_time;
+  a.form_id,
+  a.created_time,
+  f.key,
+  (SELECT name
+   FROM forms f2
+   WHERE f2.key = f.key
+   ORDER BY id DESC
+   LIMIT 1) as form_name
+FROM applications a
+  JOIN forms f ON f.id = a.form_id
+WHERE a.created_time > :start_time
+ORDER BY a.created_time;

--- a/resources/sql/statistics-queries.sql
+++ b/resources/sql/statistics-queries.sql
@@ -1,0 +1,7 @@
+-- name: yesql-get-application-stats
+SELECT
+  form_id,
+  created_time
+FROM applications
+WHERE created_time > :start_time
+ORDER BY created_time;

--- a/resources/templates/dashboard.html
+++ b/resources/templates/dashboard.html
@@ -58,12 +58,12 @@
         return response.json()
       })
       .then(function(forms) {
-        if (_.keys(forms).length > 0) {
+        if (_.keys(forms).length > 1) {
           MG.data_graphic({
             title: "Applications per " + period,
             data: createData(forms, dateFormat),
-            width: 600,
-            height: 200,
+            width: 800,
+            height: 400,
             right: 40,
             interpolate: d3.curveLinear,
             missing_is_zero: true,

--- a/resources/templates/dashboard.html
+++ b/resources/templates/dashboard.html
@@ -1,95 +1,83 @@
 <html>
 <head>
-  <script src="http://www.chartjs.org/dist/2.6.0/Chart.bundle.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.9.1/d3.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/metrics-graphics/2.11.0/metricsgraphics.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/metrics-graphics/2.11.0/metricsgraphics.min.css" rel="stylesheet">
   <style type="text/css">
-    canvas {
-      max-width: 600px;
+    .stat-container {
+      margin-bottom: 40px;
+    }
+
+    .stat-legend {
+      margin-left: 30px;
     }
   </style>
 </head>
 <body>
-<div>
-  <h2>Hakemukset kuukauden ajalta</h2>
-  <canvas id="applications-for-month"></canvas>
-</div>
-<div>
-  <h2>Hakemukset viikon ajalta</h2>
-  <canvas id="applications-for-week"></canvas>
-</div>
-<div>
-  <h2>Hakemukset päivän ajalta</h2>
-  <canvas id="applications-for-day"></canvas>
-</div>
+  <div class="stat-container">
+    <div id="applications-for-month"></div>
+    <div id="applications-for-month-legend" class="stat-legend"></div>
+  </div>
+  <div class="stat-container">
+    <div id="applications-for-week"></div>
+    <div id="applications-for-week-legend" class="stat-legend"></div>
+  </div>
+  <div class="stat-container">
+    <div id="applications-for-day"></div>
+    <div id="applications-for-day-legend" class="stat-legend"></div>
+  </div>
 </body>
 
 <script type="text/javascript">
-  function createLabels(datasets) {
-    var categories = _.flatMap(datasets, function(dataset) {
-      return _.map(dataset.data, function(datum) {
-        return datum.x
+
+  function createLegend(forms) {
+    return _.map(forms, function(form, formKey) {
+      return form['form-name']
+    })
+  }
+
+  function createData(forms, dateFormat) {
+    var arrs = _.map(forms, function(form, formKey) {
+      return _.map(form.counts, function(n, category) {
+        return {
+          date: category,
+          value: n
+        }
       })
     })
-
-    return _.sortBy(_.uniq(categories))
-  }
-
-  function createDatasets(applications) {
-    return _.map(applications, function(application, formId) {
-      return {
-        "label": formId,
-        "fill": false,
-        "data": _.map(application, function(n, category) {
-          return {
-            "x": category,
-            "y": n,
-          }
-        })
-      }
+    return _.map(arrs, function(arr) {
+      return MG.convert.date(arr, 'date', dateFormat)
     })
   }
 
-  function loadChartFor(period) {
+  function loadChartFor(period, dateFormat) {
     fetch('/lomake-editori/api/statistics/applications/' + period, {credentials: 'same-origin'})
       .then(function(response) {
         return response.json()
       })
-      .then(function(applications) {
-        if (_.keys(applications).length > 0) {
-          var datasets = createDatasets(applications)
-          var labels = createLabels(datasets)
-
-          new Chart(document.getElementById("applications-for-" + period), {
-            type: 'line',
-            data: {
-              datasets: datasets,
-              labels: labels,
-              scales: {
-                xAxes: [{
-                  display: true,
-                  scaleLabel: {
-                    display: true,
-                    labelString: "Aika"
-                  }
-                }],
-                yAxes: [{
-                  display: true,
-                  scaleLabel: {
-                    display: true,
-                    labelString: "Hakemusten lkm"
-                  }
-                }]
-              }
-
-            }
-          })
+      .then(function(forms) {
+        if (_.keys(forms).length > 0) {
+          MG.data_graphic({
+            title: "Applications per " + period,
+            data: createData(forms, dateFormat),
+            width: 600,
+            height: 200,
+            right: 40,
+            interpolate: d3.curveLinear,
+            missing_is_zero: true,
+            target: '#applications-for-' + period,
+            legend: createLegend(forms),
+            legend_target: '#applications-for-' + period + "-legend"
+          });
         }
-      })
+      });
   }
 
-  loadChartFor('day')
-  loadChartFor('week')
-  loadChartFor('month')
+  loadChartFor('day', '%Y-%m-%d %H:%M')
+  loadChartFor('week', '%Y-%m-%d %H:%M')
+  loadChartFor('month', '%Y-%m-%d')
 
 </script>
 </html>

--- a/resources/templates/dashboard.html
+++ b/resources/templates/dashboard.html
@@ -1,0 +1,95 @@
+<html>
+<head>
+  <script src="http://www.chartjs.org/dist/2.6.0/Chart.bundle.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"></script>
+  <style type="text/css">
+    canvas {
+      max-width: 600px;
+    }
+  </style>
+</head>
+<body>
+<div>
+  <h2>Hakemukset kuukauden ajalta</h2>
+  <canvas id="applications-for-month"></canvas>
+</div>
+<div>
+  <h2>Hakemukset viikon ajalta</h2>
+  <canvas id="applications-for-week"></canvas>
+</div>
+<div>
+  <h2>Hakemukset päivän ajalta</h2>
+  <canvas id="applications-for-day"></canvas>
+</div>
+</body>
+
+<script type="text/javascript">
+  function createLabels(datasets) {
+    var categories = _.flatMap(datasets, function(dataset) {
+      return _.map(dataset.data, function(datum) {
+        return datum.x
+      })
+    })
+
+    return _.sortBy(_.uniq(categories))
+  }
+
+  function createDatasets(applications) {
+    return _.map(applications, function(application, formId) {
+      return {
+        "label": formId,
+        "fill": false,
+        "data": _.map(application, function(n, category) {
+          return {
+            "x": category,
+            "y": n,
+          }
+        })
+      }
+    })
+  }
+
+  function loadChartFor(period) {
+    fetch('/lomake-editori/api/statistics/applications/' + period, {credentials: 'same-origin'})
+      .then(function(response) {
+        return response.json()
+      })
+      .then(function(applications) {
+        if (_.keys(applications).length > 0) {
+          var datasets = createDatasets(applications)
+          var labels = createLabels(datasets)
+
+          new Chart(document.getElementById("applications-for-" + period), {
+            type: 'line',
+            data: {
+              datasets: datasets,
+              labels: labels,
+              scales: {
+                xAxes: [{
+                  display: true,
+                  scaleLabel: {
+                    display: true,
+                    labelString: "Aika"
+                  }
+                }],
+                yAxes: [{
+                  display: true,
+                  scaleLabel: {
+                    display: true,
+                    labelString: "Hakemusten lkm"
+                  }
+                }]
+              }
+
+            }
+          })
+        }
+      })
+  }
+
+  loadChartFor('day')
+  loadChartFor('week')
+  loadChartFor('month')
+
+</script>
+</html>

--- a/resources/templates/dashboard.html
+++ b/resources/templates/dashboard.html
@@ -12,6 +12,7 @@
 
     .stat-legend {
       margin-left: 30px;
+      max-width: 1000px;
     }
   </style>
 </head>
@@ -62,7 +63,7 @@
           MG.data_graphic({
             title: "Applications per " + period,
             data: createData(forms, dateFormat),
-            width: 800,
+            width: 1000,
             height: 400,
             right: 40,
             interpolate: d3.curveLinear,

--- a/src/clj/ataru/cache/cache_service.clj
+++ b/src/clj/ataru/cache/cache_service.clj
@@ -9,9 +9,12 @@
 (def default-map-config {:ttl      600
                          :max-size 500})
 
-(def cached-map-config {:hakukohde {:config {:max-size 1000 :ttl 3600}}
-                        :haku      {:config {:max-size 1000 :ttl 3600}}
-                        :koulutus  {:config {:max-size 1000 :ttl 3600}}})
+(def cached-map-config {:hakukohde        {:config {:max-size 1000 :ttl 3600}}
+                        :haku             {:config {:max-size 1000 :ttl 3600}}
+                        :koulutus         {:config {:max-size 1000 :ttl 3600}}
+                        :statistics-month {:config {:max-size 500 :ttl 36000}}
+                        :statistics-week  {:config {:max-size 500 :ttl 3600}}
+                        :statistics-day   {:config {:max-size 500 :ttl 300}}})
 
 (def local-cluster-cfg {:clustered? true
                         :hosts ["127.0.0.1"]})
@@ -84,8 +87,9 @@
 
 (defn- get-cached-map [component cache]
   "Only allow access to preconfigured maps"
-  (when (cache cached-map-config)
-    (.getMap (:hazelcast-instance component) (name cache))))
+  (if (cache cached-map-config)
+    (.getMap (:hazelcast-instance component) (name cache))
+    (throw (RuntimeException. (str "Invalid cache: " cache)))))
 
 (defrecord HazelcastCacheService [hazelcast-instance]
   component/Lifecycle

--- a/src/clj/ataru/core.clj
+++ b/src/clj/ataru/core.clj
@@ -1,5 +1,6 @@
 (ns ataru.core
   (:require [com.stuartsierra.component :as component]
+            [clj-time.jdbc] ; for java.sql.Timestamp / org.joda.time.DateTime coercion
             [clojure.tools.namespace.repl :refer [refresh]]
             [ataru.log.audit-log :as audit-log]
             [ataru.util.app-utils :as app-utils]

--- a/src/clj/ataru/statistics/statistics_service.clj
+++ b/src/clj/ataru/statistics/statistics_service.clj
@@ -4,8 +4,8 @@
             [clj-time.format :as time-format]))
 
 (def category-formatters {:month (time-format/formatter "yyyy-MM-dd")
-                          :week  (time-format/formatter "yyyy-MM-dd-HH")
-                          :day   (time-format/formatter "yyyy-MM-dd-HH-mm")})
+                          :week  (time-format/formatter "yyyy-MM-dd HH:00")
+                          :day   (time-format/formatter "yyyy-MM-dd HH:mm")})
 
 (defn- get-and-parse-application-stats
   [start-time time-period]
@@ -13,16 +13,16 @@
         applications                    (store/get-application-stats start-time)]
     (reduce
       (fn [acc application]
-        (let [form-id (-> application
-                          :form-id
-                          (str)
-                          (keyword))
+        (let [form-key (-> application
+                           :key
+                           (keyword))
               category (time-format/unparse group-by-fn (:created-time application))]
-          (if-let [category-map (form-id acc)]
-            (if (get category-map category)
-              (update-in acc [form-id category] inc)
-              (assoc-in acc [form-id category] 1))
-            (assoc-in acc [form-id category] 1))))
+          (if-let [form-map (form-key acc)]
+            (if (get-in form-map [:counts category])
+              (update-in acc [form-key :counts category] inc)
+              (assoc-in acc [form-key :counts category] 1))
+            (assoc acc form-key {:form-name (:form-name application)
+                                 :counts    {category 1}}))))
       {}
       applications)))
 

--- a/src/clj/ataru/statistics/statistics_service.clj
+++ b/src/clj/ataru/statistics/statistics_service.clj
@@ -1,0 +1,44 @@
+(ns ataru.statistics.statistics-service
+  (:require [ataru.statistics.statistics-store :as store]
+            [clj-time.core :as time]
+            [clj-time.format :as time-format]))
+
+(def category-formatters {:month (time-format/formatter "yyyy-MM-dd")
+                          :week  (time-format/formatter "yyyy-MM-dd-HH")
+                          :day   (time-format/formatter "yyyy-MM-dd-HH-mm")})
+
+(defn- get-and-parse-application-stats
+  [start-time time-period]
+  (let [group-by-fn                     (time-period category-formatters)
+        applications                    (store/get-application-stats start-time)]
+    (reduce
+      (fn [acc application]
+        (let [form-id (-> application
+                          :form-id
+                          (str)
+                          (keyword))
+              category (time-format/unparse group-by-fn (:created-time application))]
+          (if-let [category-map (form-id acc)]
+            (if (get category-map category)
+              (update-in acc [form-id category] inc)
+              (assoc-in acc [form-id category] 1))
+            (assoc-in acc [form-id category] 1))))
+      {}
+      applications)))
+
+(defn- earlier-at-midnight
+  [period-fn period-num date-time]
+  (-> date-time
+      (time/minus (period-fn period-num))
+      (time/with-time-at-start-of-day)))
+
+(defn get-application-stats
+  [cache-service time-period]
+  (let [cache-key  (keyword (str "statistics-" (name time-period)))
+        entry-key  :applications
+        now        (time/now)
+        start-time (case time-period
+                     :month (earlier-at-midnight time/months 1 now)
+                     :week (earlier-at-midnight time/weeks 1 now)
+                     :day (earlier-at-midnight time/days 1 now))]
+    (.cache-get-or-fetch cache-service cache-key entry-key #(get-and-parse-application-stats start-time time-period))))

--- a/src/clj/ataru/statistics/statistics_store.clj
+++ b/src/clj/ataru/statistics/statistics_store.clj
@@ -1,0 +1,18 @@
+(ns ataru.statistics.statistics-store
+  (:require [yesql.core :refer [defqueries]]
+            [camel-snake-kebab.core :refer [->kebab-case-keyword]]
+            [camel-snake-kebab.extras :refer [transform-keys]]
+            [ataru.db.db :as db]))
+
+(defqueries "sql/statistics-queries.sql")
+
+(def ^:private ->kebab-case-kw (partial transform-keys ->kebab-case-keyword))
+
+(defn- exec-db
+  [ds-key query params]
+  (db/exec ds-key query params))
+
+(defn get-application-stats
+  [start-time]
+  (->> (exec-db :db yesql-get-application-stats {:start_time start-time})
+       (map ->kebab-case-kw)))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -92,6 +92,8 @@
 
 (api/defroutes test-routes
   (api/undocumented
+    (api/GET "/dashboard" []
+      (render-file-in-dev "templates/dashboard.html"))
     (api/GET "/virkailija-test.html" []
       (render-file-in-dev "templates/virkailija-test.html"))
     (api/GET "/spec/:filename.js" [filename]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -92,8 +92,6 @@
 
 (api/defroutes test-routes
   (api/undocumented
-    (api/GET "/dashboard" []
-      (render-file-in-dev "templates/dashboard.html"))
     (api/GET "/virkailija-test.html" []
       (render-file-in-dev "templates/virkailija-test.html"))
     (api/GET "/spec/:filename.js" [filename]
@@ -344,6 +342,11 @@
     ;; and verify that it works on test environment as well.
     (api/GET "/lomake-editori" [] (redirect-to-service-url))))
 
+(api/defroutes dashboard-routes
+  (api/undocumented
+    (api/GET "/dashboard" []
+      (render-file-in-dev "templates/dashboard.html"))))
+
 (defrecord Handler []
   component/Lifecycle
 
@@ -372,6 +375,7 @@
                               resource-routes
                               (api/context "/lomake-editori" []
                                 test-routes
+                                dashboard-routes
                                 (api/middleware [user-feedback/wrap-user-feedback
                                                  wrap-database-backed-session
                                                  auth-middleware/with-authentication]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -19,6 +19,7 @@
             [ataru.koodisto.koodisto :as koodisto]
             [ataru.applications.excel-export :as excel]
             [ataru.virkailija.user.session-organizations :refer [organization-list]]
+            [ataru.statistics.statistics-service :as statistics-service]
             [cheshire.core :as json]
             [clojure.core.match :refer [match]]
             [clojure.java.io :as io]
@@ -283,7 +284,14 @@
                        (header (ok (:body file-response))
                                "Content-Disposition"
                                (:content-disposition file-response))
-                       (not-found))))))
+                       (not-found))))
+
+                 (api/context "/statistics" []
+                   :tags ["statistics-api"]
+                   (api/GET "/applications/:time-period" []
+                            :path-params [time-period :- (api/describe (s/enum "month" "week" "day") "One of: month, week, day")]
+                            :summary "Get info about number of submitted applications for past time period"
+                            (ok (statistics-service/get-application-stats cache-service (keyword time-period)))))))
 
 (api/defroutes resource-routes
   (api/undocumented


### PR DESCRIPTION
A proof-of-concepty dashboard for gleaming information about the system's internals. Currently shows graphs of number of applications submitted by the past month, week and day (if any exist). The front-end is especially quick'n'dirty while the actual design of the dashboard is created.

Can be found at /lomake-editori/dashboard. 

![screen shot 2017-06-28 at 10 58 50](https://user-images.githubusercontent.com/1083484/27626659-7e5f35c0-5bf1-11e7-87f3-e3212774df2f.png)
