### PR TITLE
Attachment update notification, server-side

### DIFF
--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -70,6 +70,10 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
+), attachment_modifications AS (
+    SELECT amod.application_key
+    FROM application_events amod
+    WHERE amod.event_type = 'updated-attachment'
 )
 SELECT
   a.id,
@@ -90,7 +94,8 @@ SELECT
    WHERE ahr.application_key = a.key) AS application_hakukohde_reviews,
   (SELECT COUNT(*)
    FROM new_application_modifications am
-   WHERE am.application_key = a.key) AS new_application_modifications
+   WHERE am.application_key = a.key) AS new_application_modifications,
+  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
 FROM latest_applications AS a
 JOIN application_reviews ar ON a.key = ar.application_key
 JOIN forms AS f ON f.id = a.form_id
@@ -108,6 +113,10 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
+), attachment_modifications AS (
+    SELECT amod.application_key
+    FROM application_events amod
+    WHERE amod.event_type = 'updated-attachment'
 )
 SELECT
   a.id,
@@ -129,7 +138,8 @@ SELECT
    WHERE ahr.application_key = a.key) AS application_hakukohde_reviews,
   (SELECT COUNT(*)
    FROM new_application_modifications am
-   WHERE am.application_key = a.key)  AS new_application_modifications
+   WHERE am.application_key = a.key)  AS new_application_modifications,
+  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
@@ -148,6 +158,10 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
     JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
+), attachment_modifications AS (
+  SELECT amod.application_key
+    FROM application_events amod
+    WHERE amod.event_type = 'updated-attachment'
 )
 SELECT
   a.id,
@@ -169,7 +183,8 @@ SELECT
    WHERE ahr.application_key = a.key) AS application_hakukohde_reviews,
   (SELECT COUNT(*)
    FROM new_application_modifications am
-   WHERE am.application_key = a.key)  AS new_application_modifications
+   WHERE am.application_key = a.key)  AS new_application_modifications,
+  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
@@ -188,6 +203,10 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
+), attachment_modifications AS (
+    SELECT amod.application_key
+    FROM application_events amod
+    WHERE amod.event_type = 'updated-attachment'
 )
 SELECT
   a.id,
@@ -209,7 +228,8 @@ SELECT
    WHERE ahr.application_key = a.key) AS application_hakukohde_reviews,
   (SELECT COUNT(*)
    FROM new_application_modifications am
-   WHERE am.application_key = a.key)  AS new_application_modifications
+   WHERE am.application_key = a.key)  AS new_application_modifications,
+  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
@@ -228,6 +248,10 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
+), attachment_modifications AS (
+    SELECT amod.application_key
+    FROM application_events amod
+    WHERE amod.event_type = 'updated-attachment'
 )
 SELECT
   a.id,
@@ -249,7 +273,8 @@ SELECT
    WHERE ahr.application_key = a.key) AS application_hakukohde_reviews,
   (SELECT COUNT(*)
    FROM new_application_modifications am
-   WHERE am.application_key = a.key)  AS new_application_modifications
+   WHERE am.application_key = a.key)  AS new_application_modifications,
+  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
@@ -268,6 +293,10 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
+), attachment_modifications AS (
+    SELECT amod.application_key
+    FROM application_events amod
+    WHERE amod.event_type = 'updated-attachment'
 )
 SELECT
   a.id,
@@ -289,7 +318,8 @@ SELECT
    WHERE ahr.application_key = a.key) AS application_hakukohde_reviews,
   (SELECT COUNT(*)
    FROM new_application_modifications am
-   WHERE am.application_key = a.key)  AS new_application_modifications
+   WHERE am.application_key = a.key)  AS new_application_modifications,
+  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
@@ -308,6 +338,10 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
+), attachment_modifications AS (
+    SELECT amod.application_key
+    FROM application_events amod
+    WHERE amod.event_type = 'updated-attachment'
 )
 SELECT
   a.id,
@@ -329,7 +363,8 @@ SELECT
    WHERE ahr.application_key = a.key) AS application_hakukohde_reviews,
   (SELECT COUNT(*)
    FROM new_application_modifications am
-   WHERE am.application_key = a.key)  AS new_application_modifications
+   WHERE am.application_key = a.key)  AS new_application_modifications,
+  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -70,10 +70,11 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
-), attachment_modifications AS (
-    SELECT amod.application_key
-    FROM application_events amod
-    WHERE amod.event_type = 'updated-attachment'
+), latest_attachment_event AS (
+    SELECT application_key, MAX(time) AS latest_attachment_modification_time
+    FROM application_events
+    WHERE event_type = 'updated-attachment'
+    GROUP BY application_key
 )
 SELECT
   a.id,
@@ -95,10 +96,11 @@ SELECT
   (SELECT COUNT(*)
    FROM new_application_modifications am
    WHERE am.application_key = a.key) AS new_application_modifications,
-  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
+  le.latest_attachment_modification_time
 FROM latest_applications AS a
 JOIN application_reviews ar ON a.key = ar.application_key
 JOIN forms AS f ON f.id = a.form_id
+LEFT JOIN latest_attachment_event le ON a.key = le.application_key
 WHERE a.haku IS NULL
   AND f.key = :form_key
 ORDER BY a.created_time DESC;
@@ -113,10 +115,11 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
-), attachment_modifications AS (
-    SELECT amod.application_key
-    FROM application_events amod
-    WHERE amod.event_type = 'updated-attachment'
+), latest_attachment_event AS (
+    SELECT application_key, MAX(time) AS latest_attachment_modification_time
+    FROM application_events
+    WHERE event_type = 'updated-attachment'
+    GROUP BY application_key
 )
 SELECT
   a.id,
@@ -139,11 +142,12 @@ SELECT
   (SELECT COUNT(*)
    FROM new_application_modifications am
    WHERE am.application_key = a.key)  AS new_application_modifications,
-  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
+  le.latest_attachment_modification_time
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
   JOIN latest_forms AS lf ON lf.key = f.key
+  LEFT JOIN latest_attachment_event le ON a.key = le.application_key
 WHERE :hakukohde_oid = ANY (a.hakukohde)
   AND (:query_type = 'ALL' OR lf.organization_oid IN (:authorized_organization_oids))
 ORDER BY a.created_time DESC;
@@ -158,10 +162,11 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
     JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
-), attachment_modifications AS (
-  SELECT amod.application_key
-    FROM application_events amod
-    WHERE amod.event_type = 'updated-attachment'
+), latest_attachment_event AS (
+    SELECT application_key, MAX(time) AS latest_attachment_modification_time
+    FROM application_events
+    WHERE event_type = 'updated-attachment'
+    GROUP BY application_key
 )
 SELECT
   a.id,
@@ -184,11 +189,12 @@ SELECT
   (SELECT COUNT(*)
    FROM new_application_modifications am
    WHERE am.application_key = a.key)  AS new_application_modifications,
-  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
+  le.latest_attachment_modification_time
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
   JOIN latest_forms AS lf ON lf.key = f.key
+  LEFT JOIN latest_attachment_event le ON a.key = le.application_key
 WHERE a.haku = :haku_oid
   AND (:query_type = 'ALL' OR lf.organization_oid IN (:authorized_organization_oids))
 ORDER BY a.created_time DESC;
@@ -203,10 +209,11 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
-), attachment_modifications AS (
-    SELECT amod.application_key
-    FROM application_events amod
-    WHERE amod.event_type = 'updated-attachment'
+), latest_attachment_event AS (
+    SELECT application_key, MAX(time) AS latest_attachment_modification_time
+    FROM application_events
+    WHERE event_type = 'updated-attachment'
+    GROUP BY application_key
 )
 SELECT
   a.id,
@@ -229,11 +236,12 @@ SELECT
   (SELECT COUNT(*)
    FROM new_application_modifications am
    WHERE am.application_key = a.key)  AS new_application_modifications,
-  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
+  le.latest_attachment_modification_time
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
   JOIN latest_forms AS lf ON lf.key = f.key
+  LEFT JOIN latest_attachment_event le ON a.key = le.application_key
 WHERE a.ssn = :ssn
   AND (:query_type = 'ALL' OR lf.organization_oid IN (:authorized_organization_oids))
 ORDER BY a.created_time DESC;
@@ -248,10 +256,11 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
-), attachment_modifications AS (
-    SELECT amod.application_key
-    FROM application_events amod
-    WHERE amod.event_type = 'updated-attachment'
+), latest_attachment_event AS (
+    SELECT application_key, MAX(time) AS latest_attachment_modification_time
+    FROM application_events
+    WHERE event_type = 'updated-attachment'
+    GROUP BY application_key
 )
 SELECT
   a.id,
@@ -274,11 +283,12 @@ SELECT
   (SELECT COUNT(*)
    FROM new_application_modifications am
    WHERE am.application_key = a.key)  AS new_application_modifications,
-  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
+  le.latest_attachment_modification_time
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
   JOIN latest_forms AS lf ON lf.key = f.key
+  LEFT JOIN latest_attachment_event le ON a.key = le.application_key
 WHERE a.dob = :dob
   AND (:query_type = 'ALL' OR lf.organization_oid IN (:authorized_organization_oids))
 ORDER BY a.created_time DESC;
@@ -293,10 +303,11 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
-), attachment_modifications AS (
-    SELECT amod.application_key
-    FROM application_events amod
-    WHERE amod.event_type = 'updated-attachment'
+), latest_attachment_event AS (
+    SELECT application_key, MAX(time) AS latest_attachment_modification_time
+    FROM application_events
+    WHERE event_type = 'updated-attachment'
+    GROUP BY application_key
 )
 SELECT
   a.id,
@@ -319,11 +330,12 @@ SELECT
   (SELECT COUNT(*)
    FROM new_application_modifications am
    WHERE am.application_key = a.key)  AS new_application_modifications,
-  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
+  le.latest_attachment_modification_time
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
   JOIN latest_forms AS lf ON lf.key = f.key
+  LEFT JOIN latest_attachment_event le ON a.key = le.application_key
 WHERE a.email = :email
   AND (:query_type = 'ALL' OR lf.organization_oid IN (:authorized_organization_oids))
 ORDER BY a.created_time DESC;
@@ -338,10 +350,11 @@ WITH latest_information_request_event AS (
     FROM latest_information_request_event ir
       JOIN latest_modification_by_applicant up ON ir.application_key = up.application_key
     WHERE ir.time < up.time
-), attachment_modifications AS (
-    SELECT amod.application_key
-    FROM application_events amod
-    WHERE amod.event_type = 'updated-attachment'
+), latest_attachment_event AS (
+    SELECT application_key, MAX(time) AS latest_attachment_modification_time
+    FROM application_events
+    WHERE event_type = 'updated-attachment'
+    GROUP BY application_key
 )
 SELECT
   a.id,
@@ -364,11 +377,12 @@ SELECT
   (SELECT COUNT(*)
    FROM new_application_modifications am
    WHERE am.application_key = a.key)  AS new_application_modifications,
-  (SELECT COUNT(*) FROM attachment_modifications amod WHERE amod.application_key = a.key) AS attachment_modifications
+  le.latest_attachment_modification_time
 FROM latest_applications AS a
   JOIN application_reviews AS ar ON a.key = ar.application_key
   JOIN forms AS f ON a.form_id = f.id
   JOIN latest_forms AS lf ON lf.key = f.key
+  LEFT JOIN latest_attachment_event le ON a.key = le.application_key
 WHERE to_tsvector('simple', a.preferred_name || ' ' || a.last_name) @@ to_tsquery(:name)
       AND (:query_type = 'ALL' OR lf.organization_oid IN (:authorized_organization_oids))
 ORDER BY a.created_time DESC;

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -235,6 +235,10 @@
                                 (filter (comp not (partial contains? new-attachments))))]
     (doseq [attachment-key orphan-attachments]
       (file-store/delete-file (name attachment-key)))
+    (when (> (count orphan-attachments) 0)
+      (application-store/add-application-event {:event-type      "updated-attachment"
+                                                :application-key (:key old-application)}
+                                               nil))
     (log/info (str "Updated application " (:key old-application) ", removed old attachments: " (clojure.string/join ", " orphan-attachments)))))
 
 (defn- valid-virkailija-secret [{:keys [virkailija-secret]}]

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -235,7 +235,7 @@
                                 (filter (comp not (partial contains? new-attachments))))]
     (doseq [attachment-key orphan-attachments]
       (file-store/delete-file (name attachment-key)))
-    (when (> (count orphan-attachments) 0)
+    (when (not-empty orphan-attachments)
       (application-store/add-application-event {:event-type      "updated-attachment"
                                                 :application-key (:key old-application)}
                                                nil))

--- a/src/clj/ataru/virkailija/authentication/virkailija_edit.clj
+++ b/src/clj/ataru/virkailija/authentication/virkailija_edit.clj
@@ -14,10 +14,11 @@
 
 (defn upsert-virkailija
   [session]
-  (when-let [virkailija (ldap/get-virkailija-by-username (-> session :identity :username))]
-    (db/exec :db yesql-upsert-virkailija<! {:oid        (:employeeNumber virkailija)
-                                            :first_name (:givenName virkailija)
-                                            :last_name  (:sn virkailija)})))
+  (when session
+    (when-let [virkailija (ldap/get-virkailija-by-username (-> session :identity :username))]
+      (db/exec :db yesql-upsert-virkailija<! {:oid        (:employeeNumber virkailija)
+                                              :first_name (:givenName virkailija)
+                                              :last_name  (:sn virkailija)}))))
 
 (defn create-virkailija-credentials [session application-key]
   (when-let [virkailija (upsert-virkailija session)]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -218,7 +218,11 @@
                                                     (access-controlled-application/get-application-list-by-hakukohde hakukohdeOid session organization-service)
 
                                                     (some? hakuOid)
-                                                    (access-controlled-application/get-application-list-by-haku hakuOid session organization-service)
+                                                    (access-controlled-application/get-application-list-by-haku hakuOid
+                                                                                                                session
+                                                                                                                organization-service
+                                                                                                                tarjonta-service
+                                                                                                                ohjausparametrit-service)
 
                                                     (some? ssn)
                                                     (access-controlled-application/get-application-list-by-ssn ssn session organization-service)

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -308,7 +308,8 @@
                          "received-from-applicant"
                          "review-state-change"
                          "hakukohde-review-state-change"
-                         "modification-link-sent"))
+                         "modification-link-sent"
+                         "updated-attachment"))
 
 (s/defschema Event
   {:event-type                        event-types

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -208,7 +208,7 @@
    (s/optional-key :application-hakukohde-reviews) [{:requirement (apply s/enum review-states/hakukohde-review-type-names)
                                                      :state       (apply s/enum review-requirement-values)
                                                      :hakukohde   s/Str}] ; "form" or oid
-   :attachment-modifications                       s/Int})
+   :latest-attachment-modification-time            (s/maybe org.joda.time.DateTime)})
 
 (s/defschema Application
   {(s/optional-key :key)                s/Str

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -208,7 +208,8 @@
    (s/optional-key :application-hakukohde-reviews) [{:requirement (apply s/enum review-states/hakukohde-review-type-names)
                                                      :state       (apply s/enum review-requirement-values)
                                                      :hakukohde   s/Str}] ; "form" or oid
-   :latest-attachment-modification-time            (s/maybe org.joda.time.DateTime)})
+   :latest-attachment-modification-time            (s/maybe org.joda.time.DateTime)
+   (s/optional-key :tarjonta)                      FormTarjontaMetadata})
 
 (s/defschema Application
   {(s/optional-key :key)                s/Str

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -207,7 +207,8 @@
    (s/optional-key :secret)                        s/Str
    (s/optional-key :application-hakukohde-reviews) [{:requirement (apply s/enum review-states/hakukohde-review-type-names)
                                                      :state       (apply s/enum review-requirement-values)
-                                                     :hakukohde   s/Str}]}) ; "form" or oid
+                                                     :hakukohde   s/Str}] ; "form" or oid
+   :attachment-modifications                       s/Int})
 
 (s/defschema Application
   {(s/optional-key :key)                s/Str

--- a/src/cljs/ataru/virkailija/application/handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/handlers.cljs
@@ -152,7 +152,9 @@
 
 (defn- parse-application-time
   [application]
-  (assoc application :created-time (temporal/str->googdate (:created-time application))))
+  (-> application
+      (update :created-time temporal/str->googdate)
+      (update :latest-attachment-modification-time temporal/str->googdate)))
 
 (reg-event-fx
   :application/handle-fetch-applications-response

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -317,7 +317,7 @@
        {:class (when (empty? (:hakukohde application)) "application-handling__application-hakukohde-cell--form")}]
       (map
         (fn [hakukohde-oid]
-          (let [hakukohde              ((keyword hakukohde-oid) all-hakukohteet)
+          (let [hakukohde              (-> hakukohde-oid keyword all-hakukohteet)
                 show-state-email-icon? (and
                                          (< 0 (:new-application-modifications application))
                                          (->> application

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -736,6 +736,9 @@
           [:span.application-handling__event-caption--inner "Täydennyspyyntö lähetetty" (virkailija-initials-span event)]
           [:span.application-handling__event-caption--inner.application-handling__event-caption--extra-info (str "\"" message "\"")]]
 
+         {:event-type "updated-attachment"}
+         "Hakija päivitti liitetiedostoja"
+
          :else "Tuntematon"))
 
 (defn to-event-row


### PR DESCRIPTION
Creates an `application_events` row (`event_type` is `updated-attachment`). The event ends up to the application state in the query used to get metadata for all applications for current haku (or hakukohde, etc).

As a minor UI level change the event is also displayed in the events list of the application handling view.