### PR TITLE
HLE-508: Fill texts with any non-blank localization (prioritizing sel…

### DIFF
--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -178,3 +178,7 @@
        (filter email-pred)
        (first)
        :value))
+
+(defn non-blank-val [m ks]
+  (when m
+    (first (filter not-blank? (vals (select-keys m ks))))))

--- a/src/cljs/ataru/hakija/banner.cljs
+++ b/src/cljs/ataru/hakija/banner.cljs
@@ -4,6 +4,7 @@
             [reagent.ratom :refer [reaction]]
             [reagent.core :as r]
             [cljs.core.match :refer-macros [match]]
+            [ataru.util :as util]
             [ataru.cljs-util :refer [get-translation]]))
 
 (defn logo []
@@ -22,8 +23,7 @@
 (defn invalid-field-status []
   (let [show-details        (r/atom false)
         toggle-show-details #(do (reset! show-details (not @show-details)) nil)
-        lang                (subscribe [:application/form-language])
-        default-lang        (subscribe [:application/default-language])]
+        languages           (subscribe [:application/default-languages])]
     (fn [valid-status]
       (when (seq (:invalid-fields valid-status))
         [:div.application__invalid-field-status
@@ -40,8 +40,7 @@
                     {:on-click toggle-show-details}
                     "x"]]
                   (map (fn [field]
-                         (let [label (or (get-in field [:label @lang])
-                                         (get-in field [:label @default-lang]))]
+                         (let [label (util/non-blank-val (:label field) @languages)]
                            [:a {:href (str "#scroll-to-" (name (:key field)))} [:div label]]))
                        (:invalid-fields valid-status)))])]))))
 

--- a/src/cljs/ataru/hakija/subs.cljs
+++ b/src/cljs/ataru/hakija/subs.cljs
@@ -74,13 +74,6 @@
            (:cannot-edit field)))))
 
 (re-frame/reg-sub
-  :application/default-language
-  (fn [db]
-    (-> db
-        (get-in [:form :languages])
-        first)))
-
-(re-frame/reg-sub
   :application/get-i18n-text
   (fn [db [_ translations]]
     (get translations @(re-frame/subscribe [:application/form-language]))))
@@ -223,6 +216,13 @@
   :application/prioritize-hakukohteet?
   (fn [db _]
     (-> db :form :tarjonta :prioritize-hakukohteet)))
+
+(re-frame/reg-sub
+  :application/default-languages
+  (fn [db _]
+    (let [default-languages (get-in db [:form :languages])
+          selected-language (get-in db [:form :selected-language])]
+      (cons selected-language default-languages))))
 
 (re-frame/reg-sub
   :application/hakukohde-priority-number


### PR DESCRIPTION
…ected language and form language after that ordered by fi, sv, en)

Previously:
1. User selected language (could be anything basically)
2. First of form languages (doesn't matter if blank)
3. Exception in option values where all languages are checked (including ones that are not supported by form