### PR TITLE
Hakemus edit loopholes

### DIFF
--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -201,7 +201,8 @@
                     {:key "first-name", :value "Aku Petteri", :fieldType "textField", :label {:fi "Etunimet", :sv "Förnamn"}}
                     {:key "postal-code", :value "00013", :fieldType "textField", :label {:fi "Postinumero", :sv "Postnummer"}}
                     {:key "language", :value "suomi", :fieldType "dropdown", :label {:fi "Äidinkieli", :sv "Modersmål"}}
-                    {:key "gender", :value "Mies", :fieldType "dropdown", :label {:fi "Sukupuoli", :sv "Kön"}}]})
+                    {:key "gender", :value "Mies", :fieldType "dropdown", :label {:fi "Sukupuoli", :sv "Kön"}}
+                    {:key "164954b5-7b23-4774-bd44-dee14071316b" :value ["57af9386-d80c-4321-ab4a-d53619c14a74"] :fieldType "attachment" :label {:fi "Eka liite" :sv ""}}]})
 
 (def application-with-person-info-module {:key "9d24af7d-f672-4c0e-870f-3c6999f105e0",
                                           :lang "fi",

--- a/spec/ataru/fixtures/form.clj
+++ b/spec/ataru/fixtures/form.clj
@@ -138,4 +138,11 @@
                                               :id "b0839467-a6e8-4294-b5cc-830756bbda8a",
                                               :params {},
                                               :validators ["required"]}],
-                                  :params {}}]})
+                                  :params {}}
+                                 {:label {:fi "Eka liite"
+                                          :sv ""}
+                                  :fieldClass "formField"
+                                  :id "164954b5-7b23-4774-bd44-dee14071316b"
+                                  :params {}
+                                  :options []
+                                  :fieldType "attachment"}]})

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -23,9 +23,11 @@
 (def form-invalid-ssn-field (assoc-in application-fixtures/person-info-form-application [:answers 8 :value] "010101-123M"))
 (def form-invalid-postal-code (assoc-in application-fixtures/person-info-form-application [:answers 11 :value] "0001"))
 (def form-invalid-dropdown-value (assoc-in application-fixtures/person-info-form-application [:answers 13 :value] "kuikka"))
-(def form-for-hakukohde-edited-email (assoc-in application-fixtures/person-info-form-application-for-hakukohde [:answers 2 :value] "edited@foo.com"))
 (def form-edited-email (assoc-in application-fixtures/person-info-form-application [:answers 2 :value] "edited@foo.com"))
 (def form-edited-ssn (assoc-in application-fixtures/person-info-form-application [:answers 8 :value] "020202A0202"))
+(def form-for-hakukohde-edited (-> application-fixtures/person-info-form-application-for-hakukohde
+                                   (assoc-in [:answers 2 :value] "edited@foo.com")
+                                   (assoc-in [:answers 14 :value] ["57af9386-d80c-4321-ab4a-d53619c14a74_edited"])))
 
 (def handler (-> (routes/new-handler)
                  (assoc :tarjonta-service (tarjonta-service/new-tarjonta-service))
@@ -109,8 +111,6 @@
   {:on    false
    :start (- (System/currentTimeMillis) (* 30 24 3600 1000))
    :end   (- (System/currentTimeMillis) (* 20 24 3600 1000))})
-
-
 
 (describe "/application"
   (tags :unit :hakija-routes)
@@ -202,7 +202,6 @@
 
       (it "should not allow editing ssn"
         (with-response :put resp form-edited-ssn
-          (println resp)
           (should= 200 (:status resp))
           (let [id (-> resp :body :id)
                 application (get-application-by-id id)]
@@ -212,7 +211,8 @@
       (around [spec]
         (with-redefs [application-email/start-email-submit-confirmation-job (fn [_])
                       application-email/start-email-edit-confirmation-job (fn [_])
-                      hakuaika/get-hakuaika-info hakuaika-ended-within-10-days]
+                      hakuaika/get-hakuaika-info hakuaika-ended-within-10-days
+                      application-service/remove-orphan-attachments (fn [_ _])]
           (spec)))
 
       (before-all
@@ -224,11 +224,12 @@
           (should (have-application-in-db (get-in resp [:body :id])))))
 
       (it "should allow application edit after hakuaika within 10 days and only changes to attachments"
-        (with-response :put resp form-for-hakukohde-edited-email
+        (with-response :put resp form-for-hakukohde-edited
           (should= 200 (:status resp))
           (let [id (-> resp :body :id)
                 application (get-application-by-id id)]
-            (should= "aku@ankkalinna.com" (get-answer application "email")))))
+            (should= "aku@ankkalinna.com" (get-answer application "email"))
+            (should= ["57af9386-d80c-4321-ab4a-d53619c14a74_edited"] (get-answer application "164954b5-7b23-4774-bd44-dee14071316b")))))
 
       (it "should not allow application edit after hakuaika"
         (with-redefs [hakuaika/get-hakuaika-info hakuaika-ended-within-20-days]

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -198,16 +198,15 @@
           (should= 200 (:status resp))
           (let [id (-> resp :body :id)
                 application (get-application-by-id id)]
-            (should= "edited@foo.com" (get-answer application "email"))))))
+            (should= "edited@foo.com" (get-answer application "email")))))
 
-      ; TODO: Make backend check whether fields can be edited don't rely on frontend stuff..
-      ;(it "should not allow editing ssn"
-      ;  (with-response :put resp form-edited-ssn
-      ;    (println resp)
-      ;    (should= 200 (:status resp))
-      ;    (let [id (-> resp :body :id)
-      ;          application (get-application-by-id id)]
-      ;      (should= "010101A123N" (get-answer application "ssn"))))))
+      (it "should not allow editing ssn"
+        (with-response :put resp form-edited-ssn
+          (println resp)
+          (should= 200 (:status resp))
+          (let [id (-> resp :body :id)
+                application (get-application-by-id id)]
+            (should= "010101A123N" (get-answer application "ssn"))))))
 
     (describe "PUT application after hakuaika ended"
       (around [spec]
@@ -224,14 +223,12 @@
           (should= 200 (:status resp))
           (should (have-application-in-db (get-in resp [:body :id])))))
 
-
-      ; TODO: Make backend check whether fields can be edited don't rely on frontend stuff, email should remain unedited.
-      (it "should allow application edit after hakuaika within 10 days"
+      (it "should allow application edit after hakuaika within 10 days and only changes to attachments"
         (with-response :put resp form-for-hakukohde-edited-email
           (should= 200 (:status resp))
           (let [id (-> resp :body :id)
                 application (get-application-by-id id)]
-            (should= "edited@foo.com" (get-answer application "email")))))
+            (should= "aku@ankkalinna.com" (get-answer application "email")))))
 
       (it "should not allow application edit after hakuaika"
         (with-redefs [hakuaika/get-hakuaika-info hakuaika-ended-within-20-days]

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -49,7 +49,7 @@
   ([secret tarjonta-service]
    (let [application (-> secret
                          (application-store/get-latest-application-by-secret)
-                         (application-service/remove-uneditable-answers tarjonta-service)
+                         (application-service/flag-uneditable-answers tarjonta-service)
                          (attachments-metadata->answers))]
      (if application
        (do


### PR DESCRIPTION
When editing hakemus check field editability with backend logic, don't rely on request body data (haaahaa curlers!)