### PR TITLE
BUG-2074

### DIFF
--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -48,7 +48,6 @@
        :content-disposition (-> resp :headers :content-disposition)})))
 
 (defn- generate-filename [filename counter]
-  (log/info "filename: " filename " counter: " counter)
   (let [name (str (str/join "." (butlast (str/split filename #"\."))))
         extension (last (str/split filename #"\."))]
     (str (apply str (take 240 name)) counter "." extension)))
@@ -60,13 +59,13 @@
       (doseq [key keys]
         (if-let [file (get-file key)]
           (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))
-                generated-filename (if (contains? @filenames (generate-filename filename "")) (generate-filename filename (swap! counter inc)) (generate-filename filename ""))]
+                generated-filename (if (contains? @filenames (generate-filename filename ""))
+                                     (generate-filename filename (swap! counter inc))
+                                     (generate-filename filename ""))]
             (.putNextEntry zout (new ZipEntry generated-filename))
             (with-open [fin (:body file)]
               (io/copy fin zout))
             (swap! filenames conj generated-filename)
-            (log/info "file-zip filename: " generated-filename)
-            (log/info "file-zip filenames: " filenames)
             (.closeEntry zout)
             (.flush zout))
           (log/error "Could not get file" key))))))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -59,12 +59,8 @@
       (doseq [key keys]
         (if-let [file (get-file key)]
           (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-            (conj filenames filename)
             (.putNextEntry zout (new ZipEntry
-                                     (conj filename
-                                           (if
-                                             (contains? filenames (generate-filename filename ""))
-                                             (generate-filename filename (inc counter)) filename))))
+                                     (conj filenames (if (contains? filenames (generate-filename filename "")) (generate-filename filename (inc counter)) (generate-filename filename "")))))
             (with-open [fin (:body file)]
               (io/copy fin zout))
             (.closeEntry zout)

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -53,7 +53,9 @@
     (doseq [key keys]
       (if-let [file (get-file key)]
         (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-          (.putNextEntry zout (new ZipEntry (str (subs (str (str/join "." (butlast (str/split filename #"\."))) "_" key) 0 250) "." (last (str/split filename #"\.")))))
+          (.putNextEntry zout (new ZipEntry
+                                   (str (subs (str (str/join "." (butlast (str/split filename #"\."))) "_" key) 0 250)
+                                     "." (last (str/split filename #"\.")))))
           (with-open [fin (:body file)]
             (io/copy fin zout))
           (.closeEntry zout)

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -69,5 +69,5 @@
             (conj filenames (.getName zout))
             (log/info "file-zip filename: " (.getName filename))
             (log/info "file-zip filenames: " filenames)
-            (.getName zout))
+            )
           (log/error "Could not get file" key))))))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -5,7 +5,8 @@
             [ataru.util.http-util :as http-util]
             [cheshire.core :as json]
             [clojure.java.io :as io]
-            [taoensso.timbre :as log])
+            [taoensso.timbre :as log]
+            [cuerdas.core :as str])
   (:import [java.text Normalizer Normalizer$Form]
            [java.util.zip ZipOutputStream ZipEntry]))
 
@@ -48,10 +49,11 @@
 
 (defn get-file-zip [keys out]
   (with-open [zout (ZipOutputStream. out)]
+    ;(def files #{})
     (doseq [key keys]
       (if-let [file (get-file key)]
         (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-          (.putNextEntry zout (new ZipEntry (str filename)))
+          (.putNextEntry zout (new ZipEntry (str (butlast (str/split filename)) "_" key "." (butlast (str/split filename)))))
           (with-open [fin (:body file)]
             (io/copy fin zout))
           (.closeEntry zout)

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -60,7 +60,7 @@
       (doseq [key keys]
         (if-let [file (get-file key)]
           (let [[_ (atom filename)] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-          (swap! filename (if (contains? @filenames (generate-filename filename "")) (generate-filename filename (swap! counter inc)) (generate-filename filename "")))
+          (swap! filename (if (contains? @filenames (generate-filename @filename "")) (generate-filename @filename (swap! counter inc)) (generate-filename @filename "")))
             (.putNextEntry zout (new ZipEntry @filename))
             (with-open [fin (:body file)]
               (io/copy fin zout))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -59,8 +59,9 @@
       (doseq [key keys]
         (if-let [file (get-file key)]
           (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-            (.putNextEntry zout (new ZipEntry
-                                     (conj filenames (if (contains? filenames (generate-filename filename "")) (generate-filename filename (inc counter)) (generate-filename filename "")))))
+            (var-set filename (if (contains? filenames (generate-filename filename "")) (generate-filename filename (inc counter)) (generate-filename filename "")))
+            (conj filenames filename)
+            (.putNextEntry zout (new ZipEntry filename))
             (with-open [fin (:body file)]
               (io/copy fin zout))
             (.closeEntry zout)

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -51,7 +51,7 @@
   (log/info "filename: " filename " counter: " counter)
   (let [name (str (str/join "." (butlast (str/split filename #"\."))))
         extension (last (str/split filename #"\."))]
-    (str (apply str (take 240 name)) @counter "." extension)))
+    (str (apply str (take 240 name)) counter "." extension)))
 
 ( defn get-file-zip [keys out]
   (with-open [zout (ZipOutputStream. out)]
@@ -64,8 +64,8 @@
             (.putNextEntry zout (new ZipEntry generated-filename))
             (with-open [fin (:body file)]
               (io/copy fin zout))
-            (swap! filenames conj (.getName zout))
-            (log/info "file-zip filename: " (.getName zout))
+            (swap! filenames conj generated-filename)
+            (log/info "file-zip filename: " generated-filename)
             (log/info "file-zip filenames: " filenames)
             (.closeEntry zout)
             (.flush zout))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -56,18 +56,19 @@
 ( defn get-file-zip [keys out]
   (with-open [zout (ZipOutputStream. out)]
     (let [filenames (atom #{})
-          counter 0]
+          counter (atom 0)]
       (doseq [key keys]
         (if-let [file (get-file key)]
           (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-            (.putNextEntry zout (new ZipEntry (if (contains? @filenames (generate-filename filename "")) (generate-filename filename (inc counter)) (generate-filename filename ""))))
+            (.putNextEntry zout (new ZipEntry (if (contains? @filenames (generate-filename filename "")) (generate-filename filename (swap! counter inc)) (generate-filename filename ""))))
             (with-open [fin (:body file)]
               (io/copy fin zout))
             (swap! filenames conj (.getName zout))
+            (log/info "file-zip filename: " (.getName zout))
+            (log/info "file-zip filenames: " filenames)
             (.closeEntry zout)
             (.flush zout)
 
-            (log/info "file-zip filename: " (.getName filename))
-            (log/info "file-zip filenames: " filenames)
+
             )
           (log/error "Could not get file" key))))))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -53,7 +53,7 @@
     (doseq [key keys]
       (if-let [file (get-file key)]
         (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-          (.putNextEntry zout (new ZipEntry (str (butlast (str/split filename #"\.")) "_" key "." (butlast (str/split filename #"\.")))))
+          (.putNextEntry zout (new ZipEntry (str (apply str (butlast (str/split filename #"\."))) "_" key "." (last (str/split filename #"\.")))))
           (with-open [fin (:body file)]
             (io/copy fin zout))
           (.closeEntry zout)

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -53,21 +53,7 @@
         extension (last (str/split filename #"\."))]
     (str (apply str (take 240 name)) counter "." extension)))
 
-
-(defn get-file-zip [keys out]
-  (with-open [zout (ZipOutputStream. out)]
-    (doseq [key keys]
-      (if-let [file (get-file key)]
-        (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-          (.putNextEntry zout (new ZipEntry (str filename)))
-          (with-open [fin (:body file)]
-            (io/copy fin zout))
-          (.closeEntry zout)
-          (.flush zout))
-        (log/error "Could not get file" key)))))
-
-
-(comment defn get-file-zip [keys out]
+( defn get-file-zip [keys out]
   (with-open [zout (ZipOutputStream. out)]
     (let [filenames #{}
           counter 0]

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -61,13 +61,13 @@
         (if-let [file (get-file key)]
           (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
             (var-set filename (if (contains? filenames (generate-filename filename "")) (generate-filename filename (inc counter)) (generate-filename filename "")))
-
             (log/info "file-zip filename: " filename)
-            (conj filenames filename)
-            (log/info "file-zip filenames: " filenames)
             (.putNextEntry zout (new ZipEntry filename))
             (with-open [fin (:body file)]
               (io/copy fin zout))
+
             (.closeEntry zout)
+            (conj filenames filename)
+            (log/info "file-zip filenames: " filenames)
             (.flush zout))
           (log/error "Could not get file" key))))))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -6,7 +6,7 @@
             [cheshire.core :as json]
             [clojure.java.io :as io]
             [taoensso.timbre :as log]
-            [cuerdas.core :as str])
+            [clojure.string :as str])
   (:import [java.text Normalizer Normalizer$Form]
            [java.util.zip ZipOutputStream ZipEntry]))
 
@@ -53,7 +53,7 @@
     (doseq [key keys]
       (if-let [file (get-file key)]
         (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-          (.putNextEntry zout (new ZipEntry (str (butlast (str/split filename)) "_" key "." (butlast (str/split filename)))))
+          (.putNextEntry zout (new ZipEntry (str (butlast (str/split filename #"\.")) "_" key "." (butlast (str/split filename #"\.")))))
           (with-open [fin (:body file)]
             (io/copy fin zout))
           (.closeEntry zout)

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -48,6 +48,7 @@
        :content-disposition (-> resp :headers :content-disposition)})))
 
 (defn- generate-filename [filename counter]
+  (log/info "filename: " filename " counter: " counter)
   (let [name (str (str/join "." (butlast (str/split filename #"\."))))
         extension (last (str/split filename #"\."))]
     (str (apply str (take 240 name)) counter "." extension)))
@@ -60,7 +61,10 @@
         (if-let [file (get-file key)]
           (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
             (var-set filename (if (contains? filenames (generate-filename filename "")) (generate-filename filename (inc counter)) (generate-filename filename "")))
+
+            (log/info "file-zip filename: " filename)
             (conj filenames filename)
+            (log/info "file-zip filenames: " filenames)
             (.putNextEntry zout (new ZipEntry filename))
             (with-open [fin (:body file)]
               (io/copy fin zout))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -53,7 +53,7 @@
     (doseq [key keys]
       (if-let [file (get-file key)]
         (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-          (.putNextEntry zout (new ZipEntry (str (apply str (butlast (str/split filename #"\."))) "_" key "." (last (str/split filename #"\.")))))
+          (.putNextEntry zout (new ZipEntry (str (subs (str (str/join "." (butlast (str/split filename #"\."))) "_" key) 0 250) "." (last (str/split filename #"\.")))))
           (with-open [fin (:body file)]
             (io/copy fin zout))
           (.closeEntry zout)

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -59,9 +59,9 @@
           counter (atom 0)]
       (doseq [key keys]
         (if-let [file (get-file key)]
-          (let [[_ (atom filename)] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-          (swap! filename (if (contains? @filenames (generate-filename @filename "")) (generate-filename @filename (swap! counter inc)) (generate-filename @filename "")))
-            (.putNextEntry zout (new ZipEntry @filename))
+          (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))
+                generated-filename (if (contains? @filenames (generate-filename filename "")) (generate-filename filename (swap! counter inc)) (generate-filename filename ""))]
+            (.putNextEntry zout (new ZipEntry generated-filename))
             (with-open [fin (:body file)]
               (io/copy fin zout))
             (swap! filenames conj (.getName zout))

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -53,7 +53,21 @@
         extension (last (str/split filename #"\."))]
     (str (apply str (take 240 name)) counter "." extension)))
 
+
 (defn get-file-zip [keys out]
+  (with-open [zout (ZipOutputStream. out)]
+    (doseq [key keys]
+      (if-let [file (get-file key)]
+        (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
+          (.putNextEntry zout (new ZipEntry (str filename)))
+          (with-open [fin (:body file)]
+            (io/copy fin zout))
+          (.closeEntry zout)
+          (.flush zout))
+        (log/error "Could not get file" key)))))
+
+
+(comment defn get-file-zip [keys out]
   (with-open [zout (ZipOutputStream. out)]
     (let [filenames #{}
           counter 0]
@@ -65,7 +79,6 @@
             (.putNextEntry zout (new ZipEntry filename))
             (with-open [fin (:body file)]
               (io/copy fin zout))
-
             (.closeEntry zout)
             (conj filenames filename)
             (log/info "file-zip filenames: " filenames)

--- a/src/clj/ataru/files/file_store.clj
+++ b/src/clj/ataru/files/file_store.clj
@@ -74,13 +74,14 @@
       (doseq [key keys]
         (if-let [file (get-file key)]
           (let [[_ filename] (re-matches #"attachment; filename=\"(.*)\"" (:content-disposition file))]
-            (var-set filename (if (contains? filenames (generate-filename filename "")) (generate-filename filename (inc counter)) (generate-filename filename "")))
             (log/info "file-zip filename: " filename)
-            (.putNextEntry zout (new ZipEntry filename))
+            (.putNextEntry zout (new ZipEntry (if (contains? filenames (generate-filename filename "")) (generate-filename filename (inc counter)) (generate-filename filename ""))))
             (with-open [fin (:body file)]
               (io/copy fin zout))
             (.closeEntry zout)
-            (conj filenames filename)
+            (.flush zout)
+            (conj filenames (.getName zout))
+            (log/info "file-zip filename: " (.getName filename))
             (log/info "file-zip filenames: " filenames)
-            (.flush zout))
+            (.getName zout))
           (log/error "Could not get file" key))))))


### PR DESCRIPTION
Fiksattu Zip-filen muodostus: 
- Jos useita saman nimisiä tiedostoja, laitetaan kirjain perään
- Jos tiedostonimen pituus on yli 240 merkkiä, otetaan vain 240 merkkiä nimen alusta.