### PR TITLE
Accessibility improvements

### DIFF
--- a/resources/templates/hakija.html
+++ b/resources/templates/hakija.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+    <title>Opintopolku – hakulomake</title>
     <meta charset='utf-8'>
     <script src="/hakemus/vendor/js/stacktrace.min.js?fingerprint={{cache-fingerprint}}"></script>
     <link rel="stylesheet" href="/hakemus/vendor/css/animate.min.css?fingerprint={{cache-fingerprint}}">

--- a/resources/templates/virkailija.html
+++ b/resources/templates/virkailija.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset='utf-8'>
+    <title>Opintopolku – Lomake-editori</title>
     <link rel="stylesheet" href="/lomake-editori/vendor/css/animate.min.css?fingerprint={{cache-fingerprint}}">
     <link rel="stylesheet" href="/lomake-editori/vendor/css/material-design-iconic-font.min.css?fingerprint={{cache-fingerprint}}">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,600,400italic,600italic,700italic' rel='stylesheet' type='text/css'>

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -80,7 +80,6 @@
                                                                                         "dropdown"
                                                                                         "singleChoice"
                                                                                         "multipleChoice"
-                                                                                        "koodistoField"
                                                                                         "attachment"
                                                                                         "hakukohteet"])
                         (s/optional-key :belongs-to-hakukohteet)         [s/Str]})

--- a/src/cljc/ataru/translations/application_view.cljc
+++ b/src/cljc/ataru/translations/application_view.cljc
@@ -51,4 +51,7 @@
                                        :sv "Skicka respons"}
    :feedback-thanks                   {:fi "Kiitos palautteestasi!"
                                        :en "Thank you for your feedback!"
-                                       :sv "Tack för din respons!"}})
+                                       :sv "Tack för din respons!"}
+   :page-title                        {:fi "Opintopolku – hakulomake"
+                                       :en "Studyinfo – application form"
+                                       :sv "Studieinfo – ansökningsblankett"}})

--- a/src/cljc/ataru/virkailija/component_data/component.cljc
+++ b/src/cljc/ataru/virkailija/component_data/component.cljc
@@ -99,10 +99,9 @@
   {:fieldClass                     "formField"
    :fieldType                      "hakukohteet"
    :id                             "hakukohteet"
-   ; TODO localizations
    :label                          {:fi "Hakukohteet"
-                                    :sv ""
-                                    :en ""}
+                                    :sv "Ansökningsmål"
+                                    :en "Application options"}
    :params                         {}
    :options                        []
    :validators                     [:hakukohteet]

--- a/src/cljs/ataru/application_common/fx.cljs
+++ b/src/cljs/ataru/application_common/fx.cljs
@@ -19,3 +19,8 @@
                                   (re-frame/dispatch dispatch)
                                   (swap! debounces dissoc id))
                                 timeout))))
+
+(re-frame/reg-fx
+  :set-page-title
+  (fn [title]
+    (aset js/document "title" title)))

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -80,6 +80,7 @@
       (let [label (non-blank-val (get-in field-descriptor [:label @lang])
                                  (get-in field-descriptor [:label @default-lang]))]
         [:label.application__form-field-label
+         {:for (:id field-descriptor)}
          [:span (str label (required-hint field-descriptor))]
          [scroll-to-anchor field-descriptor]]))))
 

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -148,7 +148,8 @@
                                                  " application__form-text-input--normal"))
                   :value       (if cannot-view? "***********" (:value @answer))
                   :on-blur     on-blur
-                  :on-change   on-change}
+                  :on-change   on-change
+                  :required    (is-required-field? field-descriptor)}
                  (when (or disabled cannot-view?) {:disabled true}))])])))
 
 (defn repeatable-text-field [field-descriptor & {:keys [div-kwd] :or {div-kwd :div.application__form-field}}]
@@ -173,13 +174,14 @@
             [:div
              [:input.application__form-text-input
               (merge
-               {:type      "text"
-                :class     (str size-class (if (show-text-field-error-class? field-descriptor value valid)
-                                             " application__form-field-error"
-                                             " application__form-text-input--normal"))
-                :value     value
-                :data-idx  0
-                :on-change on-change}
+                {:type      "text"
+                 :class     (str size-class (if (show-text-field-error-class? field-descriptor value valid)
+                                              " application__form-field-error"
+                                              " application__form-text-input--normal"))
+                 :value     value
+                 :data-idx  0
+                 :on-change on-change
+                 :required  (is-required-field? field-descriptor)}
                (when (empty? value)
                  {:on-blur on-blur}))]])
           (map-indexed
@@ -238,7 +240,8 @@
            ; dynamically made changes to the text-field value.
            :default-value value
            :on-change     on-change
-           :value         value}]
+           :value         value
+           :required      (is-required-field? field-descriptor)}]
          [:span.application__form-textarea-max-length (str (count value) " / " max-length)]]))))
 
 (declare render-field)
@@ -333,7 +336,8 @@
                                     {:id (:id field-descriptor)
                                      :value     @value
                                      :on-change on-change
-                                     :disabled  @disabled?}
+                                     :disabled  @disabled?
+                                     :required  (is-required-field? field-descriptor)}
                                     (concat
                                       (when
                                         (and
@@ -497,7 +501,8 @@
        :type      "file"
        :multiple  "multiple"
        :key       (str "upload-button-" component-id "-" attachment-count)
-       :on-change (partial upload-attachment field-descriptor component-id attachment-count)}]
+       :on-change (partial upload-attachment field-descriptor component-id attachment-count)
+       :required  (is-required-field? field-descriptor)}]
      [:label.application__form-upload-label
       {:for id}
       [:i.zmdi.zmdi-cloud-upload.application__form-upload-icon]

--- a/src/cljs/ataru/hakija/application_hakukohde_component.cljs
+++ b/src/cljs/ataru/hakija/application_hakukohde_component.cljs
@@ -93,19 +93,27 @@
 (defn- search-hit-hakukohde-row
   [hakukohde-oid]
   (let [hakukohde-selected? @(subscribe [:application/hakukohde-selected? hakukohde-oid])
-        search-term @(subscribe [:application/hakukohde-query])]
+        search-term         @(subscribe [:application/hakukohde-query])
+        aria-header-id      (str "hakukohde-search-hit-header-" hakukohde-oid)
+        aria-description-id (str "hakukohde-search-hit-description-" hakukohde-oid)]
     [:div.application__hakukohde-row.application__hakukohde-row--search-hit
-     {:class (when hakukohde-selected? "application__hakukohde-row--search-hit-selected")}
+     {:class         (when hakukohde-selected? "application__hakukohde-row--search-hit-selected")
+      :aria-selected hakukohde-selected?}
      [:div.application__hakukohde-row-text-container
       [:div.application__hakukohde-selected-row-header
+       {:id aria-header-id}
        (hilight-text @(subscribe [:application/hakukohde-label hakukohde-oid]) search-term)]
       [:div.application__hakukohde-selected-row-description
+       {:id aria-description-id}
        (hilight-text @(subscribe [:application/hakukohde-description hakukohde-oid]) search-term)]]
      [:div.application__hakukohde-row-button-container
       (if hakukohde-selected?
         [:i.application__hakukohde-selected-check.zmdi.zmdi-check.zmdi-hc-2x]
         (if @(subscribe [:application/hakukohteet-full?])
           [:a.application__hakukohde-select-button.application__hakukohde-select-button--disabled
+           {:aria-labelledby  aria-header-id
+            :aria-describedby aria-description-id
+            :aria-disabled    true}
            @(subscribe [:application/get-i18n-text
                         ; TODO localization
                         {:fi "Lisää"
@@ -113,7 +121,9 @@
                          :en ""}])]
           [:a.application__hakukohde-select-button
            {:on-click           hakukohde-select-event-handler
-            :data-hakukohde-oid hakukohde-oid}
+            :data-hakukohde-oid hakukohde-oid
+            :aria-labelledby  aria-header-id
+            :aria-describedby aria-description-id}
            @(subscribe [:application/get-i18n-text
                         ; TODO localization
                         {:fi "Lisää"
@@ -132,6 +142,11 @@
       [:div.application__hakukohde-selection-search-input.application__form-text-input-box
        [:input.application__form-text-input-in-box
         {:on-change   hakukohde-query-change-event-handler
+         :title @(subscribe [:application/get-i18n-text
+                             ; TODO localization
+                             {:fi "Etsi tämän haun koulutuksia"
+                              :sv ""
+                              :en ""}])
          :placeholder @(subscribe [:application/get-i18n-text
                                    ; TODO localization
                                    {:fi "Etsi tämän haun koulutuksia"

--- a/src/cljs/ataru/hakija/application_hakukohde_component.cljs
+++ b/src/cljs/ataru/hakija/application_hakukohde_component.cljs
@@ -73,10 +73,9 @@
      :data-hakukohde-oid hakukohde-oid
      :role               "button"}
     @(subscribe [:application/get-i18n-text
-                 ; TODO localization
                  {:fi "Poista"
-                  :sv ""
-                  :en ""}])]])
+                  :sv "Ta bort"
+                  :en "Remove"}])]])
 
 (defn- selected-hakukohde-row
   [hakukohde-oid]
@@ -117,10 +116,9 @@
             :aria-describedby aria-description-id
             :aria-disabled    true}
            @(subscribe [:application/get-i18n-text
-                        ; TODO localization
                         {:fi "Lisää"
-                         :sv ""
-                         :en ""}])]
+                         :sv "Lägg till"
+                         :en "Add"}])]
           [:a.application__hakukohde-select-button
            {:on-click           hakukohde-select-event-handler
             :role               "button"
@@ -128,10 +126,9 @@
             :aria-labelledby    aria-header-id
             :aria-describedby   aria-description-id}
            @(subscribe [:application/get-i18n-text
-                        ; TODO localization
                         {:fi "Lisää"
-                         :sv ""
-                         :en ""}])]))]]))
+                         :sv "Lägg till"
+                         :en "Add"}])]))]]))
 
 (defn- hakukohde-selection-search
   []
@@ -146,15 +143,13 @@
        [:input.application__form-text-input-in-box
         {:on-change   hakukohde-query-change-event-handler
          :title @(subscribe [:application/get-i18n-text
-                             ; TODO localization
                              {:fi "Etsi tämän haun koulutuksia"
-                              :sv ""
-                              :en ""}])
+                              :sv "Sök ansökningsmål i denna ansökan"
+                              :en "Search for application options"}])
          :placeholder @(subscribe [:application/get-i18n-text
-                                   ; TODO localization
                                    {:fi "Etsi tämän haun koulutuksia"
-                                    :sv ""
-                                    :en ""}])
+                                    :sv "Sök ansökningsmål i denna ansökan"
+                                    :en "Search for application options"}])
          :value       hakukohde-query}]
        (when (not (empty? hakukohde-query))
          [:div.application__form-clear-text-input-in-box
@@ -185,10 +180,9 @@
        [:a.application__hakukohde-selection-open-search
         {:on-click hakukohde-search-toggle-event-handler}
         @(subscribe [:application/get-i18n-text
-                     ; TODO localization
                      {:fi "Lisää hakukohde"
-                      :sv ""
-                      :en ""}])]
+                      :sv "Lägg till ansökningsmål"
+                      :en "Add application option"}])]
        (when-let [max-hakukohteet @(subscribe [:application/max-hakukohteet])]
          [:span.application__hakukohde-selection-max-label (str "(max. " max-hakukohteet ")")])
        (when @(subscribe [:application/show-hakukohde-search])

--- a/src/cljs/ataru/hakija/application_hakukohde_component.cljs
+++ b/src/cljs/ataru/hakija/application_hakukohde_component.cljs
@@ -69,8 +69,9 @@
   [hakukohde-oid]
   [:div.application__hakukohde-row-button-container
    [:a.application__hakukohde-remove-link
-    {:on-click hakukohde-remove-event-handler
-     :data-hakukohde-oid hakukohde-oid}
+    {:on-click           hakukohde-remove-event-handler
+     :data-hakukohde-oid hakukohde-oid
+     :role               "button"}
     @(subscribe [:application/get-i18n-text
                  ; TODO localization
                  {:fi "Poista"
@@ -111,7 +112,8 @@
         [:i.application__hakukohde-selected-check.zmdi.zmdi-check.zmdi-hc-2x]
         (if @(subscribe [:application/hakukohteet-full?])
           [:a.application__hakukohde-select-button.application__hakukohde-select-button--disabled
-           {:aria-labelledby  aria-header-id
+           {:role             "button"
+            :aria-labelledby  aria-header-id
             :aria-describedby aria-description-id
             :aria-disabled    true}
            @(subscribe [:application/get-i18n-text
@@ -121,9 +123,10 @@
                          :en ""}])]
           [:a.application__hakukohde-select-button
            {:on-click           hakukohde-select-event-handler
+            :role               "button"
             :data-hakukohde-oid hakukohde-oid
-            :aria-labelledby  aria-header-id
-            :aria-describedby aria-description-id}
+            :aria-labelledby    aria-header-id
+            :aria-describedby   aria-description-id}
            @(subscribe [:application/get-i18n-text
                         ; TODO localization
                         {:fi "Lisää"


### PR DESCRIPTION
Various accessibility improvements. Including

* Missing localizations (sv/en)
* `for`-attributes for label elements
* HTML page titles
* Initial aria-attributes for elements

This is an initial pass, at least the following things should still be worked on:

* `aria-role` attributes for all non-form elements
* `aria-invalid` attributes for elements not passing validation