### PR TITLE
Hack-ish fix for clicking markdown help link

### DIFF
--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -211,7 +211,12 @@
      [:br]
      [:span "[linkin teksti](http://linkin osoite)"]
      [:br]
-     [:a {:href "https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" :target "_blank"} "Lisää muotoiluohjeita"]]]])
+     [:a {:href          "https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet"
+          :target        "_blank"
+          :on-mouse-down (fn [evt]
+                           (let [url (.getAttribute (-> evt .-target) "href")]
+                             (.open js/window url "_blank")))}
+      "Lisää muotoiluohjeita"]]]])
 
 (defn input-field [path lang dispatch-fn {:keys [class value-fn tag]
                                           :or   {tag :input}}]


### PR DESCRIPTION
Previously the link in the markdown info popup did now work, as clicking it would blur the related input box, hiding said popup (and link) before the `onClick` event would fire. Now use the `mouseDown` event to intercept click before hiding the element.