### PR TITLE
Lomakkeiden valimuistiuudistus

### DIFF
--- a/config/defaults.edn
+++ b/config/defaults.edn
@@ -25,7 +25,8 @@
  :cache           {:type :redis}
  :redis           {:uri "redis://localhost:6379"}
  :session         {:timeout 28800}
- :public-config   {:applicant                           {:service_url "http://localhost:8351"}
+ :public-config   {:hakija-caller-id                    "1.2.246.562.10.00000000001.ataru-hakija.frontend"
+                   :applicant                           {:service_url "http://localhost:8351"}
                    :virkailija                          {:service_url "http://localhost:8350/lomake-editori/"}
                    :environment-name                    "dev"
                    :features                            {}

--- a/config/dev.edn
+++ b/config/dev.edn
@@ -26,7 +26,8 @@
  :cache           {:type :redis}
  :redis           {:uri "redis://localhost:6380"}
  :cas             {}
- :public-config   {:applicant                           {:service_url "http://localhost:8351"}
+ :public-config   {:hakija-caller-id                    "1.2.246.562.10.00000000001.ataru-hakija.frontend"
+                   :applicant                           {:service_url "http://localhost:8351"}
                    :virkailija                          {:service_url "http://localhost:8350/lomake-editori/"}
                    :environment-name                    "test"
                    :enable-re-frisk                     true

--- a/config/test.edn
+++ b/config/test.edn
@@ -26,7 +26,8 @@
  :cache           {:type :redis}
  :redis           {:uri "redis://localhost:16380"}
  :cas             {}
- :public-config   {:applicant                           {:service_url "http://localhost:8351"}
+ :public-config   {:hakija-caller-id                    "1.2.246.562.10.00000000001.ataru-hakija.frontend"
+                   :applicant                           {:service_url "http://localhost:8351"}
                    :virkailija                          {:service_url "http://localhost:8350/lomake-editori/"}
                    :environment-name                    "test"
                    :enable-re-frisk                     true

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -28,7 +28,8 @@
        :henkilo-modified-queue {:enabled?      {{ataru_henkilo_modified_queue_enabled}}
                                 :drain-failed? {{ataru_henkilo_modified_queue_drain_failed}}
                                 :queue-url     "{{ataru_henkilo_modified_queue_url}}"}}
- :public-config {:applicant {:service_url "{{ataru_applicant_service_url}}"}
+ :public-config {:hakija-caller-id "{{ataru_hakija_frontend_caller_id | default('1.2.246.562.10.00000000001.ataru-hakija.frontend')}}"
+                 :applicant {:service_url "{{ataru_applicant_service_url}}"}
                  :virkailija {:service_url "https://{{host_virkailija}}/lomake-editori/"}
                  :environment-name "{{ataru_environment_name}}"
                  :features {}

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -59,27 +59,17 @@
                                                (get-many-from [this keys])
                                                (remove-from [this key])
                                                (clear-all [this]))
-        form-by-haku-oid-and-id-cache-loader (hakija-form-service/map->FormByHakuOidAndIdCacheLoader
-                                              {:tarjonta-service         tarjonta-service
-                                               :koodisto-cache           koodisto-cache
-                                               :organization-service     organization-service
-                                               :ohjausparametrit-service ohjausparametrit-service})
-        form-by-haku-oid-and-id-cache        (reify cache-service/Cache
-                                               (get-from [this key]
-                                                 (.load form-by-haku-oid-and-id-cache-loader key))
-                                               (get-many-from [this keys])
-                                               (remove-from [this key])
-                                               (clear-all [this]))
         form-by-haku-oid-str-cache-loader    (hakija-form-service/map->FormByHakuOidStrCacheLoader
-                                              {:tarjonta-service              tarjonta-service
-                                               :form-by-haku-oid-and-id-cache form-by-haku-oid-and-id-cache})]
+                                              {:koodisto-cache           koodisto-cache
+                                               :ohjausparametrit-service ohjausparametrit-service
+                                               :organization-service     organization-service
+                                               :tarjonta-service         tarjonta-service})]
     (-> (routes/new-handler)
         (assoc :tarjonta-service tarjonta-service)
         (assoc :job-runner (job/new-job-runner hakija-jobs/job-definitions))
         (assoc :organization-service organization-service)
         (assoc :ohjausparametrit-service ohjausparametrit-service)
         (assoc :person-service (person-service/new-person-service))
-        (assoc :form-by-haku-oid-and-id-cache form-by-haku-oid-and-id-cache)
         (assoc :form-by-haku-oid-str-cache (reify cache-service/Cache
                                              (get-from [this key]
                                                (.load form-by-haku-oid-str-cache-loader key))

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -6,6 +6,7 @@
             [ataru.files.file-store :as file-store]
             [ataru.fixtures.application :as application-fixtures]
             [ataru.fixtures.db.unit-test-db :as db]
+            [ataru.forms.form-store :as form-store]
             [ataru.email.application-email-confirmation :as application-email]
             [ataru.hakija.background-jobs.hakija-jobs :as hakija-jobs]
             [ataru.hakija.hakija-form-service :as hakija-form-service]
@@ -13,6 +14,7 @@
             [ataru.organization-service.organization-service :as organization-service]
             [ataru.tarjonta-service.hakuaika :as hakuaika]
             [ataru.cache.cache-service :as cache-service]
+            [ataru.cache.in-memory-cache :as in-memory]
             [ataru.cache.redis-cache :as redis-cache]
             [ataru.hakija.hakija-routes :as routes]
             [ataru.hakija.hakija-application-service :as application-service]
@@ -26,7 +28,8 @@
             [yesql.core :as sql]
             [ataru.fixtures.form :as form-fixtures]
             [ataru.ohjausparametrit.ohjausparametrit-service :as ohjausparametrit-service]
-            [ataru.person-service.person-service :as person-service]))
+            [ataru.person-service.person-service :as person-service])
+  (:import java.util.concurrent.TimeUnit))
 
 (sql/defqueries "sql/application-queries.sql")
 
@@ -51,7 +54,13 @@
                                                           (assoc-in [:answers 17 :value] [ "1.2.246.562.20.49028196524" "1.2.246.562.20.49028196523"])))
 
 (def handler
-  (let [tarjonta-service                     (tarjonta-service/new-tarjonta-service)
+  (let [form-by-id-cache                     (reify cache-service/Cache
+                                               (get-from [this key]
+                                                 (form-store/fetch-by-id (Integer/valueOf key)))
+                                               (get-many-from [this keys])
+                                               (remove-from [this key])
+                                               (clear-all [this]))
+        tarjonta-service                     (tarjonta-service/new-tarjonta-service)
         organization-service                 (organization-service/new-organization-service)
         ohjausparametrit-service             (ohjausparametrit-service/new-ohjausparametrit-service)
         koodisto-cache                       (reify cache-service/Cache
@@ -60,7 +69,8 @@
                                                (remove-from [this key])
                                                (clear-all [this]))
         form-by-haku-oid-str-cache-loader    (hakija-form-service/map->FormByHakuOidStrCacheLoader
-                                              {:koodisto-cache           koodisto-cache
+                                              {:form-by-id-cache         form-by-id-cache
+                                               :koodisto-cache           koodisto-cache
                                                :ohjausparametrit-service ohjausparametrit-service
                                                :organization-service     organization-service
                                                :tarjonta-service         tarjonta-service})]
@@ -70,6 +80,7 @@
         (assoc :organization-service organization-service)
         (assoc :ohjausparametrit-service ohjausparametrit-service)
         (assoc :person-service (person-service/new-person-service))
+        (assoc :form-by-id-cache form-by-id-cache)
         (assoc :form-by-haku-oid-str-cache (reify cache-service/Cache
                                              (get-from [this key]
                                                (.load form-by-haku-oid-str-cache-loader key))

--- a/src/clj/ataru/cache/caches.clj
+++ b/src/clj/ataru/cache/caches.clj
@@ -165,15 +165,6 @@
        :expire-after-access [3 TimeUnit/DAYS]
        :refresh-after       [7 TimeUnit/MINUTES]})
      {:redis-cache :koodisto-redis-cache})]
-   [:form-by-haku-oid-and-id-cache
-    (component/using
-     (redis/map->Cache
-      {:name          "form-by-haku-oid-and-id"
-       :ttl           [1 TimeUnit/HOURS]
-       :refresh-after [5 TimeUnit/SECONDS]
-       :lock-timeout  [1 TimeUnit/MINUTES]})
-     {:redis  :redis
-      :loader :form-by-haku-oid-and-id-cache-loader})]
    [:form-by-haku-oid-str-cache
     (component/using
      (redis/map->Cache

--- a/src/clj/ataru/cache/caches.clj
+++ b/src/clj/ataru/cache/caches.clj
@@ -4,6 +4,7 @@
             [ataru.cache.in-memory-cache :as in-memory]
             [ataru.cache.two-layer-cache :as two-layer]
             [ataru.cache.redis-cache :as redis]
+            [ataru.forms.form-store :as form-store]
             [ataru.lokalisointi-service.lokalisointi-service :as lokalisointi-service]
             [ataru.tarjonta-service.tarjonta-client :as tarjonta-client]
             [ataru.tarjonta-service.tarjonta-service :as tarjonta-service]
@@ -165,6 +166,13 @@
        :expire-after-access [3 TimeUnit/DAYS]
        :refresh-after       [7 TimeUnit/MINUTES]})
      {:redis-cache :koodisto-redis-cache})]
+   [:form-by-id-cache
+    (in-memory/map->InMemoryCache
+     {:loader        (cache/->FunctionCacheLoader
+                      (fn [key] (form-store/fetch-by-id (Integer/valueOf key))))
+      :size          10
+      :expires-after [3 TimeUnit/DAYS]
+      :refresh-after [1 TimeUnit/DAYS]})]
    [:form-by-haku-oid-str-cache
     (component/using
      (redis/map->Cache

--- a/src/clj/ataru/cache/in_memory_cache.clj
+++ b/src/clj/ataru/cache/in_memory_cache.clj
@@ -7,6 +7,7 @@
             LoadingCache]))
 
 (defrecord InMemoryCache [loader
+                          size
                           expires-after
                           refresh-after
                           ^LoadingCache caffeine]
@@ -15,6 +16,8 @@
     (if (nil? caffeine)
       (assoc this :caffeine
              (cond-> (Caffeine/newBuilder)
+                     (some? size)
+                     (.maximumSize size)
                      (some? expires-after)
                      (.expireAfterWrite (first expires-after) (second expires-after))
                      (some? refresh-after)

--- a/src/clj/ataru/email/application_email_confirmation.clj
+++ b/src/clj/ataru/email/application_email_confirmation.clj
@@ -122,7 +122,7 @@
                        (selmer/render-file {:lang            lang
                                             :hakukohteet     ["Hakukohde 1" "Hakukohde 2" "Hakukohde 3"]
                                             :attachments-without-answer [{:label "Liite 1"
-                                                                          :deadline (get (hakuaika/millis->localized-date-time 1540295947420) (keyword lang))}
+                                                                          :deadline (get (hakuaika/date-time->localized-date-time (t/date-time 2000 12 31)) (keyword lang))}
                                                                          {:label "Liite 2"
                                                                           :deadline ""}
                                                                          {:label "Liite 3"

--- a/src/clj/ataru/email/application_email_confirmation.clj
+++ b/src/clj/ataru/email/application_email_confirmation.clj
@@ -6,11 +6,10 @@
             [ataru.config.core :refer [config]]
             [ataru.db.db :as db]
             [ataru.email.email-store :as email-store]
-            [ataru.tarjonta-service.hakuaika :refer [millis->localized-date-time]]
             [ataru.forms.form-store :as forms]
             [ataru.tarjonta-service.hakukohde :as hakukohde]
             [ataru.tarjonta-service.tarjonta-parser :as tarjonta-parser]
-            [ataru.tarjonta-service.hakuaika :as tarjonta-hakuaika]
+            [ataru.tarjonta-service.hakuaika :as hakuaika]
             [ataru.hakija.background-jobs.hakija-jobs :as hakija-jobs]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta-service]
             [ataru.translations.texts :refer [email-default-texts]]
@@ -123,7 +122,7 @@
                        (selmer/render-file {:lang            lang
                                             :hakukohteet     ["Hakukohde 1" "Hakukohde 2" "Hakukohde 3"]
                                             :attachments-without-answer [{:label "Liite 1"
-                                                                          :deadline (get (millis->localized-date-time 1540295947420) (keyword lang))}
+                                                                          :deadline (get (hakuaika/millis->localized-date-time 1540295947420) (keyword lang))}
                                                                          {:label "Liite 2"
                                                                           :deadline ""}
                                                                          {:label "Liite 3"
@@ -157,8 +156,9 @@
                                           (:haku application)
                                           (:hakukohde application)))
         answers-by-key                  (-> application :answers util/answers-by-key)
+        hakuajat                        (hakuaika/index-hakuajat (:hakukohteet tarjonta-info))
         form                            (-> (forms/fetch-by-id (:form application))
-                                            (hakukohde/populate-attachment-deadlines now (:hakukohteet tarjonta-info)))
+                                            (hakukohde/populate-attachment-deadlines now hakuajat))
         lang                            (keyword (:lang application))
         attachment-keys-without-answers (->> (application-store/get-application-attachment-reviews (:key application))
                                              (map :attachment-key)

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -151,7 +151,6 @@
                            tarjonta-service
                            organization-service
                            ohjausparametrit-service
-                           form-by-haku-oid-and-id-cache
                            application
                            is-modify?
                            session]
@@ -184,8 +183,11 @@
                                               :key
                                               application-store/get-application-hakukohde-reviews)
         form                          (cond (some? (:haku application))
-                                            (hakija-form-service/fetch-form-by-haku-oid-and-id-cached
-                                             form-by-haku-oid-and-id-cache
+                                            (hakija-form-service/fetch-form-by-haku-oid-and-id
+                                             tarjonta-service
+                                             koodisto-cache
+                                             organization-service
+                                             ohjausparametrit-service
                                              (:haku application)
                                              (:form application)
                                              (util/application-in-processing? application-hakukohde-reviews)
@@ -317,7 +319,6 @@
    job-runner
    organization-service
    ohjausparametrit-service
-   form-by-haku-oid-and-id-cache
    application
    session]
   (log/info "Application submitted:" application)
@@ -327,7 +328,6 @@
                             tarjonta-service
                             organization-service
                             ohjausparametrit-service
-                            form-by-haku-oid-and-id-cache
                             application
                             false
                             session)
@@ -351,7 +351,6 @@
    job-runner
    organization-service
    ohjausparametrit-service
-   form-by-haku-oid-and-id-cache
    input-application
    session]
   (log/info "Application edited:" input-application)
@@ -361,7 +360,6 @@
                             tarjonta-service
                             organization-service
                             ohjausparametrit-service
-                            form-by-haku-oid-and-id-cache
                             input-application
                             true
                             session)
@@ -409,7 +407,12 @@
         false))
 
 (defn get-latest-application-by-secret
-  [secret tarjonta-service form-by-haku-oid-and-id-cache koodisto-cache person-client]
+  [koodisto-cache
+   ohjausparametrit-service
+   organization-service
+   person-client
+   tarjonta-service
+   secret]
   (let [[actor-role secret] (match [secret]
                               [{:virkailija s}]
                               [:virkailija s]
@@ -436,12 +439,14 @@
         lang-override              (when secret-expired? (application-store/get-application-language-by-secret secret))
         application-in-processing? (util/application-in-processing? (:application-hakukohde-reviews application))
         inactivated?               (is-inactivated? application)
-        form                       (cond (some? (:haku application)) (hakija-form-service/fetch-form-by-haku-oid-cached
-                                                                       tarjonta-service
-                                                                       form-by-haku-oid-and-id-cache
-                                                                       (:haku application)
-                                                                       application-in-processing?
-                                                                       form-roles)
+        form                       (cond (some? (:haku application)) (hakija-form-service/fetch-form-by-haku-oid
+                                                                      tarjonta-service
+                                                                      koodisto-cache
+                                                                      organization-service
+                                                                      ohjausparametrit-service
+                                                                      (:haku application)
+                                                                      application-in-processing?
+                                                                      form-roles)
                                          (some? (:form application)) (hakija-form-service/fetch-form-by-key
                                                                        (->> application
                                                                             :form

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -147,7 +147,8 @@
                   :session   session
                   :id        {:email (util/extract-email application)}}))
 
-(defn- validate-and-store [koodisto-cache
+(defn- validate-and-store [form-by-id-cache
+                           koodisto-cache
                            tarjonta-service
                            organization-service
                            ohjausparametrit-service
@@ -184,6 +185,7 @@
                                               application-store/get-application-hakukohde-reviews)
         form                          (cond (some? (:haku application))
                                             (hakija-form-service/fetch-form-by-haku-oid-and-id
+                                             form-by-id-cache
                                              tarjonta-service
                                              koodisto-cache
                                              organization-service
@@ -196,6 +198,7 @@
                                             (hakija-form-service/fetch-form-by-id
                                              (:form application)
                                              form-roles
+                                             form-by-id-cache
                                              koodisto-cache
                                              nil
                                              (util/application-in-processing? application-hakukohde-reviews)))
@@ -314,7 +317,8 @@
    application-id))
 
 (defn handle-application-submit
-  [koodisto-cache
+  [form-by-id-cache
+   koodisto-cache
    tarjonta-service
    job-runner
    organization-service
@@ -324,7 +328,8 @@
   (log/info "Application submitted:" application)
   (let [{:keys [passed? id]
          :as   result}
-        (validate-and-store koodisto-cache
+        (validate-and-store form-by-id-cache
+                            koodisto-cache
                             tarjonta-service
                             organization-service
                             ohjausparametrit-service
@@ -346,7 +351,8 @@
     result))
 
 (defn handle-application-edit
-  [koodisto-cache
+  [form-by-id-cache
+   koodisto-cache
    tarjonta-service
    job-runner
    organization-service
@@ -356,7 +362,8 @@
   (log/info "Application edited:" input-application)
   (let [{:keys [passed? id application]
          :as   result}
-        (validate-and-store koodisto-cache
+        (validate-and-store form-by-id-cache
+                            koodisto-cache
                             tarjonta-service
                             organization-service
                             ohjausparametrit-service
@@ -407,7 +414,8 @@
         false))
 
 (defn get-latest-application-by-secret
-  [koodisto-cache
+  [form-by-id-cache
+   koodisto-cache
    ohjausparametrit-service
    organization-service
    person-client
@@ -440,6 +448,7 @@
         application-in-processing? (util/application-in-processing? (:application-hakukohde-reviews application))
         inactivated?               (is-inactivated? application)
         form                       (cond (some? (:haku application)) (hakija-form-service/fetch-form-by-haku-oid
+                                                                      form-by-id-cache
                                                                       tarjonta-service
                                                                       koodisto-cache
                                                                       organization-service
@@ -453,6 +462,7 @@
                                                                             form-store/fetch-by-id
                                                                             :key)
                                                                        form-roles
+                                                                       form-by-id-cache
                                                                        koodisto-cache
                                                                        nil
                                                                        application-in-processing?))

--- a/src/clj/ataru/hakija/hakija_form_service.clj
+++ b/src/clj/ataru/hakija/hakija_form_service.clj
@@ -217,23 +217,6 @@
                                    application-in-processing-state?
                                    roles)))
 
-(s/defn ^:always-validate fetch-form-by-hakukohde-oid :- s/Any
-  [tarjonta-service :- s/Any
-   koodisto-cache :- s/Any
-   organization-service :- s/Any
-   ohjausparametrit-service :- s/Any
-   hakukohde-oid :- s/Any
-   application-in-processing-state? :- s/Bool
-   roles :- [form-role/FormRole]]
-  (when-let [hakukohde (tarjonta/get-hakukohde tarjonta-service hakukohde-oid)]
-    (fetch-form-by-haku-oid tarjonta-service
-                            koodisto-cache
-                            organization-service
-                            ohjausparametrit-service
-                            (:haku-oid hakukohde)
-                            false
-                            roles)))
-
 (s/defn ^:always-validate fetch-form-by-haku-oid-str-cached :- s/Any
   [form-by-haku-oid-str-cache :- s/Any
    haku-oid :- s/Str

--- a/src/clj/ataru/hakija/hakija_form_service.clj
+++ b/src/clj/ataru/hakija/hakija_form_service.clj
@@ -122,16 +122,15 @@
 (s/defn ^:always-validate flag-uneditable-and-unviewable-fields :- s/Any
   [form :- s/Any
    now :- s/Any
-   hakukohteet :- s/Any
+   hakuajat :- s/Any
    roles :- [form-role/FormRole]
    application-in-processing-state? :- s/Bool]
-  (let [hakuajat (hakuaika/index-hakuajat hakukohteet)]
-    (update form :content (partial util/map-form-fields
-                                   (partial flag-uneditable-and-unviewable-field
-                                            now
-                                            hakuajat
-                                            roles
-                                            application-in-processing-state?)))))
+  (update form :content (partial util/map-form-fields
+                                 (partial flag-uneditable-and-unviewable-field
+                                          now
+                                          hakuajat
+                                          roles
+                                          application-in-processing-state?))))
 
 (s/defn ^:always-validate remove-required-hakija-validator-if-virkailija :- s/Any
   [form :- s/Any
@@ -153,13 +152,14 @@
    koodisto-cache :- s/Any
    hakukohteet :- s/Any
    application-in-processing-state? :- s/Bool]
-  (let [now (time/now)]
+  (let [now      (time/now)
+        hakuajat (hakuaika/index-hakuajat hakukohteet)]
     (when-let [form (form-store/fetch-by-id id)]
       (when (not (:deleted form))
         (-> (koodisto/populate-form-koodisto-fields koodisto-cache form)
             (remove-required-hakija-validator-if-virkailija roles)
-            (populate-attachment-deadlines now hakukohteet)
-            (flag-uneditable-and-unviewable-fields now hakukohteet roles application-in-processing-state?))))))
+            (populate-attachment-deadlines now hakuajat)
+            (flag-uneditable-and-unviewable-fields now hakuajat roles application-in-processing-state?))))))
 
 (s/defn ^:always-validate fetch-form-by-key :- s/Any
   [key :- s/Any

--- a/src/clj/ataru/hakija/hakija_form_service.clj
+++ b/src/clj/ataru/hakija/hakija_form_service.clj
@@ -197,7 +197,6 @@
           (merge tarjonta-info)
           (assoc? :priorisoivat-hakukohderyhmat priorisoivat)
           (assoc? :rajaavat-hakukohderyhmat rajaavat)
-          (assoc :load-time (System/currentTimeMillis))
           (populate-hakukohde-answer-options tarjonta-info)
           (populate-can-submit-multiple-applications tarjonta-info)))))
 

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -151,7 +151,6 @@
       (if-let [form-with-tarjonta (form-service/fetch-form-by-haku-oid-str-cached
                                    form-by-haku-oid-str-cache
                                    haku-oid
-                                   false
                                    role)]
         (response/content-type (response/ok form-with-tarjonta)
                                "application/json")
@@ -164,7 +163,6 @@
                                    tarjonta-service
                                    form-by-haku-oid-str-cache
                                    hakukohde-oid
-                                   false
                                    role)]
         (response/content-type (response/ok form-with-tarjonta)
                                "application/json")

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -157,7 +157,7 @@
                                    role)]
         (response/content-type (response/ok form-with-tarjonta)
                                "application/json")
-        (response/not-found)))
+        (response/not-found {})))
     (api/GET ["/hakukohde/:hakukohde-oid", :hakukohde-oid #"[0-9\.]+"] []
       :summary "Gets form for hakukohde"
       :path-params [hakukohde-oid :- s/Str]
@@ -169,14 +169,14 @@
                                    role)]
         (response/content-type (response/ok form-with-tarjonta)
                                "application/json")
-        (response/not-found)))
+        (response/not-found {})))
     (api/GET "/form/:key" []
       :path-params [key :- s/Str]
       :query-params [role :- [form-role/FormRole]]
       :return ataru-schema/FormWithContent
       (if-let [form (form-service/fetch-form-by-key key role form-by-id-cache koodisto-cache nil false)]
         (response/ok form)
-        (response/not-found)))
+        (response/not-found {})))
     (api/POST "/feedback" []
       :summary "Add feedback sent by applicant"
       :body [feedback ataru-schema/ApplicationFeedback]
@@ -184,7 +184,7 @@
         (do
           (flowdock-client/send-application-feedback saved-application)
           (response/ok {:id (:id saved-application)}))
-        (response/bad-request)))
+        (response/bad-request {})))
     (api/POST "/application" {session :session}
       :summary "Submit application"
       :body [application ataru-schema/Application]
@@ -298,8 +298,8 @@
                 response/ok
                 (response/header "Content-Disposition"
                                  (:content-disposition file)))
-            (response/not-found))
-          (response/unauthorized)))
+            (response/not-found {}))
+          (response/unauthorized {})))
       (api/DELETE "/:key" []
         :summary "Delete a file"
         :path-params [key :- s/Str]
@@ -316,7 +316,7 @@
       (let [code (koodisto/get-postal-office-by-postal-code koodisto-cache postal-code)]
         (if-let [labels (:label code)]
           (response/ok labels)
-          (response/not-found))))
+          (response/not-found {}))))
     (api/GET "/has-applied" []
       :summary "Check if a person has already applied"
       :query-params [hakuOid :- (api/describe s/Str "Haku OID")

--- a/src/clj/ataru/hakija/hakija_system.clj
+++ b/src/clj/ataru/hakija/hakija_system.clj
@@ -51,17 +51,12 @@
                            (person-client/map->PersonCacheLoader {})
                            [:oppijanumerorekisteri-cas-client])
 
-    :form-by-haku-oid-and-id-cache-loader (component/using
-                                           (hakija-form-service/map->FormByHakuOidAndIdCacheLoader {})
-                                           [:tarjonta-service
-                                            :koodisto-cache
-                                            :organization-service
-                                            :ohjausparametrit-service])
-
     :form-by-haku-oid-str-cache-loader (component/using
                                         (hakija-form-service/map->FormByHakuOidStrCacheLoader {})
-                                        [:tarjonta-service
-                                         :form-by-haku-oid-and-id-cache])
+                                        [:koodisto-cache
+                                         :ohjausparametrit-service
+                                         :organization-service
+                                         :tarjonta-service])
 
     :person-service (component/using
                      (person-service/new-person-service)

--- a/src/clj/ataru/hakija/hakija_system.clj
+++ b/src/clj/ataru/hakija/hakija_system.clj
@@ -53,7 +53,8 @@
 
     :form-by-haku-oid-str-cache-loader (component/using
                                         (hakija-form-service/map->FormByHakuOidStrCacheLoader {})
-                                        [:koodisto-cache
+                                        [:form-by-id-cache
+                                         :koodisto-cache
                                          :ohjausparametrit-service
                                          :organization-service
                                          :tarjonta-service])
@@ -99,7 +100,8 @@
 
     :job-runner (component/using
                  (job/new-job-runner hakija-jobs/job-definitions)
-                 [:ohjausparametrit-service
+                 [:form-by-id-cache
+                  :ohjausparametrit-service
                   :henkilo-cache
                   :koodisto-cache
                   :person-service

--- a/src/clj/ataru/tarjonta_service/hakukohde.clj
+++ b/src/clj/ataru/tarjonta_service/hakukohde.clj
@@ -78,12 +78,11 @@
     (assoc-in field [:params :deadline-label] label)
     field))
 
-(defn populate-attachment-deadlines [form now hakukohteet]
-  (let [hakuajat (hakuaika/index-hakuajat hakukohteet)]
-    (update form :content (partial util/map-form-fields
-                                   (partial populate-attachment-deadline
-                                            now
-                                            hakuajat)))))
+(defn populate-attachment-deadlines [form now hakuajat]
+  (update form :content (partial util/map-form-fields
+                                 (partial populate-attachment-deadline
+                                          now
+                                          hakuajat))))
 
 (defn populate-hakukohde-answer-options [form tarjonta-info]
   ; walking through entire content is very slow for large forms, so try a naive optimization first

--- a/src/clj/ataru/tutkintojen_tunnustaminen.clj
+++ b/src/clj/ataru/tutkintojen_tunnustaminen.clj
@@ -158,10 +158,11 @@
     application))
 
 (defn- get-form
-  [koodisto-cache application]
+  [form-by-id-cache koodisto-cache application]
   (let [form (hakija-form-service/fetch-form-by-id
               (:form-id application)
               [:hakija]
+              form-by-id-cache
               koodisto-cache
               nil
               false)]
@@ -277,14 +278,14 @@
     cfg))
 
 (defn- application-job-step
-  [koodisto-cache application-id edit?]
+  [form-by-id-cache koodisto-cache application-id edit?]
   (let [{:keys [form-key
                 country-question-id
                 attachment-total-size-limit
                 ftp]} (get-configuration)
         application   (get-application country-question-id application-id)]
     (if (= form-key (:form-key application))
-      (let [form        (get-form koodisto-cache application)
+      (let [form        (get-form form-by-id-cache koodisto-cache application)
             attachments (get-attachments attachment-total-size-limit application)
             message     (if edit?
                           (->application-edited application form attachments)
@@ -304,12 +305,12 @@
       {:transition {:id :final}})))
 
 (defn tutkintojen-tunnustaminen-submit-job-step
-  [{:keys [application-id]} {:keys [koodisto-cache]}]
-  (application-job-step koodisto-cache application-id false))
+  [{:keys [application-id]} {:keys [form-by-id-cache koodisto-cache]}]
+  (application-job-step form-by-id-cache koodisto-cache application-id false))
 
 (defn tutkintojen-tunnustaminen-edit-job-step
-  [{:keys [application-id]} {:keys [koodisto-cache]}]
-  (application-job-step koodisto-cache application-id true))
+  [{:keys [application-id]} {:keys [form-by-id-cache koodisto-cache]}]
+  (application-job-step form-by-id-cache koodisto-cache application-id true))
 
 (defn tutkintojen-tunnustaminen-review-state-changed-job-step
   [{:keys [event-id]} _]

--- a/src/clj/ataru/virkailija/virkailija_system.clj
+++ b/src/clj/ataru/virkailija/virkailija_system.clj
@@ -67,7 +67,8 @@
 
     :form-by-haku-oid-str-cache-loader (component/using
                                         (hakija-form-service/map->FormByHakuOidStrCacheLoader {})
-                                        [:koodisto-cache
+                                        [:form-by-id-cache
+                                         :koodisto-cache
                                          :ohjausparametrit-service
                                          :organization-service
                                          :tarjonta-service])
@@ -105,7 +106,8 @@
 
     :job-runner (component/using
                  (job/new-job-runner virkailija-jobs/job-definitions)
-                 [:ohjausparametrit-service
+                 [:form-by-id-cache
+                  :ohjausparametrit-service
                   :henkilo-cache
                   :koodisto-cache
                   :person-service

--- a/src/clj/ataru/virkailija/virkailija_system.clj
+++ b/src/clj/ataru/virkailija/virkailija_system.clj
@@ -65,17 +65,12 @@
                            (person-client/map->PersonCacheLoader {})
                            [:oppijanumerorekisteri-cas-client])
 
-    :form-by-haku-oid-and-id-cache-loader (component/using
-                                           (hakija-form-service/map->FormByHakuOidAndIdCacheLoader {})
-                                           [:tarjonta-service
-                                            :koodisto-cache
-                                            :organization-service
-                                            :ohjausparametrit-service])
-
     :form-by-haku-oid-str-cache-loader (component/using
                                         (hakija-form-service/map->FormByHakuOidStrCacheLoader {})
-                                        [:tarjonta-service
-                                         :form-by-haku-oid-and-id-cache])
+                                        [:koodisto-cache
+                                         :ohjausparametrit-service
+                                         :organization-service
+                                         :tarjonta-service])
 
     :person-service (component/using
                      (person-service/new-person-service)

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -362,8 +362,7 @@
    (s/optional-key :previews)       [Preview]})
 
 (s/defschema FormWithContentAndTarjontaMetadata
-  (merge FormWithContent {:tarjonta FormTarjontaMetadata
-                          :load-time s/Int}))
+  (merge FormWithContent {:tarjonta FormTarjontaMetadata}))
 
 (s/defschema Value
   (s/cond-pre s/Str

--- a/src/cljs/ataru/hakija/core.cljs
+++ b/src/cljs/ataru/hakija/core.cljs
@@ -4,7 +4,7 @@
             [re-frisk.core :as re-frisk]
             [taoensso.timbre :refer-macros [spy info]]
             [ataru.cljs-util :as cljs-util]
-            [ataru.hakija.hakija-ajax :refer [post]]
+            [ataru.hakija.hakija-ajax :as ajax]
             [ataru.hakija.application-view :refer [form-view]]
             [ataru.hakija.application-handlers] ;; required although no explicit dependency
             [ataru.hakija.application-hakukohde-handlers] ;; required although no explicit dependency
@@ -65,8 +65,15 @@
   (.addEventListener js/window "online" (fn [] (re-frame/dispatch [:application/network-online])))
   (.addEventListener js/window "offline" (fn [] (re-frame/dispatch [:application/network-offline]))))
 
+(re-frame/reg-event-db
+  :application/handle-client-error
+  (fn [db _] db))
+
 (defn ^:export init []
-  (cljs-util/set-global-error-handler! #(post "/hakemus/api/client-error" %))
+  (cljs-util/set-global-error-handler! #(ajax/http {:method    :post
+                                                    :post-data %
+                                                    :url       "/hakemus/api/client-error"
+                                                    :handler   [:application/handle-client-error]}))
   (network-listener)
   (mount-root)
   (re-frame/dispatch-sync [:application/initialize-db])

--- a/src/cljs/ataru/hakija/rules.cljs
+++ b/src/cljs/ataru/hakija/rules.cljs
@@ -201,10 +201,10 @@
         auto-input? (and is-finland?
                          (= 5 (count (:value postal-code))))]
     (when auto-input?
-      (ajax/get (str "/hakemus/api/postal-codes/" (:value postal-code))
-                :application/handle-postal-code-input
-                nil
-                :application/handle-postal-code-error))
+      (ajax/http {:method        :get
+                  :url           (str "/hakemus/api/postal-codes/" (:value postal-code))
+                  :handler       [:application/handle-postal-code-input]
+                  :error-handler [:application/handle-postal-code-error]}))
     (-> db
         (update-in [:application :answers :postal-office]
                    merge {:valid (not is-finland?) :value ""})


### PR DESCRIPTION
Siirrä lomaketietojen välimuistia lähemmäksi tietokantaa. Tässä välimuistissa pidetään tietokannasta ladattua lomaketietoa ilman ajanhetken ja tarjontatiedon pohjalta laskettuja lisätietoja. Tämä mahdollistaa välimuistin hyödyntämisen myös kun lomake ladataan hakemuskohtaisilla lisätiedoilla esim. hakemuksen muokkausta varten.

Uutta hakemusta jätettäessä lomake ladataan edelleen edellä kuvatun välimuistin päällä olevasta välimuistista niin, että tiedoissa on mukana ajanhetken ja tarjontatietojen vaikutus ja lomake on Json serialisoitu.