### PR TITLE
Fix application editing with old forms

### DIFF
--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -98,7 +98,7 @@
 
 (defn- merge-applications [new-application old-application]
   (merge new-application
-         (select-keys old-application [:key :secret :haku :hakukohde :person-oid])))
+         (select-keys old-application [:key :secret :haku :person-oid])))
 
 (defn update-application [{:keys [lang secret] :as new-application}]
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -94,8 +94,8 @@
         form               (-> application
                                (:form)
                                (form-store/fetch-by-id)
-                               (hakukohde/populate-hakukohde-answer-options tarjonta-info)
-                               (hakija-form-service/inject-hakukohde-component-if-missing))
+                               (hakija-form-service/inject-hakukohde-component-if-missing)
+                               (hakukohde/populate-hakukohde-answer-options tarjonta-info))
         allowed            (allowed-to-apply? tarjonta-service application)
         latest-application (application-store/get-latest-application-by-secret (:secret application))
         final-application  (if is-modify?

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -5,6 +5,7 @@
     [ataru.hakija.background-jobs.hakija-jobs :as hakija-jobs]
     [ataru.hakija.application-email-confirmation :as application-email]
     [ataru.hakija.background-jobs.attachment-finalizer-job :as attachment-finalizer-job]
+    [ataru.hakija.hakija-form-service :as hakija-form-service]
     [ataru.person-service.person-integration :as person-integration]
     [ataru.tarjonta-service.hakuaika :as hakuaika]
     [ataru.tarjonta-service.hakukohde :as hakukohde]
@@ -88,16 +89,19 @@
     (log/info (str "Updated application " (:key old-application) ", removed old attachments: " (clojure.string/join ", " orphan-attachments)))))
 
 (defn- validate-and-store [tarjonta-service application store-fn is-modify?]
-  (let [form               (form-store/fetch-by-id (:form application))
-        tarjonta-info      (when (:haku application)
+  (let [tarjonta-info      (when (:haku application)
                              (tarjonta-parser/parse-tarjonta-info-by-haku tarjonta-service (:haku application)))
-        form-with-tarjonta (hakukohde/populate-hakukohde-answer-options form tarjonta-info)
+        form               (-> application
+                               (:form)
+                               (form-store/fetch-by-id)
+                               (hakukohde/populate-hakukohde-answer-options tarjonta-info)
+                               (hakija-form-service/inject-hakukohde-component-if-missing))
         allowed            (allowed-to-apply? tarjonta-service application)
         latest-application (application-store/get-latest-application-by-secret (:secret application))
         final-application  (if is-modify?
                              (merge-uneditable-answers-from-previous latest-application application)
                              application)
-        validation-result  (validator/valid-application? final-application form-with-tarjonta)]
+        validation-result  (validator/valid-application? final-application form)]
     (cond
       (and (:haku application)
            (empty? (:hakukohde application)))

--- a/src/clj/ataru/hakija/hakija_form_service.clj
+++ b/src/clj/ataru/hakija/hakija_form_service.clj
@@ -6,7 +6,7 @@
             [taoensso.timbre :refer [warn]]
             [ataru.virkailija.component-data.component :as component]))
 
-(defn- inject-hakukohde-component-if-missing
+(defn inject-hakukohde-component-if-missing
   "Add hakukohde component to legacy forms (new ones have one added on creation)"
   [form]
   (let [has-hakukohde-component? (-> (filter #(= (keyword (:id %)) :hakukohteet) (:content form))

--- a/src/cljc/ataru/virkailija/component_data/component.cljc
+++ b/src/cljc/ataru/virkailija/component_data/component.cljc
@@ -93,6 +93,8 @@
    :params     {}
    :options    []})
 
+; NB: when altering this, take into account that the hakukohteet component is
+;     dynamically injected to legacy forms without one already present:
 (defn hakukohteet []
   {:fieldClass "formField"
    :fieldType "hakukohteet"


### PR DESCRIPTION
Editing applications with old forms was broken due to them not having the `hakukohteet` component in the form content. This fixes the issue by dynamically adding the component to the forms from which it is missing (both on client side and during validation on the server).