### PR TITLE
Remove orphan attachment reviews

### DIFF
--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -683,6 +683,10 @@ SELECT *
 FROM application_hakukohde_attachment_reviews
 WHERE application_key = :application_key AND attachment_key = :attachment_key AND hakukohde = :hakukohde;
 
+-- name: yesql-delete-application-attachment-reviews!
+DELETE FROM application_hakukohde_attachment_reviews
+WHERE application_key = :application_key AND attachment_key IN (:attachment_keys);
+
 -- name: yesql-applications-by-haku-and-hakukohde-oids
 SELECT
   la.key,

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -93,8 +93,7 @@ SELECT
                                      'state', state,
                                      'hakukohde', hakukohde))
    FROM application_hakukohde_attachment_reviews aar
-   WHERE aar.application_key = a.key
-     AND (aar.hakukohde = 'form' OR aar.hakukohde = ANY (a.hakukohde))) AS application_attachment_reviews,
+   WHERE aar.application_key = a.key) AS application_attachment_reviews,
   (SELECT COUNT(*)
    FROM new_application_modifications am
    WHERE am.application_key = a.key)  AS new_application_modifications,
@@ -638,11 +637,9 @@ WHERE application_key = :application_key;
 SELECT
   attachment_key,
   state,
-  reviews.hakukohde
-FROM application_hakukohde_attachment_reviews AS reviews
-  JOIN latest_applications AS applications ON application_key = key
-WHERE reviews.application_key = :application_key
-      AND (reviews.hakukohde = 'form' OR reviews.hakukohde = ANY (applications.hakukohde));
+  hakukohde
+FROM application_hakukohde_attachment_reviews
+WHERE application_key = :application_key;
 
 -- name: yesql-get-payment-obligation-for-applications
 SELECT DISTINCT ON (application_key, hakukohde) application_key, hakukohde, state

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -684,7 +684,7 @@ WHERE application_key = :application_key AND attachment_key = :attachment_key AN
 -- name: yesql-delete-application-attachment-reviews!
 DELETE FROM application_hakukohde_attachment_reviews
 WHERE application_key = :application_key
-      AND (attachment_key IN (:attachment_keys)
+      AND (attachment_key NOT IN (:attachment_keys)
            OR hakukohde NOT IN (:applied_hakukohteet));
 
 -- name: yesql-applications-by-haku-and-hakukohde-oids

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -491,9 +491,10 @@ VALUES (:application_key, :event_type, :new_review_state, :virkailija_oid, :haku
 INSERT INTO application_reviews (application_key, state) VALUES (:application_key, :state);
 
 -- name: yesql-save-attachment-review!
--- Add not-checked state to new application attachments
 INSERT INTO application_hakukohde_attachment_reviews (application_key, attachment_key, hakukohde, state)
-VALUES (:application_key, :attachment_key, :hakukohde, :state);
+VALUES (:application_key, :attachment_key, :hakukohde, :state)
+ON CONFLICT (application_key, attachment_key, hakukohde)
+  DO NOTHING;
 
 -- name: yesql-save-application-review!
 -- Save modifications for existing review record
@@ -685,7 +686,9 @@ WHERE application_key = :application_key AND attachment_key = :attachment_key AN
 
 -- name: yesql-delete-application-attachment-reviews!
 DELETE FROM application_hakukohde_attachment_reviews
-WHERE application_key = :application_key AND attachment_key IN (:attachment_keys);
+WHERE application_key = :application_key
+      AND (attachment_key IN (:attachment_keys)
+           OR hakukohde NOT IN (:applied_hakukohteet));
 
 -- name: yesql-applications-by-haku-and-hakukohde-oids
 SELECT

--- a/spec/ataru/applications/application_store_spec.clj
+++ b/spec/ataru/applications/application_store_spec.clj
@@ -135,10 +135,12 @@
         (should== [{:application_key "attachments"
                     :attachment_key  "att__1"
                     :state           "not-checked"
+                    :updated?        false
                     :hakukohde       "form"}
                    {:application_key "attachments"
                     :attachment_key  "att__2"
                     :state           "incomplete"
+                    :updated?        false
                     :hakukohde       "form"}]
          (#'store/create-application-attachment-reviews application nil [] false)))))
 
@@ -148,18 +150,22 @@
         (should== [{:application_key "attachments"
                     :attachment_key  "att__1"
                     :state           "not-checked"
+                    :updated?        false
                     :hakukohde       "hakukohde1"}
                    {:application_key "attachments"
                     :attachment_key  "att__1"
                     :state           "not-checked"
+                    :updated?        false
                     :hakukohde       "hakukohde2"}
                    {:application_key "attachments"
                     :attachment_key  "att__2"
                     :state           "incomplete"
+                    :updated?        false
                     :hakukohde       "hakukohde1"}
                    {:application_key "attachments"
                     :attachment_key  "att__2"
                     :state           "incomplete"
+                    :updated?        false
                     :hakukohde       "hakukohde2"}]
                   (#'store/create-application-attachment-reviews application nil [{:oid "hakukohde1"} {:oid "hakukohde2"}] false)))))
 
@@ -167,8 +173,14 @@
     (let [application (first (filter #(= "attachments" (:key %)) fixtures/applications))]
       (with-redefs [forms/fetch-by-id (fn [_] form-fixtures/attachment-test-form)]
         (should== [{:application_key "attachments"
+                    :attachment_key  "att__1"
+                    :state           "not-checked"
+                    :updated?        false
+                    :hakukohde       "form"}
+                   {:application_key "attachments"
                     :attachment_key  "att__2"
                     :state           "incomplete"
+                    :updated?        true
                     :hakukohde       "form"}]
                   (#'store/create-application-attachment-reviews application {:att__1 {:value ["liite-id"]}
                                                                               :att__2 {:value ["32131"]}} [] true))))))

--- a/spec/ataru/applications/application_store_spec.clj
+++ b/spec/ataru/applications/application_store_spec.clj
@@ -131,56 +131,54 @@
 
   (it "should create attachment reviews for new applcation without hakukohteet"
     (let [application (first (filter #(= "attachments" (:key %)) fixtures/applications))]
-      (with-redefs [forms/fetch-by-id (fn [_] form-fixtures/attachment-test-form)]
-        (should== [{:application_key "attachments"
-                    :attachment_key  "att__1"
-                    :state           "not-checked"
-                    :updated?        false
-                    :hakukohde       "form"}
-                   {:application_key "attachments"
-                    :attachment_key  "att__2"
-                    :state           "incomplete"
-                    :updated?        false
-                    :hakukohde       "form"}]
-         (#'store/create-application-attachment-reviews application nil [] false)))))
+      (should== [{:application_key "attachments"
+                  :attachment_key  "att__1"
+                  :state           "not-checked"
+                  :updated?        false
+                  :hakukohde       "form"}
+                 {:application_key "attachments"
+                  :attachment_key  "att__2"
+                  :state           "incomplete"
+                  :updated?        false
+                  :hakukohde       "form"}]
+                (#'store/create-application-attachment-reviews application nil form-fixtures/attachment-test-form [] false))))
 
   (it "should create attachment reviews for new applcation with hakukohteet"
     (let [application (first (filter #(= "attachments" (:key %)) fixtures/applications))]
-      (with-redefs [forms/fetch-by-id (fn [_] form-fixtures/attachment-test-form)]
-        (should== [{:application_key "attachments"
-                    :attachment_key  "att__1"
-                    :state           "not-checked"
-                    :updated?        false
-                    :hakukohde       "hakukohde1"}
-                   {:application_key "attachments"
-                    :attachment_key  "att__1"
-                    :state           "not-checked"
-                    :updated?        false
-                    :hakukohde       "hakukohde2"}
-                   {:application_key "attachments"
-                    :attachment_key  "att__2"
-                    :state           "incomplete"
-                    :updated?        false
-                    :hakukohde       "hakukohde1"}
-                   {:application_key "attachments"
-                    :attachment_key  "att__2"
-                    :state           "incomplete"
-                    :updated?        false
-                    :hakukohde       "hakukohde2"}]
-                  (#'store/create-application-attachment-reviews application nil [{:oid "hakukohde1"} {:oid "hakukohde2"}] false)))))
+      (should== [{:application_key "attachments"
+                  :attachment_key  "att__1"
+                  :state           "not-checked"
+                  :updated?        false
+                  :hakukohde       "hakukohde1"}
+                 {:application_key "attachments"
+                  :attachment_key  "att__1"
+                  :state           "not-checked"
+                  :updated?        false
+                  :hakukohde       "hakukohde2"}
+                 {:application_key "attachments"
+                  :attachment_key  "att__2"
+                  :state           "incomplete"
+                  :updated?        false
+                  :hakukohde       "hakukohde1"}
+                 {:application_key "attachments"
+                  :attachment_key  "att__2"
+                  :state           "incomplete"
+                  :updated?        false
+                  :hakukohde       "hakukohde2"}]
+                (#'store/create-application-attachment-reviews application nil form-fixtures/attachment-test-form [{:oid "hakukohde1"} {:oid "hakukohde2"}] false))))
 
   (it "should update attachment reviews for applcation without hakukohteet"
     (let [application (first (filter #(= "attachments" (:key %)) fixtures/applications))]
-      (with-redefs [forms/fetch-by-id (fn [_] form-fixtures/attachment-test-form)]
-        (should== [{:application_key "attachments"
-                    :attachment_key  "att__1"
-                    :state           "not-checked"
-                    :updated?        false
-                    :hakukohde       "form"}
-                   {:application_key "attachments"
-                    :attachment_key  "att__2"
-                    :state           "incomplete"
-                    :updated?        true
-                    :hakukohde       "form"}]
-                  (#'store/create-application-attachment-reviews application {:att__1 {:value ["liite-id"]}
-                                                                              :att__2 {:value ["32131"]}} [] true))))))
+      (should== [{:application_key "attachments"
+                  :attachment_key  "att__1"
+                  :state           "not-checked"
+                  :updated?        false
+                  :hakukohde       "form"}
+                 {:application_key "attachments"
+                  :attachment_key  "att__2"
+                  :state           "incomplete"
+                  :updated?        true
+                  :hakukohde       "form"}]
+                (#'store/create-application-attachment-reviews application {:att__1 {:value ["liite-id"]}
+                                                                            :att__2 {:value ["32131"]}}
+                 form-fixtures/attachment-test-form [] true)))))

--- a/spec/ataru/fixtures/db/browser_test_db.clj
+++ b/spec/ataru/fixtures/db/browser_test_db.clj
@@ -266,9 +266,9 @@
   (form-store/create-new-form! hakija-hakukohteen-hakuaika-test-form
                                (:key hakija-hakukohteen-hakuaika-test-form))
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
-    (application-store/add-application application1 [])
-    (application-store/add-application application2 [])
-    (application-store/add-application application3 [])))
+    (application-store/add-application application1 [] nil)
+    (application-store/add-application application2 [] nil)
+    (application-store/add-application application3 [] nil)))
 
 (defn reset-test-db [insert-initial-fixtures?]
   (db/clear-db! :db (-> config :db :schema))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -75,9 +75,9 @@
       (recur (crypto/url-part 34)))))
 
 (defn- create-attachment-reviews
-  [attachment-field answer old-answer application-key hakutoiveet]
-  (let [value-changed?                     (or (nil? old-answer)
-                                               (not= old-answer answer))
+  [attachment-field answer old-answer update? application-key hakutoiveet]
+  (let [value-changed?                     (and update?
+                                                (not= old-answer answer))
         review-base                        {:application_key application-key
                                             :attachment_key  (:id attachment-field)
                                             :state           (if (empty? answer)
@@ -135,6 +135,7 @@
                      (create-attachment-reviews attachment
                                                 answer
                                                 old-answer
+                                                update?
                                                 (:key application)
                                                 applied-hakukohteet)))))))
 

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -122,9 +122,9 @@
           fields))
 
 (defn- create-application-attachment-reviews
-  [application old-answers applied-hakukohteet update?]
+  [application old-answers form applied-hakukohteet update?]
   (let [answers-by-key (-> application :content :answers util/answers-by-key)]
-    (->> (forms/fetch-by-id (:form_id application))
+    (->> form
          :content
          util/flatten-form-fields
          (filter-relevant-attachments answers-by-key)
@@ -158,7 +158,7 @@
 (defn- create-attachment-hakukohde-reviews-for-application
   [application applied-hakukohteet old-answers form connection]
   (let [update? (not-empty old-answers)
-        reviews (create-application-attachment-reviews application old-answers applied-hakukohteet update?)]
+        reviews (create-application-attachment-reviews application old-answers form applied-hakukohteet update?)]
     (doseq [review reviews]
       ((if (:updated? review)
          yesql-update-attachment-hakukohde-review!

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -150,8 +150,6 @@
                                 (map :attachment_key)
                                 (filter #(not (contains? field-ids %)))
                                 distinct)]
-    (println applied-hakukohteet)
-    (println orphan-attachments)
     (yesql-delete-application-attachment-reviews! {:application_key     application-key
                                                    :attachment_keys     (cons "" orphan-attachments)
                                                    :applied_hakukohteet (cons "" applied-hakukohteet)}

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -143,15 +143,11 @@
   (let [field-ids          (->> form
                                 :content
                                 util/flatten-form-fields
+                                (filter #(= "attachment" (:fieldType %)))
                                 (map :id)
-                                set)
-        reviews            (yesql-get-application-attachment-reviews {:application_key application-key} connection)
-        orphan-attachments (->> reviews
-                                (map :attachment_key)
-                                (filter #(not (contains? field-ids %)))
-                                distinct)]
+                                set)]
     (yesql-delete-application-attachment-reviews! {:application_key     application-key
-                                                   :attachment_keys     (cons "" orphan-attachments)
+                                                   :attachment_keys     (cons "" field-ids)
                                                    :applied_hakukohteet (cons "" applied-hakukohteet)}
                                                   connection)))
 

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -29,8 +29,8 @@
     [clj-time.coerce :as t]
     [ataru.applications.application-service :as application-service]))
 
-(defn- store-and-log [application applied-hakukohteet store-fn]
-  (let [application-id (store-fn application applied-hakukohteet)]
+(defn- store-and-log [application applied-hakukohteet store-fn form]
+  (let [application-id (store-fn application applied-hakukohteet form)]
     (log/info "Stored application with id: " application-id)
     {:passed?        true
      :id application-id
@@ -184,7 +184,7 @@
       :else
       (do
         (remove-orphan-attachments final-application latest-application)
-        (store-and-log final-application applied-hakukohteet store-fn)))))
+        (store-and-log final-application applied-hakukohteet store-fn form)))))
 
 (defn- start-person-creation-job [application-id]
   (log/info "Started person creation job (to person service) with job id"


### PR DESCRIPTION
When a question is removed from form, remove possibly orphaned attachment
reviews if application is updated.