### PR TITLE
BUG-2077  ui overflow

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -174,7 +174,8 @@ body {
   font-weight: 300;
   margin: 0 0 0 10px;
   padding: 0;
-  display: table;
+  display: block;
+  overflow-wrap: break-word;
 }
 .application__form-field-list li {
   display: table-row;

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -731,6 +731,7 @@ textarea.application__form-text-area__size-large {
   padding: 2px 8px 2px 8px;
   border-radius: 3px;
   background-color: #DEF2FF;
+  max-width: fit-content;
   &__success {
     background-color: @sg-color-green-lighten-1;
   }

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -86,7 +86,7 @@ body {
 
 .application__wrapper-contents {
   margin-top: 13px;
-  width: 100%;
+  width: 75%;
 }
 .application__form-field {
   display: flex;

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -175,7 +175,7 @@ body {
   margin: 0 0 0 10px;
   padding: 0;
   display: block;
-  overflow-wrap: break-word;
+  word-break: break-all;
 }
 .application__form-field-list li {
   display: table-row;
@@ -795,7 +795,7 @@ textarea.application__form-text-area__size-large {
 
 .application__form-attachment-filename {
   font-size: 14px;
-  overflow-wrap: break-word;
+  word-break:break-all;
 }
 
 .application__form-attachment-error {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -743,7 +743,7 @@ textarea.application__form-text-area__size-large {
 }
 
 .application__form-attachment-check-mark-container {
-  flex: auto;
+  flex: inherit;
 }
 
 .application__form-attachment-check-mark {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -174,7 +174,7 @@ body {
   font-weight: 300;
   margin: 0 0 0 10px;
   padding: 0;
-  display: block;
+  display: flex;
   word-break: break-all;
 }
 .application__form-field-list li {
@@ -795,7 +795,8 @@ textarea.application__form-text-area__size-large {
 
 .application__form-attachment-filename {
   font-size: 14px;
-  word-break:break-all;
+  display: flex;
+  word-break: break-all;
 }
 
 .application__form-attachment-error {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -793,6 +793,7 @@ textarea.application__form-text-area__size-large {
 
 .application__form-attachment-filename {
   font-size: 14px;
+  overflow-wrap: break-word;
 }
 
 .application__form-attachment-error {

--- a/resources/less/virkailija-application.less
+++ b/resources/less/virkailija-application.less
@@ -1665,7 +1665,8 @@ and (max-width: 1000px) {
 
 .application__virkailija-readonly-attachment-area {
   margin-top: 5px;
-  display: block;
+  display: flex;
+  word-break: break-all;
   align-items: center;
 }
 

--- a/resources/less/virkailija-application.less
+++ b/resources/less/virkailija-application.less
@@ -638,6 +638,7 @@ and (max-width: 1000px) {
   //transform: translateX(-100%);
   min-width: 672px;
   right: 436px;
+  left: -672px;
   animation-duration: 0.5s;
 }
 
@@ -682,6 +683,7 @@ and (max-width: 1000px) {
   margin: 0px;
   font-weight: lighter;
   list-style: none;
+  overflow-wrap: break-word;
 }
 
 .application__attachment-review-row-label {

--- a/resources/less/virkailija-application.less
+++ b/resources/less/virkailija-application.less
@@ -1658,28 +1658,13 @@ and (max-width: 1000px) {
   font-size: 14px;
   font-weight: 300;
   line-height: 150%;
+  overflow-wrap: break-word;
 }
 
 .application__virkailija-readonly-attachment-area {
   margin-top: 5px;
-  display: flex;
+  display: block;
   align-items: center;
-}
-
-.application__virkailija-readonly-attachment-delete {
-  .arrow(left, @pale-blue, 8px, 8px);
-  align-items: center;
-  background: @pale-blue;
-  border-radius: 3px;
-  color: white;
-  display: flex;
-  font-size: 13px;
-  margin-left: 20px;
-  padding: 4px 7px 4px 4px;
-}
-.application__virkailija-readonly-attachment-delete--confirm {
-  .arrow(left, @sg-color-red, 8px, 8px);
-  background-color: @sg-color-red;
 }
 
 .application__virkailija-readonly-attachment-virus-status-not-started {

--- a/resources/less/virkailija-application.less
+++ b/resources/less/virkailija-application.less
@@ -683,7 +683,7 @@ and (max-width: 1000px) {
   margin: 0px;
   font-weight: lighter;
   list-style: none;
-  overflow-wrap: break-word;
+  word-break:break-all;
 }
 
 .application__attachment-review-row-label {
@@ -1660,7 +1660,7 @@ and (max-width: 1000px) {
   font-size: 14px;
   font-weight: 300;
   line-height: 150%;
-  overflow-wrap: break-word;
+  word-break:break-all;
 }
 
 .application__virkailija-readonly-attachment-area {

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -806,7 +806,7 @@
         filename-parts (split filename #"\.")
         short-filename (if (< (count filename) max-filename-length)
                          filename
-                         (str (subs (first filename-parts) 0 max-filename-length) "[...]." (second filename-parts)))]
+                         (str (subs (first filename-parts) 0 max-filename-length) "[...]." (last filename-parts)))]
     [:div
      (if (:final file)
        [:a.application__form-attachment-filename

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -1,5 +1,5 @@
 (ns ataru.hakija.application-form-components
-  (:require [clojure.string :refer [trim split]]
+  (:require [clojure.string :refer [trim]]
             [re-frame.core :refer [subscribe dispatch dispatch-sync]]
             [reagent.ratom :refer-macros [reaction]]
             [markdown.core :refer [md->html]]
@@ -800,20 +800,14 @@
                                   id
                                   question-group-idx
                                   attachment-idx]))
-        link @(subscribe [:application/attachment-download-link (:key file)])
-        filename (:filename file)
-        max-filename-length 78
-        filename-parts (split filename #"\.")
-        short-filename (if (< (count filename) max-filename-length)
-                         filename
-                         (str (subs (first filename-parts) 0 max-filename-length) "[...]." (last filename-parts)))]
+        link @(subscribe [:application/attachment-download-link (:key file)])]
     [:div
      (if (:final file)
        [:a.application__form-attachment-filename
         {:href link}
-        short-filename]
+        (:filename file)]
        [:span.application__form-attachment-filename
-        short-filename])
+        (:filename file)])
      (when (and (some? (:size file)) show-size?)
        [:span (str " (" (util/size-bytes->str (:size file)) ")")])]))
 

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -1,5 +1,5 @@
 (ns ataru.hakija.application-form-components
-  (:require [clojure.string :refer [trim]]
+  (:require [clojure.string :refer [trim split]]
             [re-frame.core :refer [subscribe dispatch dispatch-sync]]
             [reagent.ratom :refer-macros [reaction]]
             [markdown.core :refer [md->html]]
@@ -800,14 +800,20 @@
                                   id
                                   question-group-idx
                                   attachment-idx]))
-        link @(subscribe [:application/attachment-download-link (:key file)])]
+        link @(subscribe [:application/attachment-download-link (:key file)])
+        filename (:filename file)
+        max-filename-length 78
+        filename-parts (split filename #"\.")
+        short-filename (if (< (count filename) max-filename-length)
+                         filename
+                         (str (subs (first filename-parts) 0 max-filename-length) "[...]." (second filename-parts)))]
     [:div
      (if (:final file)
        [:a.application__form-attachment-filename
         {:href link}
-        (:filename file)]
+        short-filename]
        [:span.application__form-attachment-filename
-        (:filename file)])
+        short-filename])
      (when (and (some? (:size file)) show-size?)
        [:span (str " (" (util/size-bytes->str (:size file)) ")")])]))
 


### PR DESCRIPTION
Pitkät tiedostonimet näkyvät liian leveänä.

Rivitetään tyyleillä (break-word) missä mahdollista, muuten lyhennetään näytettyä nimeä koodissa. 
