### PR TITLE
Bug 2065

### DIFF
--- a/spec/ataru/applications/excel_export_spec.clj
+++ b/spec/ataru/applications/excel_export_spec.clj
@@ -37,6 +37,10 @@
     (should= 1 (.getHorizontalSplitTopRow info))
     (should= 0 (.getVerticalSplitLeftColumn info))))
 
+(defn- format-included-ids [id-string]
+  (not-empty (set (remove clojure.string/blank? (clojure.string/split id-string #"\s+"))))
+  )
+
 (defmacro with-excel [skip-answers? bindings & body]
   `(let [~(first bindings) (File/createTempFile (str "excel-" (UUID/randomUUID)) ".xlsx")]
      (try
@@ -49,7 +53,7 @@
                                         nil
                                         nil
                                         ~skip-answers?
-                                        (constantly true)
+                                        (format-included-ids "ovela-kysymys")
                                         :fi
                                         (tarjonta-service/new-tarjonta-service)
                                         koodisto-cache

--- a/spec/ataru/applications/excel_export_spec.clj
+++ b/spec/ataru/applications/excel_export_spec.clj
@@ -38,10 +38,11 @@
     (should= 0 (.getVerticalSplitLeftColumn info))))
 
 (defn- format-included-ids [id-string]
-  (not-empty (set (remove clojure.string/blank? (clojure.string/split id-string #"\s+"))))
+  (or (not-empty (set (remove clojure.string/blank? (clojure.string/split id-string #"\s+"))))
+                 (constantly true))
   )
 
-(defmacro with-excel [skip-answers? bindings & body]
+(defmacro with-excel [input-params bindings & body]
   `(let [~(first bindings) (File/createTempFile (str "excel-" (UUID/randomUUID)) ".xlsx")]
      (try
        (with-open [output# (FileOutputStream. (.getPath ~(first bindings)))]
@@ -52,8 +53,8 @@
                                         fixtures/application-review-notes
                                         nil
                                         nil
-                                        ~skip-answers?
-                                        (format-included-ids "ovela-kysymys")
+                                        (~input-params :skip-answers?)
+                                        (format-included-ids (or (~input-params :included-ids) ""))
                                         :fi
                                         (tarjonta-service/new-tarjonta-service)
                                         koodisto-cache
@@ -79,7 +80,7 @@
       (spec)))
 
   (it "should export applications for a form without hakukohde or haku"
-    (with-excel false [file [fixtures/application-for-form]]
+    (with-excel {:skip-answers? false} [file [fixtures/application-for-form]]
       (let [workbook          (WorkbookFactory/create file)
             metadata-sheet    (.getSheetAt workbook 0)
             application-sheet (.getSheetAt workbook 1)]
@@ -92,7 +93,7 @@
         (verify-pane-information application-sheet))))
 
   (it "should export applications for a hakukohde with haku"
-    (with-excel false [file [fixtures/application-for-hakukohde]]
+    (with-excel {:skip-answers? false} [file [fixtures/application-for-hakukohde]]
       (let [workbook          (WorkbookFactory/create file)
             metadata-sheet    (.getSheetAt workbook 0)
             application-sheet (.getSheetAt workbook 1)]
@@ -104,7 +105,7 @@
         (verify-row application-sheet 2 nil))))
 
   (it "should export applications to separate sheets, grouped by form"
-    (with-excel false [file [fixtures/application-for-form fixtures/application-for-hakukohde]]
+    (with-excel {:skip-answers? false} [file [fixtures/application-for-form fixtures/application-for-hakukohde]]
       (let [workbook                    (WorkbookFactory/create file)
             metadata-sheet              (.getSheetAt workbook 0)
             form-application-sheet      (.getSheetAt workbook 1)
@@ -123,13 +124,27 @@
   (it "should always export answers to special questions"
     (with-redefs [form-store/fetch-by-id  (fn [_] fixtures/form-with-special-questions)
                   form-store/fetch-by-key (fn [_] fixtures/form-with-special-questions)]
-      (with-excel true [file [fixtures/application-with-special-answers]]
+      (with-excel {:skip-answers? true :included-ids ""} [file [fixtures/application-with-special-answers]]
         (let [workbook          (WorkbookFactory/create file)
               metadata-sheet    (.getSheetAt workbook 0)
               application-sheet (.getSheetAt workbook 1)]
           (verify-row metadata-sheet 0 ["Nimi" "Id" "Tunniste" "Viimeksi muokattu" "Viimeinen muokkaaja"])
           (verify-row metadata-sheet 1 ["Form name" "321" "form_321_key" "2016-06-14 15:34:56" "IRMELI KUIKELOINEN"])
           (verify-row metadata-sheet 2 nil)
-          (verify-row application-sheet 0 ["Id" "Lähetysaika" "Hakemuksen tila" "Hakukohteen käsittelyn tila" "Kielitaitovaatimus" "Tutkinnon kelpoisuus" "Hakukelpoisuus" "Hakukelpoisuus asetettu automaattisesti" "Hylkäyksen syy" "Maksuvelvollisuus" "Valinnan tila" "Pisteet" "Hakijan henkilö-OID" "Turvakielto" "Muistiinpanot" "Opiskelijavalinnan tulokseni saa julkaista internetissä?" "Etunimi" "Hakukohteet"])
-          (verify-row application-sheet 1 ["application_3424_key" "2016-06-15 15:34:56" "Aktiivinen" "Käsittelyssä" "Tarkastamatta" "Tarkastamatta" "Tarkastamatta" nil nil "Tarkastamatta" "Hyväksytty" "12" "1.123.345456567123" "kyllä" "2018-07-29 17:11:12 Virk Ailija: Asia kunnossa,\n2018-07-30 18:12:13 Ajilia Kriv: Muikkari" "Ei" "Person-etunimi" "(1) Ajoneuvonosturinkuljettajan ammattitutkinto - Koulutuskeskus Sedu, Ilmajoki, Ilmajoentie (hakukohde.oid)"])
-          (verify-row application-sheet 2 nil))))))
+          (verify-row application-sheet 0 ["Id" "Lähetysaika" "Hakemuksen tila" "Hakukohteen käsittelyn tila" "Kielitaitovaatimus" "Tutkinnon kelpoisuus" "Hakukelpoisuus" "Hakukelpoisuus asetettu automaattisesti" "Hylkäyksen syy" "Maksuvelvollisuus" "Valinnan tila" "Pisteet" "Hakijan henkilö-OID" "Turvakielto" "Muistiinpanot" "Kysymys 4" "Opiskelijavalinnan tulokseni saa julkaista internetissä?" "Etunimi" "Hakukohteet"])
+          (verify-row application-sheet 1 ["application_3424_key" "2016-06-15 15:34:56" "Aktiivinen" "Käsittelyssä" "Tarkastamatta" "Tarkastamatta" "Tarkastamatta" nil nil "Tarkastamatta" "Hyväksytty" "12" "1.123.345456567123" "kyllä" "2018-07-29 17:11:12 Virk Ailija: Asia kunnossa,\n2018-07-30 18:12:13 Ajilia Kriv: Muikkari" "Vastaus 4" "Ei" "Person-etunimi" "(1) Ajoneuvonosturinkuljettajan ammattitutkinto - Koulutuskeskus Sedu, Ilmajoki, Ilmajoentie (hakukohde.oid)"])
+          (verify-row application-sheet 2 nil)))))
+
+  (it "should not include Kysymys 4 when not including everything"
+      (with-redefs [form-store/fetch-by-id  (fn [_] fixtures/form-with-special-questions)
+                    form-store/fetch-by-key (fn [_] fixtures/form-with-special-questions)]
+        (with-excel {:skip-answers? true :included-ids "joku-kysymys-vaan"} [file [fixtures/application-with-special-answers]]
+                    (let [workbook          (WorkbookFactory/create file)
+                          metadata-sheet    (.getSheetAt workbook 0)
+                          application-sheet (.getSheetAt workbook 1)]
+                      (verify-row metadata-sheet 0 ["Nimi" "Id" "Tunniste" "Viimeksi muokattu" "Viimeinen muokkaaja"])
+                      (verify-row metadata-sheet 1 ["Form name" "321" "form_321_key" "2016-06-14 15:34:56" "IRMELI KUIKELOINEN"])
+                      (verify-row metadata-sheet 2 nil)
+                      (verify-row application-sheet 0 ["Id" "Lähetysaika" "Hakemuksen tila" "Hakukohteen käsittelyn tila" "Kielitaitovaatimus" "Tutkinnon kelpoisuus" "Hakukelpoisuus" "Hakukelpoisuus asetettu automaattisesti" "Hylkäyksen syy" "Maksuvelvollisuus" "Valinnan tila" "Pisteet" "Hakijan henkilö-OID" "Turvakielto" "Muistiinpanot" "Opiskelijavalinnan tulokseni saa julkaista internetissä?" "Etunimi" "Hakukohteet"])
+                      (verify-row application-sheet 1 ["application_3424_key" "2016-06-15 15:34:56" "Aktiivinen" "Käsittelyssä" "Tarkastamatta" "Tarkastamatta" "Tarkastamatta" nil nil "Tarkastamatta" "Hyväksytty" "12" "1.123.345456567123" "kyllä" "2018-07-29 17:11:12 Virk Ailija: Asia kunnossa,\n2018-07-30 18:12:13 Ajilia Kriv: Muikkari" "Ei" "Person-etunimi" "(1) Ajoneuvonosturinkuljettajan ammattitutkinto - Koulutuskeskus Sedu, Ilmajoki, Ilmajoentie (hakukohde.oid)"])
+                      (verify-row application-sheet 2 nil))))))

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -17,7 +17,8 @@
             [clojure.java.io :refer [input-stream]]
             [taoensso.timbre :refer [spy debug]]
             [ataru.application.review-states :as review-states]
-            [ataru.application.application-states :as application-states]))
+            [ataru.application.application-states :as application-states]
+            [taoensso.timbre :as log]))
 
 
 (def max-value-length 5000)
@@ -344,10 +345,10 @@
   [form-fields form-fields-by-id skip-answers? included-ids selected-oids]
   (->> form-fields
        (remove #(or (:exclude-from-answers %)
-                    (and (or skip-answers?
-                             (not (included-ids (:id %))))
-                         (not (answer-to-always-include? (:id %))))
-                    (belongs-to-other-hakukohde? selected-oids %)))
+                    (and (not (included-ids (:id %)))
+                         (or (and skip-answers?
+                                  (not (answer-to-always-include? (:id %))))
+                             (belongs-to-other-hakukohde? selected-oids %)))))
        (map #(vector (:id %) (pick-header form-fields-by-id %)))))
 
 (defn- headers-from-applications


### PR DESCRIPTION
Ei filtteröidä exceliltä pois sellaisia kysymyksiä, joita on erikseen pyydetty antamalla kysymyksen tunniste kälin kautta, vaikka joku muu ehdoista täyttyisikin. 
Huom. jos kälistä ei valitse mitään tunnistetta, tulkitaan se nykytoteutuksella niin että kaikki kysymykset haluttiin. Tämä on toivottua toimintaa. 