### PR TITLE
Fix issues found when testing anonymization

### DIFF
--- a/dev-resources/sql/anonymizer-application-queries.sql
+++ b/dev-resources/sql/anonymizer-application-queries.sql
@@ -1,5 +1,5 @@
 -- name: sql-get-all-applications
-SELECT id, key, preferred_name, last_name, ssn, content FROM applications;
+SELECT id, key, preferred_name, last_name, ssn, person_oid, content FROM applications;
 
 -- name: sql-update-application!
 UPDATE applications

--- a/dev/clj/ataru/anonymizer/core.clj
+++ b/dev/clj/ataru/anonymizer/core.clj
@@ -4,8 +4,8 @@
             [taoensso.timbre :as log]
             [ataru.anonymizer.ssn-generator :as ssn-gen]))
 
-(defn- anonymize [fake-persons applications {:keys [key preferred_name last_name content] :as application}]
-  (if-let [fake-person (get fake-persons key)]
+(defn- anonymize [fake-persons applications {:keys [key preferred_name last_name content person_oid] :as application}]
+  (if-let [fake-person (get fake-persons person_oid)]
     (let [{:keys [gender first-name last-name address fake-ssn phone email postal-code]} (first fake-person)
           anonymize-answer (fn [{:keys [key value] :as answer}]
                                (let [value (case key
@@ -51,9 +51,9 @@
                                          hetu
                                          etunimi
                                          puhelinnumero
-                                         oidhenkilo
+                                         personOid
                                          lahiosoite]}]
-  {:person-oid  oidhenkilo
+  {:person-oid  personOid
    :fake-ssn    hetu
    :address     lahiosoite
    :email       sahkopostiosoite


### PR DESCRIPTION
- Use correct person-oid key when parsing anonymous persons file.
- Get persons with person OID, not with application OID.