### PR TITLE
Fix incorrect database use in tests; introduce more granular test Makefile API 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,14 @@ help:
 # Test db management
 # ----------------
 
+compile-test-code:
+	APP=virkailija lein with-profile test less once
+	APP=virkailija lein with-profile test cljsbuild once virkailija-min hakija-min
+
 test-clojurescript:
 	APP=virkailija lein with-profile test doo chrome-headless test once
 
-test-browser:
+test-browser: compile-test-code
 	APP=virkailija lein with-profile test spec -t ui
 
 test-clojure: nuke-test-db init-test-db

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,9 @@ init-test-db:
 nuke-test-db:
 	APP=virkailija lein with-profile test run -m ataru.fixtures.db.unit-test-db/clear-database
 
+load-test-fixture: nuke-test-db init-test-db
+	APP=virkailija lein with-profile test run -m ataru.fixtures.db.browser-test-db/init-db-fixture
+
 # ----------------
 # Top-level commands (all apps)
 # ----------------

--- a/Makefile.md
+++ b/Makefile.md
@@ -44,6 +44,15 @@ make log, make logs
 make clean
 	Clean project. Removes unused docker containers and cleans compiled classes
 
+make nuke-test-db, clear-test-db
+        These targets manage test database. Typical run order is nuke, clear since
+        clear runs the migrations.
+
+make test-clojurescript, test-browser, test-clojure
+        Test targets. These targets DO NOT clear the database between runs in order
+        to speed up execution, so use with care.
+	
+
 Makefile targets are provided for restarting certain applications. Examples:
 
 make stop-hakija	Stops hakija application

--- a/Makefile.md
+++ b/Makefile.md
@@ -51,7 +51,10 @@ make nuke-test-db, clear-test-db
 make test-clojurescript, test-browser, test-clojure
         Test targets. These targets DO NOT clear the database between runs in order
         to speed up execution, so use with care.
-	
+
+make load-test-fixture
+        This target resets test database and loads test fixture. It is useful for
+        repeatedly running browser tests.
 
 Makefile targets are provided for restarting certain applications. Examples:
 

--- a/project.clj
+++ b/project.clj
@@ -230,6 +230,17 @@
                               :resource-paths ["dev-resources"]
                               :env            {:dev? "true"}}
 
+             :test           {:dependencies   [[com.cemerick/piggieback "0.2.2"]
+                                               [figwheel-sidecar "0.5.18"]
+                                               [snipsnap "0.2.0" :exclusions [org.clojure/clojure]]
+                                               [reloaded.repl "0.2.4"]
+                                               [speclj-junit "0.0.11-20151116.130002-1"]
+                                               [criterium "0.4.4"]]
+                              :source-paths   ["dev/clj" "test/cljc/unit" "spec"]
+                              :resource-paths ["dev-resources"]
+                              :env            {:dev? "true"
+                                               :config "config/test.edn"}}
+
              :virkailija-dev [:dev {:figwheel    {:nrepl-port  3334
                                                   :server-port 3449}
                                     :target-path "target-virkailija"
@@ -237,6 +248,7 @@
                                     :jvm-opts    ^:replace ["-Dapp=virkailija"
                                                             "-Duser.home=."
                                                             "-XX:MaxJavaStackTraceDepth=10"]}]
+
              :hakija-dev     [:dev {:figwheel    {:nrepl-port  3336
                                                   :server-port 3450}
                                     :target-path "target-hakija"


### PR DESCRIPTION
Tests run locally were using incorrect test database due to missing test profile. This caused tests to clobber the development database, which is usually not desirable.

The Makefile is also taught to run the different parts of test execution, that were previously only in `bin/cibuild.sh`.