### PR TITLE
BUG-2048 Use fallback language for attachments' labels

### DIFF
--- a/src/clj/ataru/email/application_email_confirmation.clj
+++ b/src/clj/ataru/email/application_email_confirmation.clj
@@ -140,7 +140,9 @@
         (map #(preview-submit-email (:lang %) (:subject %) (:content %) (:content-ending %)) x)))
 
 (defn- attachment-with-deadline [application lang field]
-  (let [attachment {:label (-> field :label lang)}]
+  (let [attachment {:label (-> field
+                               :label
+                               (util/non-blank-val [lang :fi :sv :en]))}]
     (assoc attachment :deadline (-> field :params :deadline-label lang))))
 
 (defn- create-email [koodisto-cache tarjonta-service organization-service ohjausparametrit-service subject template-name application-id]


### PR DESCRIPTION
When building a confirmation email, if attachment does not have the name (label)
for given language, use the labels in fallback language, in this order:  fi, sv, en.