### PR TITLE
Introduce stricter version checks to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Project-specific configuration
 EXECUTABLES = lein docker docker-compose npm lftp
 PORTS=15432 16379 15433 1221 16380 8350 8351
-TOOL_VERSIONS := node:8.11 npm:6.11 docker-compose:1.21 lein:2.9
+TOOL_VERSIONS := node:8.11 npm:6 docker-compose:1.21 lein:2.9
 
 VIRKAILIJA_CONFIG ?= ../ataru-secrets/virkailija-local-dev.edn
 HAKIJA_CONFIG ?= ../ataru-secrets/hakija-local-dev.edn

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ check-tools:
 	$(info Checking commands in path: $(EXECUTABLES) ...)
 	$(foreach exec,$(EXECUTABLES),\
 		$(if $(shell which $(exec)),$(info .. $(exec) found),$(error No $(exec) in PATH)))
+	$(info Checking tool versions...)
+	@./bin/check-tool-version.sh node 8.11
+	@./bin/check-tool-version.sh npm 6.11
+	@./bin/check-tool-version.sh docker-compose 1.21
+	@./bin/check-tool-version.sh lein 2.9
 
 # ----------------
 # Docker build

--- a/bin/check-tool-version.sh
+++ b/bin/check-tool-version.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+TOOL=$1
+EXPECTED_VERSION=$2
+
+# Source: https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
+vercomp () {
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}
+
+VERSION=$($TOOL --version | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')
+
+vercomp $VERSION $EXPECTED_VERSION
+RESULT=$?
+
+if [[ "$RESULT" -gt 1 ]]; then
+    echo "$TOOL ... installed version $VERSION is too old! update to version $EXPECTED_VERSION"
+    exit 1
+else
+    echo "$TOOL ... version ok ($VERSION)"
+    exit 0
+fi


### PR DESCRIPTION
This pull request introduces version checks to Makefile. This should prevent issues where f.ex too old nodejs causes hard to debug issues (for example, eslint refusing to run)