### PR TITLE
Authenticated Omatsivut API

### DIFF
--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -210,22 +210,17 @@ WITH latest AS (
   SELECT DISTINCT ON (key) * FROM applications ORDER BY key, created_time DESC
 )
 SELECT
-  a.id,
-  a.key,
-  a.lang,
-  a.preferred_name,
-  a.last_name,
-  a.created_time,
-  ar.state                               AS state,
-  ar.score                               AS score,
-  a.form_id                              AS form,
-  a.haku,
-  a.secret
+  a.key AS oid,
+  a.key AS key,
+  a.secret AS secret,
+  ar.state AS state,
+  a.haku AS haku,
+  a.hakukohde AS hakukohteet
 FROM latest a
   JOIN application_reviews ar ON a.key = ar.application_key
-  JOIN forms f ON a.form_id = f.id
 WHERE a.person_oid = :person_oid
-      AND (:query_type = 'ALL' OR f.organization_oid IN (:authorized_organization_oids))
+  AND a.haku IS NOT NULL
+  AND ar.state <> 'inactivated'
 ORDER BY a.created_time DESC;
 
 -- name: yesql-get-application-events

--- a/src/clj/ataru/applications/application_access_control.clj
+++ b/src/clj/ataru/applications/application_access_control.clj
@@ -108,3 +108,13 @@
    #(application-store/get-person-and-application-oids
      haku-oid
      hakukohde-oids)))
+
+(defn omatsivut-applications [organization-service session person-oid]
+  (session-orgs/run-org-authorized
+   session
+   organization-service
+   [:view-applications :edit-applications]
+   (constantly nil)
+   (constantly nil)
+   #(application-store/get-full-application-list-by-person-oid-for-omatsivut
+     person-oid)))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -252,9 +252,7 @@
 
 (defn get-full-application-list-by-person-oid-for-omatsivut [person-oid]
   (->> (exec-db :db yesql-get-application-list-by-person-oid-for-omatsivut
-         {:person_oid                   person-oid
-          :query_type                   "ALL"
-          :authorized_organization_oids [""]})
+                {:person_oid person-oid})
        (map ->kebab-case-kw)))
 
 (defn has-ssn-applied [haku-oid ssn]

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -208,9 +208,8 @@
       (api/GET "/applications/:person-oid" []
         :summary "Get latest versions of every application belonging to a user with given person OID"
         :path-params [person-oid :- (api/describe s/Str "Person OID")]
-        :return [ataru-schema/ApplicationInfo]
+        :return [ataru-schema/OmatsivutApplication]
         (response/ok (application-store/get-full-application-list-by-person-oid-for-omatsivut person-oid))))
-
     (api/POST "/client-error" []
       :summary "Log client-side errors to server log"
       :body [error-details client-error/ClientError]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -367,6 +367,16 @@
 
                  (api/context "/external" []
                    :tags ["external-api"]
+                   (api/GET "/omatsivut/applications/:person-oid" {session :session}
+                            :summary "Get latest versions of every application belonging to a user with given person OID"
+                            :path-params [person-oid :- (api/describe s/Str "Person OID")]
+                            :return [ataru-schema/OmatsivutApplication]
+                            (if-let [applications (access-controlled-application/omatsivut-applications
+                                                   organization-service
+                                                   session
+                                                   person-oid)]
+                              (response/ok applications)
+                              (response/unauthorized {:error "Unauthorized"})))
                    (api/GET "/applications" {session :session}
                             :summary "Get the latest versions of applications in haku or hakukohde or by oids."
                             :query-params [{hakuOid :- s/Str nil}

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -211,6 +211,14 @@
    (s/optional-key :tarjonta)           FormTarjontaMetadata
    (s/optional-key :person-oid)         (s/maybe s/Str)})
 
+(s/defschema OmatsivutApplication
+  {:oid s/Str
+   :key s/Str
+   :state s/Str
+   :secret s/Str
+   :haku s/Str
+   :hakukohteet [s/Str]})
+
 (s/defschema VtsApplication
   {:oid           s/Str ; (:key application)
    :hakuOid       s/Str


### PR DESCRIPTION
Vanha secure kontekstissa oleva API on jätetty tarkoituksella olemaan, jotta tämän muutoksen voisi viedä tuotantoon ilman, että vanhaa APIa käyttävä Omatsivut hajoaa.