### PR TITLE
HLE-1068: valinnan tila hakemuspalvelussa

### DIFF
--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -33,7 +33,7 @@
                  :applicant {:service_url "{{ataru_applicant_service_url}}"}
                  :virkailija {:service_url "https://{{host_virkailija}}/lomake-editori/"}
                  :environment-name "{{ataru_environment_name}}"
-                 :features {}
+                 :features {:kevyt-valinta {{ataru_kevyt_valinta_enabled | default('false')}}}
                  :attachment-modify-grace-period-days 14
                  :attachment-file-max-size-bytes {{ataru_attachment_file_max_size_bytes}}
                  :attachment-file-part-max-size-bytes {{ataru_attachment_file_part_max_size_bytes}}

--- a/resources/ataru-oph.properties
+++ b/resources/ataru-oph.properties
@@ -36,6 +36,9 @@ tarjonta-service.haku = ${tarjonta-service.base}/haku/$1
 tarjonta-service.koulutus = ${tarjonta-service.base}/koulutus/$1
 tarjonta-service.forms-in-use = ${tarjonta-service.base}/haku/ataru/all
 
+valintalaskentakoostepalvelu.base = ${url-virkailija}/valintalaskentakoostepalvelu/resources
+valintalaskentakoostepalvelu-service.hakukohde-uses-valintalaskenta = ${valintalaskentakoostepalvelu.base}/valintaperusteet/hakukohde/$1/kayttaaValintalaskentaa
+
 ryhmasahkoposti-service = ${url-virkailija}/ryhmasahkoposti-service/email/firewall
 
 liiteri.base = ${url-liiteri}/api

--- a/resources/less/vars.less
+++ b/resources/less/vars.less
@@ -70,6 +70,7 @@
 @attachment-skimming-header-separator-color: #D8D8D8;
 @attachment-skimming-image-view-border-color: #D8D8D8;
 @attachment-skimming-image-view-text-color: #f2f2f2;
+@kevyt-valinta-grayed-out-color: #D8D8D8;
 
 @processing-blue: @pale-blue;
 @unprocessed-orange: @sg-color-red;

--- a/resources/less/virkailija-kevyt-valinta.less
+++ b/resources/less/virkailija-kevyt-valinta.less
@@ -1,0 +1,54 @@
+@import "vars";
+
+.application-handling__kevyt-valinta {
+  display: flex;
+  flex-flow: column nowrap;
+  margin: 32px 0;
+}
+
+.application-handling__kevyt-valinta-row {
+  align-items: center;
+  display: flex;
+  flex-flow: row nowrap;
+}
+
+.application-handling__kevyt-valinta-row > :not(:last-child) {
+  margin-right: 10px;
+}
+
+.application-handling__kevyt-valinta-check {
+  border-radius: 50%;
+  height: 12px;
+  width: 12px;
+}
+
+.application-handling__kevyt-valinta-check--checked {
+  align-items: center;
+  background-color: @light-green;
+  color: @white;
+  display: flex;
+  font-size: 10px;
+  justify-content: center;
+}
+
+.application-handling__kevyt-valinta-check--bold {
+  font-weight: 600;
+}
+
+.application-handling__kevyt-valinta-label {
+  align-items: center;
+  display: flex;
+  width: 121px;
+}
+
+.application-handling__kevyt-valinta-hr {
+  background-color: @kevyt-valinta-grayed-out-color;
+  height: 1px;
+  margin-left: 10px;
+  width: 100%;
+}
+
+.application-handling__kevyt-valinta-value {
+  color: @button-blue;
+  font-weight: 800;
+}

--- a/resources/less/virkailija-site.less
+++ b/resources/less/virkailija-site.less
@@ -5,3 +5,4 @@
 @import "virkailija-common";
 @import "editor";
 @import "virkailija-application";
+@import "virkailija-kevyt-valinta";

--- a/spec/ataru/user_rights_spec.clj
+++ b/spec/ataru/user_rights_spec.clj
@@ -1,5 +1,5 @@
-(ns ataru.organization-service.user-rights-spec
-  (:require [ataru.organization-service.user-rights :refer [virkailija->right-organization-oids]]
+(ns ataru.user-rights-spec
+  (:require [ataru.user-rights :refer [virkailija->right-organization-oids]]
             [speclj.core :refer [describe it should= tags]]))
 
 (def test-user1 {:oidHenkilo    "1.2.246.562.24.23424"

--- a/src/clj/ataru/haku/haku_service.clj
+++ b/src/clj/ataru/haku/haku_service.clj
@@ -8,6 +8,7 @@
    [ataru.organization-service.session-organizations :as session-orgs]
    [ataru.applications.application-store :as application-store]
    [ataru.forms.form-store :as form-store]
+   [ataru.hakukohde.hakukohde-service :as hakukohde-service]
    [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
    [ataru.tarjonta-service.tarjonta-service :as tarjonta-service]
    [clj-time.core :as t]
@@ -129,7 +130,7 @@
                             (map tarjonta-service/parse-haku)
                             (util/group-by-first :oid))
      :hakukohteet      (->> (keys tarjonta-haut)
-                            (mapcat #(tarjonta/hakukohde-search tarjonta-service % nil))
+                            (mapcat #(hakukohde-service/get-hakukohteet tarjonta-service % nil))
                             (util/group-by-first :oid))
      :hakukohderyhmat  (util/group-by-first
                          :oid

--- a/src/clj/ataru/haku/haku_service.clj
+++ b/src/clj/ataru/haku/haku_service.clj
@@ -8,7 +8,6 @@
    [ataru.organization-service.session-organizations :as session-orgs]
    [ataru.applications.application-store :as application-store]
    [ataru.forms.form-store :as form-store]
-   [ataru.hakukohde.hakukohde-service :as hakukohde-service]
    [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
    [ataru.tarjonta-service.tarjonta-service :as tarjonta-service]
    [clj-time.core :as t]
@@ -130,7 +129,10 @@
                             (map tarjonta-service/parse-haku)
                             (util/group-by-first :oid))
      :hakukohteet      (->> (keys tarjonta-haut)
-                            (mapcat #(hakukohde-service/get-hakukohteet tarjonta-service % nil))
+                            (mapcat #(tarjonta/hakukohde-search
+                                       tarjonta-service
+                                       %
+                                       nil))
                             (util/group-by-first :oid))
      :hakukohderyhmat  (util/group-by-first
                          :oid

--- a/src/clj/ataru/hakukohde/hakukohde_service.clj
+++ b/src/clj/ataru/hakukohde/hakukohde_service.clj
@@ -1,8 +1,0 @@
-(ns ataru.hakukohde.hakukohde-service
-  (:require [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]))
-
-(defn get-hakukohteet [tarjonta-service haku-oid organization-oid]
-  (tarjonta/hakukohde-search
-    tarjonta-service
-    haku-oid
-    organization-oid))

--- a/src/clj/ataru/hakukohde/hakukohde_service.clj
+++ b/src/clj/ataru/hakukohde/hakukohde_service.clj
@@ -1,0 +1,8 @@
+(ns ataru.hakukohde.hakukohde-service
+  (:require [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]))
+
+(defn get-hakukohteet [tarjonta-service haku-oid organization-oid]
+  (tarjonta/hakukohde-search
+    tarjonta-service
+    haku-oid
+    organization-oid))

--- a/src/clj/ataru/organization_service/session_organizations.clj
+++ b/src/clj/ataru/organization_service/session_organizations.clj
@@ -2,7 +2,7 @@
   (:require
     [schema.core :as s]
     [ataru.organization-service.organization-client :as organization-client]
-    [ataru.organization-service.user-rights :refer [Right]]
+    [ataru.user-rights :refer [Right]]
     [ataru.organization-service.organization-service :as organization-service]))
 
 (defn- right-organizations

--- a/src/clj/ataru/organization_service/user_rights.clj
+++ b/src/clj/ataru/organization_service/user_rights.clj
@@ -4,9 +4,11 @@
 
 (def ^:private
   oikeus-to-right
-  {{:palvelu "ATARU_EDITORI" :oikeus "CRUD"} :form-edit
-   {:palvelu "ATARU_HAKEMUS" :oikeus "READ"} :view-applications
-   {:palvelu "ATARU_HAKEMUS" :oikeus "CRUD"} :edit-applications})
+  {{:palvelu "ATARU_EDITORI" :oikeus "CRUD"}         :form-edit
+   {:palvelu "ATARU_HAKEMUS" :oikeus "READ"}         :view-applications
+   {:palvelu "ATARU_HAKEMUS" :oikeus "CRUD"}         :edit-applications
+   {:palvelu "ATARU_HAKEMUS" :oikeus "VALINTA_READ"} :view-valinta
+   {:palvelu "ATARU_HAKEMUS" :oikeus "VALINTA_CRUD"} :edit-valinta})
 
 (def right-names (vals oikeus-to-right))
 

--- a/src/clj/ataru/tarjonta_service/tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_service.clj
@@ -66,7 +66,8 @@
    :prioritize-hakukohteet (:usePriority haku)
    :yhteishaku             (yhteishaku? haku)
    :hakuajat               (mapv parse-hakuaika (:hakuaikas haku))
-   :hakukohteet            (:hakukohdeOids haku)})
+   :hakukohteet            (:hakukohdeOids haku)
+   :sijoittelu             (:sijoittelu haku)})
 
 (defn- parse-search-result
   [search-result]

--- a/src/clj/ataru/valintalaskentakoostepalvelu/valintalaskentakoostepalvelu_client.clj
+++ b/src/clj/ataru/valintalaskentakoostepalvelu/valintalaskentakoostepalvelu_client.clj
@@ -1,0 +1,51 @@
+(ns ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-client
+  (:require [ataru.cache.cache-service :as cache]
+            [ataru.cas.client :as cas]
+            [ataru.config.url-helper :as url]
+            [cheshire.core :as json]
+            [clojure.core.match :as match]
+            [schema.core :as s]))
+
+(defn throw-error [msg]
+  (throw (Exception. msg)))
+
+(s/defschema HakukohdeValintalaskentaResponse
+  {:kayttaaValintalaskentaa s/Bool})
+
+(def ^:private hakukohde-valintalaskenta-checker (s/checker HakukohdeValintalaskentaResponse))
+
+(defn- hakukohde-uses-valintalaskenta? [valintalaskentakoostepalvelu-cas-client
+                                        hakukohde-oid]
+  (let [url    (url/resolve-url :valintalaskentakoostepalvelu-service.hakukohde-uses-valintalaskenta hakukohde-oid)
+        result (cas/cas-authenticated-get
+                 valintalaskentakoostepalvelu-cas-client
+                 url)]
+    (match/match result
+                 {:status 200 :body body}
+                 (json/parse-string body true)
+
+                 :else (throw-error (str "Could not get hakukohde by oid " hakukohde-oid ", "
+                                         "status: " (:status result)
+                                         "response body: "
+                                         (:body result))))))
+
+(defrecord HakukohdeValintalaskentaCacheLoader [valintalaskentakoostepalvelu-cas-client]
+  cache/CacheLoader
+
+  (load [_ hakukohde-oid]
+    (hakukohde-uses-valintalaskenta? valintalaskentakoostepalvelu-cas-client
+                                     hakukohde-oid))
+
+  (load-many [_ hakukohde-oids]
+    (reduce (fn [acc hakukohde-oid]
+              (let [result (hakukohde-uses-valintalaskenta? valintalaskentakoostepalvelu-cas-client
+                                                            hakukohde-oid)]
+                (assoc acc hakukohde-oid result)))
+            {}
+            hakukohde-oids))
+
+  (load-many-size [_]
+    1)
+
+  (check-schema [_ response]
+    (hakukohde-valintalaskenta-checker response)))

--- a/src/clj/ataru/valintalaskentakoostepalvelu/valintalaskentakoostepalvelu_protocol.clj
+++ b/src/clj/ataru/valintalaskentakoostepalvelu/valintalaskentakoostepalvelu_protocol.clj
@@ -1,0 +1,4 @@
+(ns ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-protocol)
+
+(defprotocol ValintalaskentakoostepalveluService
+  (hakukohde-uses-valintalaskenta? [this hakukohde-oid]))

--- a/src/clj/ataru/valintalaskentakoostepalvelu/valintalaskentakoostepalvelu_service.clj
+++ b/src/clj/ataru/valintalaskentakoostepalvelu/valintalaskentakoostepalvelu_service.clj
@@ -1,0 +1,13 @@
+(ns ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-service
+  (:require [ataru.cache.cache-service :as cache]
+            [ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-protocol :refer [ValintalaskentakoostepalveluService]]))
+
+(defrecord CachedValintalaskentakoostepalveluService [valintalaskentakoostepalvelu-hakukohde-valintalaskenta-cache]
+  ValintalaskentakoostepalveluService
+
+  (hakukohde-uses-valintalaskenta? [this hakukohde-oid]
+    (cache/get-from valintalaskentakoostepalvelu-hakukohde-valintalaskenta-cache
+                    hakukohde-oid)))
+
+(defn new-valintalaskentakoostepalvelu-service []
+  (map->CachedValintalaskentakoostepalveluService {}))

--- a/src/clj/ataru/virkailija/authentication/auth.clj
+++ b/src/clj/ataru/virkailija/authentication/auth.clj
@@ -6,7 +6,7 @@
             [ataru.log.audit-log :as audit-log]
             [ataru.organization-service.organization-client :as organization-client]
             [ataru.organization-service.organization-service :as organization-service]
-            [ataru.organization-service.user-rights :as rights]
+            [ataru.user-rights :as rights]
             [ataru.person-service.person-service :as person-service]
             [ataru.virkailija.authentication.cas-ticketstore :as cas-store]
             [ataru.util :as util]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -713,6 +713,7 @@
       (api/GET "/valintaperusteet/hakukohde/:hakukohde-oid/kayttaa-valintalaskentaa" {session :session}
         :path-params [hakukohde-oid :- s/Str]
         :return ataru-schema/KayttaaValintalaskentaaResponse
+        :summary "Tarkistaa valintalaskentakoostepalvelusta käyttääkö annettu hakukohde valintalaskentaa"
         (let [valintalaskenta-enabled? (:kayttaaValintalaskentaa
                                          (valintalaskentakoostepalvelu/hakukohde-uses-valintalaskenta? valintalaskentakoostepalvelu-service
                                                                                                        hakukohde-oid))]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -45,6 +45,7 @@
             [ataru.organization-service.organization-selection :as organization-selection]
             [ataru.organization-service.organization-client :as organization-client]
             [ataru.organization-service.organization-service :as organization-service]
+            [ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-protocol :as valintalaskentakoostepalvelu]
             [cheshire.core :as json]
             [cheshire.generate :refer [add-encoder]]
             [clojure.core.match :refer [match]]
@@ -184,6 +185,7 @@
 
 (defn api-routes [{:keys [organization-service
                           tarjonta-service
+                          valintalaskentakoostepalvelu-service
                           job-runner
                           ohjausparametrit-service
                           virkailija-tarjonta-service
@@ -705,6 +707,17 @@
               response/ok
               (response/header "Cache-Control" "public, max-age=300"))
           (response/bad-request))))
+
+    (api/context "/valintalaskentakoostepalvelu" []
+      :tags ["valintalaskentakoostepalvelu-api"]
+      (api/GET "/valintaperusteet/hakukohde/:hakukohde-oid/kayttaa-valintalaskentaa" {session :session}
+        :path-params [hakukohde-oid :- s/Str]
+        :return ataru-schema/KayttaaValintalaskentaaResponse
+        (let [valintalaskenta-enabled? (:kayttaaValintalaskentaa
+                                         (valintalaskentakoostepalvelu/hakukohde-uses-valintalaskenta? valintalaskentakoostepalvelu-service
+                                                                                                       hakukohde-oid))]
+          (response/ok {:hakukohde-oid   hakukohde-oid
+                        :valintalaskenta valintalaskenta-enabled?}))))
 
     (api/context "/koodisto" []
       :tags ["koodisto-api"]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -696,10 +696,11 @@
                :haut             {haku-oid (tarjonta-service/parse-haku
                                             (tarjonta/get-haku tarjonta-service
                                                                haku-oid))}
-               :hakukohteet      (util/group-by-first :oid (tarjonta/hakukohde-search
-                                                            tarjonta-service
-                                                            haku-oid
-                                                            nil))
+               :hakukohteet      (->> (tarjonta/hakukohde-search
+                                        tarjonta-service
+                                        haku-oid
+                                        nil)
+                                      (util/group-by-first :oid))
                :hakukohderyhmat  (util/group-by-first :oid (organization-service/get-hakukohde-groups organization-service))}
               response/ok
               (response/header "Cache-Control" "public, max-age=300"))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -22,6 +22,7 @@
             [ataru.forms.form-store :as form-store]
             [ataru.forms.hakukohderyhmat :as hakukohderyhmat]
             [ataru.haku.haku-service :as haku-service]
+            [ataru.hakukohde.hakukohde-service :as hakukohde-service]
             [ataru.information-request.information-request-service :as information-request]
             [ataru.koodisto.koodisto :as koodisto]
             [ataru.middleware.cache-control :as cache-control]
@@ -696,11 +697,10 @@
                :haut             {haku-oid (tarjonta-service/parse-haku
                                             (tarjonta/get-haku tarjonta-service
                                                                haku-oid))}
-               :hakukohteet      (->> (tarjonta/hakukohde-search
-                                        tarjonta-service
-                                        haku-oid
-                                        nil)
-                                      (util/group-by-first :oid))
+               :hakukohteet      (util/group-by-first :oid
+                                                      (hakukohde-service/get-hakukohteet tarjonta-service
+                                                                                         haku-oid
+                                                                                         nil))
                :hakukohderyhmat  (util/group-by-first :oid (organization-service/get-hakukohde-groups organization-service))}
               response/ok
               (response/header "Cache-Control" "public, max-age=300"))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -22,7 +22,6 @@
             [ataru.forms.form-store :as form-store]
             [ataru.forms.hakukohderyhmat :as hakukohderyhmat]
             [ataru.haku.haku-service :as haku-service]
-            [ataru.hakukohde.hakukohde-service :as hakukohde-service]
             [ataru.information-request.information-request-service :as information-request]
             [ataru.koodisto.koodisto :as koodisto]
             [ataru.middleware.cache-control :as cache-control]
@@ -700,9 +699,10 @@
                                             (tarjonta/get-haku tarjonta-service
                                                                haku-oid))}
                :hakukohteet      (util/group-by-first :oid
-                                                      (hakukohde-service/get-hakukohteet tarjonta-service
-                                                                                         haku-oid
-                                                                                         nil))
+                                                      (tarjonta/hakukohde-search
+                                                        tarjonta-service
+                                                        haku-oid
+                                                        nil))
                :hakukohderyhmat  (util/group-by-first :oid (organization-service/get-hakukohde-groups organization-service))}
               response/ok
               (response/header "Cache-Control" "public, max-age=300"))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -71,7 +71,7 @@
             [schema.core :as s]
             [selmer.parser :as selmer]
             [taoensso.timbre :refer [spy debug error warn info]]
-            [ataru.organization-service.user-rights :as user-rights]
+            [ataru.user-rights :as user-rights]
             [ataru.util :as util])
   (:import java.util.Locale
            java.time.ZonedDateTime

--- a/src/clj/ataru/virkailija/virkailija_system.clj
+++ b/src/clj/ataru/virkailija/virkailija_system.clj
@@ -119,6 +119,7 @@
                             :organization-service
                             :virkailija-tarjonta-service
                             :tarjonta-service
+                            :valintalaskentakoostepalvelu-service
                             :job-runner
                             :ohjausparametrit-service
                             :person-service

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -2,6 +2,7 @@
   (:require [ataru.application.review-states :as review-states]
             [ataru.application.field-types :refer [form-fields]]
             [ataru.hakija.application-validators :as validator]
+            [ataru.user-rights :as user-rights]
             [schema.coerce :as c]
             [schema.core :as s]
             [schema.experimental.abstract-map :as abstract-map]
@@ -463,6 +464,7 @@
   (-> Application
       (st/dissoc :person-oid)
       (st/assoc :can-edit? s/Bool)
+      (st/assoc :rights-by-hakukohde {s/Str [user-rights/Right]})
       (st/assoc :person Person)))
 
 (s/defschema ApplicationWithPersonAndForm

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -761,3 +761,7 @@
 (s/defschema ApplicationQueryResponse
   {:sort         Sort
    :applications [ApplicationInfo]})
+
+(s/defschema KayttaaValintalaskentaaResponse
+  {:hakukohde-oid   s/Str
+   :valintalaskenta s/Bool})

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -299,7 +299,8 @@
    :prioritize-hakukohteet s/Bool
    :hakuajat               [{:start                java.time.ZonedDateTime
                              (s/optional-key :end) java.time.ZonedDateTime}]
-   :hakukohteet            [s/Str]})
+   :hakukohteet            [s/Str]
+   :sijoittelu             s/Bool})
 
 (s/defschema Hakukohderyhma
   {:oid             s/Str

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -924,6 +924,9 @@ You will receive a confirmation of your application to your email."}
    :edit-applications-rights-panel                  {:fi "Hakemusten arviointi"
                                                      :sv "Utvärdering av ansökningar"
                                                      :en "Evaluation of applications"}
+   :edit-valinta-rights-panel                       {:fi "Valinnan tuloksen muokkaus"
+                                                     :sv "SV: Valinnan tuloksen muokkaus"
+                                                     :en "EN: Valinnan tuloksen muokkaus"}
    :edit-email-templates                            {:fi "Muokkaa sähköpostipohjia"
                                                      :sv "Bearbeta e-postmallar"
                                                      :en "Edit the email templates"}
@@ -1476,6 +1479,9 @@ You will receive a confirmation of your application to your email."}
    :view-applications-rights-panel                  {:fi "Hakemusten katselu"
                                                      :sv "Granskning av ansökningar"
                                                      :en "EN: Hakemusten katselu"}
+   :view-valinta-rights-panel                       {:fi "Valinnan tuloksen katselu"
+                                                     :sv "SV: Valinnan tuloksen katselu"
+                                                     :en "EN: Valinnan tuloksen katselu"}
    :virus-found                                     {:fi "Virus löytyi"
                                                      :sv "Ett virus hittades"
                                                      :en "Virus found"}

--- a/src/cljc/ataru/user_rights.cljc
+++ b/src/cljc/ataru/user_rights.cljc
@@ -1,6 +1,5 @@
-(ns ataru.organization-service.user-rights
-  (:require [ataru.config.core :refer [config]]
-            [schema.core :as s]))
+(ns ataru.user-rights
+  (:require [schema.core :as s]))
 
 (def ^:private
   oikeus-to-right

--- a/src/cljs/ataru/virkailija/application/handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/handlers.cljs
@@ -791,18 +791,14 @@
     {:db       db
      :dispatch dispatch-vec}))
 
-(reg-event-fx
+(reg-event-db
   :application/select-review-hakukohde
-  (fn [{:keys [db]} [_ selected-hakukohde-oid]]
-    (let [db         (update-in db [:application :selected-review-hakukohde-oids]
-                                (fn [hakukohde-oids]
-                                  (if (contains? (set hakukohde-oids) selected-hakukohde-oid)
-                                    (filter #(not= selected-hakukohde-oid %) hakukohde-oids)
-                                    (cons selected-hakukohde-oid hakukohde-oids))))
-          dispatches (valintalaskentakoostepalvelu-valintalaskenta-dispatch-vec db)]
-      (cond-> {:db db}
-              (not-empty dispatches)
-              (assoc :dispatch-n dispatches)))))
+  (fn [db [_ selected-hakukohde-oid]]
+    (update-in db [:application :selected-review-hakukohde-oids]
+               (fn [hakukohde-oids]
+                 (if (contains? (set hakukohde-oids) selected-hakukohde-oid)
+                   (filter #(not= selected-hakukohde-oid %) hakukohde-oids)
+                   (cons selected-hakukohde-oid hakukohde-oids))))))
 
 (reg-event-db
   :application/set-mass-information-request-form-state

--- a/src/cljs/ataru/virkailija/application/handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/handlers.cljs
@@ -496,6 +496,14 @@
         answer-map (into {} (map (fn [answer] [(keyword (:key answer)) answer])) answers)]
     (assoc application :answers answer-map)))
 
+(defn- parse-rights-by-hakukohde
+  [application]
+  (assoc application
+         :rights-by-hakukohde
+         (into {} (map (fn [[key rights]]
+                         [(name key) (set (map keyword rights))])
+                       (:rights-by-hakukohde application)))))
+
 (defn- review-notes-by-hakukohde-and-state-name
   [review-notes]
   (let [notes-by-hakukohde (->> review-notes
@@ -524,7 +532,9 @@
   (-> db
       (assoc-in [:application :selected-application-and-form]
         {:form        form
-         :application (answers-indexed application)})
+         :application (-> application
+                          answers-indexed
+                          parse-rights-by-hakukohde)})
       (assoc-in [:application :latest-form] latest-form)
       (assoc-in [:application :events] events)
       (assoc-in [:application :review] review)

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_handlers.cljs
@@ -1,0 +1,19 @@
+(ns ataru.virkailija.application.kevyt-valinta.virkailija-kevyt-valinta-handlers
+  (:require [re-frame.core :as re-frame]))
+
+(re-frame/reg-event-fx
+  :virkailija-kevyt-valinta/fetch-valintalaskentakoostepalvelu-valintalaskenta-in-use?
+  (fn [_ [_ hakukohde-oid]]
+    {:http {:method              :get
+            :path                (str "/lomake-editori/api/valintalaskentakoostepalvelu/valintaperusteet/hakukohde/"
+                                      hakukohde-oid
+                                      "/kayttaa-valintalaskentaa")
+            :handler-or-dispatch :virkailija-kevyt-valinta/handle-fetch-valintalaskentakoostepalvelu-valintalaskenta-in-use?
+            :override-args       {:error-handler #(re-frame/dispatch [:application/handle-fetch-application-error])}}}))
+
+(re-frame/reg-event-db
+  :virkailija-kevyt-valinta/handle-fetch-valintalaskentakoostepalvelu-valintalaskenta-in-use?
+  (fn [db [_ {hakukohde-oid :hakukohde-oid valintalaskenta :valintalaskenta}]]
+    (assoc-in db
+              [:application :valintalaskentakoostepalvelu hakukohde-oid :valintalaskenta]
+              valintalaskenta)))

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
@@ -5,6 +5,7 @@
 (defn- valintalaskenta-in-hakukohteet
   [db]
   (->> (get-in db [:application :selected-review-hakukohde-oids])
+       (remove #(= "form" %))
        (map #(get-in db [:application :valintalaskentakoostepalvelu % :valintalaskenta]))))
 
 (re-frame/reg-sub

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
@@ -1,0 +1,26 @@
+(ns ataru.virkailija.application.kevyt-valinta.virkailija-kevyt-valinta-subs
+  (:require [re-frame.core :as re-frame]
+            [ataru.feature-config :as fc]))
+
+(defn- valintalaskenta-in-hakukohteet
+  [db]
+  (->> (get-in db [:application :selected-review-hakukohde-oids])
+       (map #(get-in db [:application :valintalaskentakoostepalvelu % :valintalaskenta]))))
+
+(re-frame/reg-sub
+  :virkailija-kevyt-valinta/show-selection-state-dropdown?
+  (fn [db _]
+    (or (not (fc/feature-enabled? :kevyt-valinta))
+        ;; true?, koska nil tarkoittaa ettei tietoa ole vielä ladattu
+        ;; backendiltä ja nil? palauttaisi väärän positiivisen tiedon
+        (every? true? (valintalaskenta-in-hakukohteet db)))))
+
+(re-frame/reg-sub
+  :virkailija-kevyt-valinta/show-kevyt-valinta?
+  (fn [db _]
+    (let [haku-oid (get-in db [:application :selected-application-and-form :application :haku])]
+      (and (fc/feature-enabled? :kevyt-valinta)
+           (not (get-in db [:haut haku-oid :sijoittelu]))
+           ;; false?, koska nil tarkoittaa ettei tietoa ole vielä ladattu
+           ;; backendiltä ja nil? palauttaisi väärän positiivisen tiedon
+           (every? false? (valintalaskenta-in-hakukohteet db))))))

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
@@ -19,8 +19,14 @@
 (re-frame/reg-sub
   :virkailija-kevyt-valinta/show-kevyt-valinta?
   (fn [db _]
-    (let [haku-oid (get-in db [:application :selected-application-and-form :application :haku])]
+    (let [haku-oid            (get-in db [:application :selected-application-and-form :application :haku])
+          hakukohde-oids      (get-in db [:application :selected-review-hakukohde-oids])
+          rights-by-hakukohde (get-in db [:application :selected-application-and-form :application :rights-by-hakukohde])]
       (and (fc/feature-enabled? :kevyt-valinta)
+           (->> hakukohde-oids
+                (map #(get rights-by-hakukohde %))
+                (every? #(or (contains? % :view-valinta)
+                             (contains? % :edit-valinta))))
            (not (get-in db [:haut haku-oid :sijoittelu]))
            ;; false?, koska nil tarkoittaa ettei tietoa ole vielä ladattu
            ;; backendiltä ja nil? palauttaisi väärän positiivisen tiedon

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_view.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_view.cljs
@@ -1,0 +1,23 @@
+(ns ataru.virkailija.application.kevyt-valinta.virkailija-kevyt-valinta-view
+  (:require [ataru.application.review-states :as review-states]
+            [re-frame.core :as re-frame]))
+
+(defn- kevyt-valinta-selection-state-row []
+  (let [lang                  @(re-frame/subscribe [:editor/virkailija-lang])
+        selection-state-label (->> review-states/hakukohde-review-types
+                                   (filter (fn [[kw]]
+                                             (= kw :selection-state)))
+                                   (map (fn [[_ label-i18n]]
+                                          label-i18n))
+                                   (map lang))]
+    [:div.application-handling__kevyt-valinta-row
+     [:div.application-handling__kevyt-valinta-check.application-handling__kevyt-valinta-check--checked
+      [:i.zmdi.zmdi-check.application-handling__kevyt-valinta-check--bold]]
+     [:div.application-handling__kevyt-valinta-label
+      [:span selection-state-label]
+      [:div.application-handling__kevyt-valinta-hr]]
+     [:span.application-handling__kevyt-valinta-value "Hyväksytty"]]))
+
+(defn kevyt-valinta []
+  [:div.application-handling__kevyt-valinta
+   [kevyt-valinta-selection-state-row]])

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -1208,8 +1208,8 @@
         display-kevyt-valinta?            (and (not sijoittelu?)
                                                ;; false?, koska nil tarkoittaa ettei tietoa ole vielä ladattu backendiltä ja nil? palauttaisi väärän positiivisen tiedon
                                                (every? false? valintalaskenta-in-hakukohteet))
-        show-selection-state-dropdown?    (and kevyt-valinta-feature-enabled?
-                                               (every? true? valintalaskenta-in-hakukohteet))
+        show-selection-state-dropdown?    (or (not kevyt-valinta-feature-enabled?)
+                                              (every? true? valintalaskenta-in-hakukohteet))
         hakukohde-review-input-components (->> review-types
                                                (filter (fn [[kw]]
                                                          (or (not= kw :selection-state)

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -1196,10 +1196,10 @@
 
 (defn- application-hakukohde-review-inputs
   [review-types]
-  (into [:div.application-handling__review-hakukohde-inputs]
-        (mapv (fn [[kw label states]]
-                [application-hakukohde-review-input label kw states])
-              review-types)))
+  (->> review-types
+       (map (fn [[kw label states]]
+              [application-hakukohde-review-input label kw states]))
+       (into [:div.application-handling__review-hakukohde-inputs])))
 
 (defn- name-and-initials [{:keys [first-name last-name]}]
   (if (and first-name last-name)

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -1198,7 +1198,10 @@
 
 (defn- application-hakukohde-review-inputs
   [review-types]
-  (let [kevyt-valinta-enabled?            (fc/feature-enabled? :kevyt-valinta)
+  (let [haku-oid                          @(subscribe [:state-query [:application :selected-application-and-form :application :haku]])
+        haku-uses-sijoittelu?             @(subscribe [:state-query [:haut haku-oid :sijoittelu]])
+        kevyt-valinta-enabled?            (and (fc/feature-enabled? :kevyt-valinta)
+                                               (not haku-uses-sijoittelu?))
         hakukohde-review-input-components (->> review-types
                                                (filter (fn [[kw]]
                                                          (or (not kevyt-valinta-enabled?)

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -17,6 +17,7 @@
             [ataru.virkailija.routes :refer [set-history!]]
             [ataru.virkailija.virkailija-ajax :refer [http post put dispatch-flasher-error-msg]]
             [ataru.util :as util :refer [collect-ids assoc?]]
+            [ataru.user-rights :as user-rights]
             [ataru.cljs-util :as cu]
             [taoensso.timbre :refer-macros [spy debug]]
             [ataru.virkailija.temporal :as temporal]
@@ -1150,9 +1151,9 @@
             :path                (str "/lomake-editori/api/organization/user-organization/"
                                       oid
                                       "?rights="
-                                      (clojure.string/join "&rights=" ["edit-applications" "view-applications" "form-edit"]))
+                                      (clojure.string/join "&rights=" (map name user-rights/right-names)))
             :handler-or-dispatch :editor/update-selected-organization}
-     :db   (assoc-in db [:editor :user-info :selected-organization :rights] [:edit-applications :view-applications :form-edit])}))
+     :db   (assoc-in db [:editor :user-info :selected-organization :rights] user-rights/right-names)}))
 
 (reg-event-fx
   :editor/increase-organization-result-page


### PR DESCRIPTION
Alustava ei-toiminnallinen käyttöliittymä tulevalle kevytvalinta -ominaisuudelle.

* Sisältää integraation atarun virkailijasovelluksen taustajärjestelmästä valintalaskentakoostepalveluun.
* Alustavan käyttöliittymäluonnoksen (kuva ohessa).
* Logiikan, jolla tarkistetaan koska kevytvalinnan käyttöliittymä näytetään (haulla ei sijoittelua, yhdelläkään valitulla hakukohteella ei valintalaskentaa).

Asennettu pallero-ympäristöön.

![image](https://user-images.githubusercontent.com/3083043/68380937-71221e80-0159-11ea-9d7e-550f3e651496.png)
