### PR TITLE
Don't auditlog content or answers from new forms and applications.

### DIFF
--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -242,7 +242,7 @@
   (assoc (dissoc application :form) :form-id form))
 
 (defn- application->loggable-form [{:keys [form] :as application}]
-  (cond-> (select-keys application [:id :key :form-id :answers])
+  (cond-> application
     (some? form)
     (form->form-id)))
 

--- a/src/clj/ataru/log/audit_log.clj
+++ b/src/clj/ataru/log/audit_log.clj
@@ -73,6 +73,17 @@
                             (into {} (map (fn [[k v]] [k (t v)])))))
                         coll))
 
+(defn- get-message [new old]
+  (m/match [new old]
+           [(_ :guard map-or-vec?) (_ :guard map-or-vec?)]
+           (diff old new)
+
+           [(_ :guard map-or-vec?) (_ :guard nil?)]
+           (json/generate-string (dissoc new :content :answers))
+
+           [(_ :guard string?) _]
+           new))
+
 (defn- do-log [{:keys [new old id operation organization-oid]}]
   {:pre [(or (and (or (string? new)
                       (map-or-vec? new))

--- a/src/clj/ataru/log/audit_log.clj
+++ b/src/clj/ataru/log/audit_log.clj
@@ -50,17 +50,6 @@
                                         (.readTree object-mapper new-str))]
     (.writeValueAsString object-mapper diff-node)))
 
-(defn- get-message [new old]
-  (m/match [new old]
-           [(_ :guard map-or-vec?) (_ :guard map-or-vec?)]
-           (diff old new)
-
-           [(_ :guard map-or-vec?) (_ :guard nil?)]
-           (json/generate-string new)
-
-           [(_ :guard string?) _]
-           new))
-
 (defn- date->str [x]
   (cond->> x
     (instance? DateTime x)


### PR DESCRIPTION
Otetaan logitettavasta uudesta asiasta pois :content ja :answers, eli hakemuksilta ja lomakkeilta isot asiat veke auditlogitettaessa.