### PR TITLE
HLE-474 : Hiding massamuokkaus if yhteishaku (instead of tarjoaja oids)

### DIFF
--- a/src/clj/ataru/tarjonta_service/tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_service.clj
@@ -58,10 +58,11 @@
 
 (defn parse-haku
   [haku]
-  {:oid (:oid haku)
-   :name (parse-multi-lang-text (:nimi haku))
+  {:oid                    (:oid haku)
+   :name                   (parse-multi-lang-text (:nimi haku))
    :prioritize-hakukohteet (:usePriority haku)
-   :hakuajat (mapv parse-hakuaika (:hakuaikas haku))})
+   :yhteishaku             (= (:hakutapaUri haku) "hakutapa_01#1")
+   :hakuajat               (mapv parse-hakuaika (:hakuaikas haku))})
 
 (defn- parse-hakukohde
   [hakukohde]

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -229,6 +229,7 @@
 (s/defschema Haku
   {:oid                    s/Str
    :name                   LocalizedStringOptional
+   :yhteishaku             s/Bool
    :prioritize-hakukohteet s/Bool
    :hakuajat               [{:start                java.time.ZonedDateTime
                              (s/optional-key :end) java.time.ZonedDateTime}]})

--- a/src/cljs/ataru/virkailija/application/application_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/application_subs.cljs
@@ -370,18 +370,11 @@
 (re-frame/reg-sub
   :application/massamuutos-enabled?
   (fn [db _]
-    (let [applications                  (-> db :application :applications)
-          tarjoaja-oids-for-application (fn [hakukohde-oid]
-                                          (get-in db [:hakukohteet hakukohde-oid :tarjoaja-oids]))
-          only-one-tarjoaja?            (->> applications
-                                             (mapcat :hakukohde)
-                                             (mapcat tarjoaja-oids-for-application)
-                                             (set)
-                                             (rest)
-                                             (empty?))
-          hakukohde-selected?           (-> db :application :selected-hakukohde)
-          hakukohderyhma-selected?      (-> db :application :selected-hakukohderyhma)]
-      (or only-one-tarjoaja?
+    (let [applications             (-> db :application :applications)
+          yhteishaku?              (get-in db [:haut (-> db :application :selected-haku) :yhteishaku])
+          hakukohde-selected?      (-> db :application :selected-hakukohde)
+          hakukohderyhma-selected? (-> db :application :selected-hakukohderyhma)]
+      (or (not yhteishaku?)
           hakukohde-selected?
           hakukohderyhma-selected?))))
 


### PR DESCRIPTION
Tarjoaja-oids was not enough information to check if massamuokkaus should be visible. Some organisations have multiple organisation oids.