### PR TITLE
HLE-1017 :  liitepyyntojen kasittelymerkintojen muutokset

### DIFF
--- a/resources/db/migration/V1_113__attachment_review_rename.sql
+++ b/resources/db/migration/V1_113__attachment_review_rename.sql
@@ -1,0 +1,1 @@
+update application_hakukohde_attachment_reviews set state = 'attachment-missing' where state = 'incomplete';

--- a/spec/ataru/applications/application_store_spec.clj
+++ b/spec/ataru/applications/application_store_spec.clj
@@ -179,7 +179,7 @@
                   :hakukohde       "form"}
                  {:application_key "attachments"
                   :attachment_key  "att__2"
-                  :state           "incomplete"
+                  :state           "attachment-missing"
                   :updated?        false
                   :hakukohde       "form"}]
                 (store/create-application-attachment-reviews
@@ -209,12 +209,12 @@
                   :hakukohde       "hakukohde2"}
                  {:application_key "attachments"
                   :attachment_key  "att__2"
-                  :state           "incomplete"
+                  :state           "attachment-missing"
                   :updated?        false
                   :hakukohde       "hakukohde1"}
                  {:application_key "attachments"
                   :attachment_key  "att__2"
-                  :state           "incomplete"
+                  :state           "attachment-missing"
                   :updated?        false
                   :hakukohde       "hakukohde2"}]
                 (store/create-application-attachment-reviews
@@ -239,7 +239,7 @@
                   :hakukohde       "form"}
                  {:application_key "attachments"
                   :attachment_key  "att__2"
-                  :state           "incomplete"
+                  :state           "attachment-missing"
                   :updated?        true
                   :hakukohde       "form"}]
                 (store/create-application-attachment-reviews

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -133,7 +133,7 @@
         review-base    {:application_key application-key
                         :attachment_key  (:id attachment-field)
                         :state           (if (empty? answer)
-                                           "incomplete"
+                                           "attachment-missing"
                                            "not-checked")
                         :updated?        value-changed?}]
     (map #(assoc review-base :hakukohde %)

--- a/src/cljc/ataru/application/review_states.cljc
+++ b/src/cljc/ataru/application/review_states.cljc
@@ -78,7 +78,7 @@
 
 (def attachment-hakukohde-review-types-with-no-requirements
   (concat attachment-hakukohde-review-types
-          [[no-attachment-requirements (:attachmentless state-translations)]]))
+          [[no-attachment-requirements (:no-attachment-required state-translations)]]))
 
 (def attachment-review-type-names
   (map first attachment-hakukohde-review-types))

--- a/src/cljc/ataru/application/review_states.cljc
+++ b/src/cljc/ataru/application/review_states.cljc
@@ -66,7 +66,7 @@
 (def attachment-hakukohde-review-types
   [["not-checked" (:not-checked state-translations)]
    ["checked" (:checked state-translations)]
-   ["incomplete" (:incomplete-answer state-translations)]
+   ["attachment-missing" (:attachment-missing state-translations)]
    ["overdue" (:overdue state-translations)]])
 
 (def attachment-hakukohde-review-types-with-multiple-values

--- a/src/cljc/ataru/application/review_states.cljc
+++ b/src/cljc/ataru/application/review_states.cljc
@@ -66,6 +66,7 @@
 (def attachment-hakukohde-review-types
   [["not-checked" (:not-checked state-translations)]
    ["checked" (:checked state-translations)]
+   ["incomplete-attachment" (:incomplete-attachment state-translations)]
    ["attachment-missing" (:attachment-missing state-translations)]
    ["overdue" (:overdue state-translations)]])
 

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1604,6 +1604,9 @@ You will receive a confirmation of your application to your email."}
    :no-attachment-required {:fi "Ei liitepyyntöä"
                             :sv "Ei liitepyyntöä (sv) TODO"
                             :en "Ei liitepyyntöä (en) TODO"}
+   :attachment-missing     {:fi "Liite puuttuu"
+                            :sv "Liite puuttuu (sv) TODO"
+                            :en "Liite puuttuu (en) TODO"}
    :multiple-values        {:fi "Monta arvoa"
                             :sv "Multipla värden"
                             :en "Multiple values"}})

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1604,6 +1604,9 @@ You will receive a confirmation of your application to your email."}
    :no-attachment-required {:fi "Ei liitepyyntöä"
                             :sv "Ei liitepyyntöä (sv) TODO"
                             :en "Ei liitepyyntöä (en) TODO"}
+   :incomplete-attachment  {:fi "Puutteellinen liite"
+                            :sv "Puutteellinen liite (sv) TODO"
+                            :en "Puutteellinen liite (en) TODO"}
    :attachment-missing     {:fi "Liite puuttuu"
                             :sv "Liite puuttuu (sv) TODO"
                             :en "Liite puuttuu (en) TODO"}

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1601,12 +1601,13 @@ You will receive a confirmation of your application to your email."}
    :overdue                {:fi "Myöhässä"
                             :sv "Försenad"
                             :en "Overdue"}
-   :attachmentless         {:fi "Liitteettömät"
-                            :sv "Utan bilagor"
-                            :en "No attachments"}
+   :no-attachment-required {:fi "Ei liitepyyntöä"
+                            :sv "Ei liitepyyntöä (sv) TODO"
+                            :en "Ei liitepyyntöä (en) TODO"}
    :multiple-values        {:fi "Monta arvoa"
                             :sv "Multipla värden"
                             :en "Multiple values"}})
+
 
 (def excel-texts
   {:name                     {:fi "Nimi"

--- a/test-postgres/Dockerfile
+++ b/test-postgres/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:10
+FROM postgres:11
 RUN localedef -i fi_FI -c -f UTF-8 -A /usr/share/locale/locale.alias fi_FI.UTF-8
 ENV LANG fi_FI.utf8


### PR DESCRIPTION
Kolmen commitin viestien pitäisi selittää asia aika tyhjentävästi.

Nimesin myös kannassa liitteen tilan "incomplete" muotoon "attachment-missing", koska vanhan "Puutteellinen"-tilan merkitys muuttui samassa muotoon "Liite puuttuu."