### PR TITLE
Only attachments editable fixes

### DIFF
--- a/resources/spec/virkailijaHakemusEditSpec.js
+++ b/resources/spec/virkailijaHakemusEditSpec.js
@@ -4,6 +4,8 @@
     loadInFrame('/hakemus?virkailija-secret=' + virkailijaSecret)
   })
 
+  var newPhoneNumber = Math.floor(Math.random() * 10000000).toString();
+
   describe('Virkailija hakemus edit', function () {
     describe('shows application with secret', function () {
       before(
@@ -22,7 +24,7 @@
 
     describe('change values and save', function () {
       before(
-        setNthFieldInputValue(6, '12345'),
+        setNthFieldInputValue(6, newPhoneNumber),
         clickElement(function () {
           return submitButton()
         }),
@@ -42,7 +44,7 @@
           "Suomi",
           "***********",
           "test@example.com",
-          "12345",
+          newPhoneNumber,
           "Suomi",
           "Katutie 12 B",
           "40100",

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -175,8 +175,10 @@
         (with-get-response "asdfgh" resp
           (should= 200 (:status resp))
           (let [answers (-> resp :body :answers)]
-            (should= (count answers)
-                     (count (filter cannot-edit? answers)))
+            (should= 1 (count (filter #(not (cannot-edit? %)) answers)))
+            ;; Take -1 here since the form has one more quesiton than this application has answers to, and the extra
+            ;; question on the form happens to be an attachment
+            (should= (- (count answers) 1 ) (count (filter cannot-edit? answers)))
             (should= 1 (count (filter cannot-view? answers))))))))
 
     (describe "PUT application"

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -16,7 +16,7 @@
    [ataru.applications.application-store :as application-store]
    [ataru.hakija.editing-forbidden-fields :refer [viewing-forbidden-person-info-field-ids
                                                   editing-forbidden-person-info-field-ids]]
-   [ataru.application.field-types :refer [form-fields]]
+   [ataru.application.field-types :as types]
    [ataru.util :as util]
    [ataru.files.file-store :as file-store]
    [ataru.tarjonta-service.tarjonta-parser :as tarjonta-parser]
@@ -101,7 +101,7 @@
   [answers-by-key form-fields]
   (filter (fn [answer]
             (and (not (some #{(keyword (:id answer))} (keys answers-by-key)))
-                 (some #{(:fieldType answer)} form-fields)
+                 (some #{(:fieldType answer)} types/form-fields)
                  (not (:followup? answer)) ; make sure followup answers don't show when parent not selected
                  (not (:exclude-from-answers answer)))) form-fields))
 

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -16,6 +16,7 @@
    [ataru.applications.application-store :as application-store]
    [ataru.hakija.editing-forbidden-fields :refer [viewing-forbidden-person-info-field-ids
                                                   editing-forbidden-person-info-field-ids]]
+   [ataru.application.field-types :refer [form-fields]]
    [ataru.util :as util]
    [ataru.files.file-store :as file-store]
    [ataru.tarjonta-service.tarjonta-parser :as tarjonta-parser]
@@ -100,20 +101,14 @@
   [answers-by-key form-fields]
   (filter (fn [answer]
             (and (not (some #{(keyword (:id answer))} (keys answers-by-key)))
-                 (some #{(:fieldType answer)} ["textField"
-                                               "textArea"
-                                               "dropdown"
-                                               "multipleChoice"
-                                               "singleChoice"
-                                               "attachment"
-                                               "hakukohteet"]) ; no container fields!
+                 (some #{(:fieldType answer)} form-fields)
                  (not (:followup? answer)) ; make sure followup answers don't show when parent not selected
                  (not (:exclude-from-answers answer)))) form-fields))
 
 (defn- get-questions-without-answers
-  "This function serves to get dummy answers and their editability (mainly for 10 day crage period of attachments
-   for fields that were not required and thus were left editable in the 10 day attachment grace period. This happened
-   due to the fact that they had no answer in db to which make uneditable in flag-uneditable-answers."
+  "This function serves to get dummy answers and their editability for fields that were not required and thus were left
+   editable in the 10 day attachment grace period. This happened due to the fact that they had no answer in db to which
+   make uneditable in flag-uneditable-answers."
   [application]
   (let [form-fields               (-> application
                                       (:form)

--- a/src/cljc/ataru/application/field_types.cljc
+++ b/src/cljc/ataru/application/field_types.cljc
@@ -1,0 +1,10 @@
+(ns ataru.application.field-types)
+
+(def form-fields
+  ["textField"
+   "textArea"
+   "dropdown"
+   "multipleChoice"
+   "singleChoice"
+   "attachment"
+   "hakukohteet"])

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -1,5 +1,6 @@
 (ns ataru.schema.form-schema
   (:require [ataru.application.review-states :as review-states]
+            [ataru.application.field-types :refer [form-fields]]
             [ataru.hakija.application-validators :as validator]
             [schema.core :as s]))
 
@@ -75,13 +76,7 @@
                                                                            (s/optional-key :description)   LocalizedString
                                                                            (s/optional-key :default-value) (s/maybe s/Bool)
                                                                            (s/optional-key :followups)     [(s/if (comp some? :children) (s/recursive #'WrapperElement) (s/recursive #'BasicElement))]}]
-                        :fieldType                                       (apply s/enum ["textField"
-                                                                                        "textArea"
-                                                                                        "dropdown"
-                                                                                        "singleChoice"
-                                                                                        "multipleChoice"
-                                                                                        "attachment"
-                                                                                        "hakukohteet"])
+                        :fieldType                                       (apply s/enum form-fields)
                         (s/optional-key :belongs-to-hakukohteet)         [s/Str]})
 
 (s/defschema InfoElement {:fieldClass                              (s/eq "infoElement")
@@ -176,13 +171,7 @@
                                                                [(s/cond-pre s/Str
                                                                             File
                                                                             [(s/cond-pre s/Str s/Int File)])])
-                     :fieldType                    (apply s/enum ["textField"
-                                                                  "textArea"
-                                                                  "dropdown"
-                                                                  "multipleChoice"
-                                                                  "singleChoice"
-                                                                  "attachment"
-                                                                  "hakukohteet"])
+                     :fieldType                    (apply s/enum form-fields)
                      (s/optional-key :cannot-edit) s/Bool
                      (s/optional-key :cannot-view) s/Bool
                      (s/optional-key :label)       (s/maybe (s/cond-pre

--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -6,7 +6,9 @@
             [taoensso.timbre :refer-macros [spy debug]]
             [ataru.application.review-states :refer [complete-states]]
             [ataru.application-common.application-field-common :refer [required-validators]]
-            [clojure.core.match :refer [match]]))
+            [clojure.core.match :refer [match]]
+            [cljs-time.core :as time]
+            [cljs-time.coerce :refer [from-long]]))
 
 (defn- initial-valid-status [flattened-form-fields preselected-hakukohde]
   (into {}
@@ -192,6 +194,15 @@
   (and (= (:state application) "processing")
        (:is-jatkuva-haku? haku)))
 
+(defn- after-apply-end-within-10-days?
+  [apply-end-long]
+  (if apply-end-long
+    (let [now            (time/now)
+          apply-end      (from-long apply-end-long)
+          days-after-end (time/plus apply-end (time/days 10))]
+      (time/within? apply-end days-after-end now))
+    false))
+
 (defn applying-possible? [form application]
   (cond
     (:virkailija-secret application)
@@ -200,6 +211,9 @@
     (or (application-in-complete-state? application)
         (application-processing-jatkuva-haku? application (:tarjonta form)))
     false
+
+    (after-apply-end-within-10-days? (-> form :tarjonta :hakuaika-dates :end))
+    true
 
     ;; When applying to hakukohde, hakuaika must be on
     (-> form :tarjonta)

--- a/src/cljs/ataru/hakija/subs.cljs
+++ b/src/cljs/ataru/hakija/subs.cljs
@@ -44,7 +44,8 @@
 (re-frame/reg-sub
   :application/cannot-edit-answer?
   (fn [db [_ key]]
-    (-> db :application :answers key :cannot-edit)))
+    (let [answer (-> db :application :answers key)]
+      (or (:cannot-edit answer) (:cannot-view answer)))))
 
 (re-frame/reg-sub
   :application/default-language


### PR DESCRIPTION
- Fix hakemus not opening for editing
- Fix fields with no answer in backend being editable since the non-existing answer couldn't obviously be flagged as uneditable.