### PR TITLE
Fix attachment upload

### DIFF
--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -474,30 +474,29 @@
       (dispatch [:application/add-attachments field-descriptor component-id attachment-count files]))))
 
 (defn attachment-upload [field-descriptor component-id attachment-count]
-  (let [id        (str component-id "-upload-button")
-        language  @(subscribe [:application/form-language])]
-    (fn [field-descriptor component-id attachment-count]
-      [:div.application__form-upload-attachment-container
-       [:input.application__form-upload-input
-        {:id        id
-         :type      "file"
-         :multiple  "multiple"
-         :key       (str "upload-button-" component-id "-" attachment-count)
-         :on-change (partial upload-attachment field-descriptor component-id attachment-count)}]
-       [:label.application__form-upload-label
-        {:for id}
-        [:i.zmdi.zmdi-cloud-upload.application__form-upload-icon]
-        [:span.application__form-upload-button-add-text (case language
-                                                          :fi "Lisää liite..."
-                                                          :en "Upload attachment..."
-                                                          :sv "Ladda upp bilagan...")]]
-       (let [file-size-info-text (case language
-                                   :fi "Tiedoston maksimikoko on 10 MB"
-                                   :en "Maximum file size is 10 MB"
-                                   :sv "Den maximala filstorleken är 10 MB")]
-         (if @(subscribe [:state-query [:application :answers (keyword component-id) :too-big]])
-           [:span.application__form-upload-button-error.animated.shake file-size-info-text]
-           [:span.application__form-upload-button-info file-size-info-text]))])))
+  (let [id       (str component-id "-upload-button")
+        language @(subscribe [:application/form-language])]
+    [:div.application__form-upload-attachment-container
+     [:input.application__form-upload-input
+      {:id        id
+       :type      "file"
+       :multiple  "multiple"
+       :key       (str "upload-button-" component-id "-" attachment-count)
+       :on-change (partial upload-attachment field-descriptor component-id attachment-count)}]
+     [:label.application__form-upload-label
+      {:for id}
+      [:i.zmdi.zmdi-cloud-upload.application__form-upload-icon]
+      [:span.application__form-upload-button-add-text (case language
+                                                        :fi "Lisää liite..."
+                                                        :en "Upload attachment..."
+                                                        :sv "Ladda upp bilagan...")]]
+     (let [file-size-info-text (case language
+                                 :fi "Tiedoston maksimikoko on 10 MB"
+                                 :en "Maximum file size is 10 MB"
+                                 :sv "Den maximala filstorleken är 10 MB")]
+       (if @(subscribe [:state-query [:application :answers (keyword component-id) :too-big]])
+         [:span.application__form-upload-button-error.animated.shake file-size-info-text]
+         [:span.application__form-upload-button-info file-size-info-text]))]))
 
 (defn- filename->label [{:keys [filename size]}]
   (str filename " (" (util/size-bytes->str size) ")"))


### PR DESCRIPTION
Changes:

* Allow multiple attachments to be uploaded in separate "upload processes".
* Don't allow attachment with same name and size to be uploaded multiple times.