### PR TITLE
BUG-2082 copy/paste lomakeosio sometimes fails

### DIFF
--- a/resources/spec/virkailijaEditorSpec.js
+++ b/resources/spec/virkailijaEditorSpec.js
@@ -61,38 +61,49 @@
 
   function clickLomakeForEdit(name) {
     return clickElement(() =>
-        formListItems().find(
-            '.editor-form__list-form-name:contains("' + name + '")'
-        )
-    );
+      formListItems().find(
+        '.editor-form__list-form-name:contains("' + name + '")'
+      )
+    )
   }
 
-  function clickCopyFormComponent(n) {
+  function clickCopyFormComponent(name) {
     return () => {
-        testFrame()
-            .find('.editor-form__component-wrapper')
-            .eq(n)
-            .find('.editor-form__component-button:contains("Kopioi")')
-            .click()
-      }
+      testFrame()
+        .find('.editor-form__component-wrapper:contains("' + name + '")')
+        .find('.editor-form__component-button:contains("Kopioi")')
+        .click()
+    }
+  }
+
+  function clickCloseDetailsButton() {
+    return () => {
+      testFrame()
+        .find('.close-details-button')
+        .click()
+    }
   }
 
   function clickPasteFormComponent(n) {
     return () => {
       triggerEvent(
-          testFrame()
-              .find('.editor-form__drag_n_drop_spacer_container_for_component')
-              .eq(n),
-          'mouseover'
+        testFrame()
+          .find('.editor-form__drag_n_drop_spacer_container_for_component')
+          .eq(n),
+        'mouseover'
       )
-      const selector = '.editor-form__drag_n_drop_spacer_container_for_component button.editor-form__component-button:visible:enabled:contains("Liitä")';
-      return wait.until(
-          () => {
-            const b = testFrame().find(selector).length !== 0;
-            console.log(`DEBUG: ${b}`)
-            return b;
-          }
-      )().then(() => testFrame().find(selector).click())
+      const selector =
+        '.editor-form__drag_n_drop_spacer_container_for_component button.editor-form__component-button:visible:enabled:contains("Liitä")'
+      return wait
+        .until(() => {
+          const b = testFrame().find(selector).length !== 0
+          return b
+        })()
+        .then(() =>
+          testFrame()
+            .find(selector)
+            .click()
+        )
     }
   }
 
@@ -1585,17 +1596,26 @@
         })
       })
 
-      describe('PETAR copy from this form and paste into another 16', () => {
+      describe('Copy from this form and paste into another after closing the first form', () => {
         before(
-            clickLomakeForEdit("Testilomake"),
-            wait.forMilliseconds(1000),
-            clickCopyFormComponent(7),
-            wait.forMilliseconds(1000),
-            clickLomakeForEdit("Selaintestilomake2"),
-            wait.forMilliseconds(1000),
-            clickPasteFormComponent(0)
+          clickLomakeForEdit('Testilomake'),
+          wait.forMilliseconds(1000),
+          clickCopyFormComponent('Testiosio'),
+          wait.forMilliseconds(1000),
+          clickCloseDetailsButton(),
+          wait.forMilliseconds(500),
+          clickLomakeForEdit('Selaintestilomake1'),
+          wait.forMilliseconds(1000),
+          clickPasteFormComponent(0)
         )
         it('creates the copy in another form', () => {
+          expect(
+            formSections()
+              .eq(0)
+              .find('.editor-form__text-field')
+              .eq(0)
+              .val()
+          ).to.equal('Testiosio')
         })
       })
 
@@ -1673,7 +1693,7 @@
     describe('hakukohde specific question', () => {
       const component = () => formComponents().eq(0)
       before(
-        clickLomakeForEdit("belongs-to-hakukohteet-test-form"),
+        clickLomakeForEdit('belongs-to-hakukohteet-test-form'),
         wait.forMilliseconds(1000),
         clickElement(() =>
           component().find('.editor-form__component-fold-button')

--- a/resources/spec/virkailijaEditorSpec.js
+++ b/resources/spec/virkailijaEditorSpec.js
@@ -59,6 +59,43 @@
       )
   }
 
+  function clickLomakeForEdit(name) {
+    return clickElement(() =>
+        formListItems().find(
+            '.editor-form__list-form-name:contains("' + name + '")'
+        )
+    );
+  }
+
+  function clickCopyFormComponent(n) {
+    return () => {
+        testFrame()
+            .find('.editor-form__component-wrapper')
+            .eq(n)
+            .find('.editor-form__component-button:contains("Kopioi")')
+            .click()
+      }
+  }
+
+  function clickPasteFormComponent(n) {
+    return () => {
+      triggerEvent(
+          testFrame()
+              .find('.editor-form__drag_n_drop_spacer_container_for_component')
+              .eq(n),
+          'mouseover'
+      )
+      const selector = '.editor-form__drag_n_drop_spacer_container_for_component button.editor-form__component-button:visible:enabled:contains("Liitä")';
+      return wait.until(
+          () => {
+            const b = testFrame().find(selector).length !== 0;
+            console.log(`DEBUG: ${b}`)
+            return b;
+          }
+      )().then(() => testFrame().find(selector).click())
+    }
+  }
+
   function clickComponentMenuItem(title) {
     const menuItem = () => {
       triggerEvent(
@@ -1548,6 +1585,20 @@
         })
       })
 
+      describe('PETAR copy from this form and paste into another 16', () => {
+        before(
+            clickLomakeForEdit("Testilomake"),
+            wait.forMilliseconds(1000),
+            clickCopyFormComponent(7),
+            wait.forMilliseconds(1000),
+            clickLomakeForEdit("Selaintestilomake2"),
+            wait.forMilliseconds(1000),
+            clickPasteFormComponent(0)
+        )
+        it('creates the copy in another form', () => {
+        })
+      })
+
       describe('locking form', () => {
         before(
           wait.forMilliseconds(1000), // wait abit since
@@ -1622,11 +1673,7 @@
     describe('hakukohde specific question', () => {
       const component = () => formComponents().eq(0)
       before(
-        clickElement(() =>
-          formListItems().find(
-            '.editor-form__list-form-name:contains("belongs-to-hakukohteet-test-form")'
-          )
-        ),
+        clickLomakeForEdit("belongs-to-hakukohteet-test-form"),
         wait.forMilliseconds(1000),
         clickElement(() =>
           component().find('.editor-form__component-fold-button')

--- a/resources/spec/virkailijaEditorSpec.js
+++ b/resources/spec/virkailijaEditorSpec.js
@@ -205,8 +205,8 @@
   describe('Editor', () => {
     describe('with fixture forms', () => {
       before(wait.until(editorPageIsLoaded, 10000))
-      it('has 6 fixture forms', () => {
-        expect(formListItems()).to.have.length(6)
+      it('has 7 fixture forms', () => {
+        expect(formListItems()).to.have.length(7)
       })
     })
 
@@ -1596,31 +1596,9 @@
         })
       })
 
-      describe('Copy from this form and paste into another after closing the first form', () => {
-        before(
-          clickLomakeForEdit('Testilomake'),
-          wait.forMilliseconds(1000),
-          clickCopyFormComponent('Testiosio'),
-          wait.forMilliseconds(1000),
-          clickCloseDetailsButton(),
-          wait.forMilliseconds(500),
-          clickLomakeForEdit('Selaintestilomake1'),
-          wait.forMilliseconds(1000),
-          clickPasteFormComponent(0)
-        )
-        it('creates the copy in another form', () => {
-          expect(
-            formSections()
-              .eq(0)
-              .find('.editor-form__text-field')
-              .eq(0)
-              .val()
-          ).to.equal('Testiosio')
-        })
-      })
-
       describe('locking form', () => {
         before(
+          clickLomakeForEdit('Testilomake'),
           wait.forMilliseconds(1000), // wait abit since
           clickLockForm(), // this locking is sometimes so fast that the previous request gets blocked.
           wait.until(() =>
@@ -1687,6 +1665,30 @@
               .text()
           ).to.equal('Kaikki muutokset tallennettu')
         })
+      })
+    })
+
+    describe('Copy from a form and paste into another after closing the first form', () => {
+      before(
+        clickLomakeForEdit('Testilomake'),
+        wait.forMilliseconds(1000),
+        clickCopyFormComponent('Testiosio'),
+        wait.forMilliseconds(1000),
+        clickCloseDetailsButton(),
+        wait.forMilliseconds(500),
+        clickLomakeForEdit('Selaintestilomake4'),
+        wait.forMilliseconds(1000),
+        clickPasteFormComponent(0),
+        wait.forMilliseconds(500)
+      )
+      it('creates the copy in another form', () => {
+        expect(
+          formSections()
+            .eq(0)
+            .find('.editor-form__text-field')
+            .eq(0)
+            .val()
+        ).to.equal('Testiosio')
       })
     })
 

--- a/spec/ataru/fixtures/db/browser_test_db.clj
+++ b/spec/ataru/fixtures/db/browser_test_db.clj
@@ -80,6 +80,16 @@
             :locked           nil
             :locked-by        nil})
 
+(def form4 {:id               42
+            :key              "empty"
+            :name             {:fi "Selaintestilomake4"}
+            :created-by       "1.2.246.562.11.11111111111"
+            :organization-oid "1.2.246.562.10.0439845"
+            :languages        ["fi"]
+            :content          []
+            :locked           nil
+            :locked-by        nil})
+
 (def ssn-testform {:id               4
                    :key              "41101b4f-1762-49af-9db0-e3603adae656"
                    :name             {:fi "SSN_testilomake"}
@@ -275,6 +285,7 @@
   (form-store/create-new-form! form2 (:key form2))
   (form-store/create-new-form! form3 (:key form3))
   (form-store/create-new-form! form3 "41101b4f-1762-49af-9db0-e3603adae3ae")
+  (form-store/create-new-form! form4 (:key form4))
   (form-store/create-new-form! assosiaatio-hakukohteen-organisaatiosta-form
                                (:key assosiaatio-hakukohteen-organisaatiosta-form))
   (form-store/create-new-form! belongs-to-hakukohteet-test-form

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -225,7 +225,7 @@
       :summary "Get content for form"
       (ok (form-store/fetch-form id)))
 
-    (api/PUT "/forms/:id" {session :session}                ; petar here it fails with 400, sometimes
+    (api/PUT "/forms/:id" {session :session}
       :summary "Edit form content"
       :path-params [id :- Long]
       :body [operations [ataru-schema/Operation]]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -225,7 +225,7 @@
       :summary "Get content for form"
       (ok (form-store/fetch-form id)))
 
-    (api/PUT "/forms/:id" {session :session}
+    (api/PUT "/forms/:id" {session :session}                ; petar here it fails with 400, sometimes
       :summary "Edit form content"
       :path-params [id :- Long]
       :body [operations [ataru-schema/Operation]]

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -780,7 +780,7 @@
 (reg-event-db :editor/paste-component paste-component)
 
 (reg-event-db
-  :editor/copy-component
+  :editor/copy-component                                    ; petar da li je ovo akcija na "copy"?
   (fn copy-component [db [_ path cut?]]
     (assoc-in db [:editor :copy-component] {:copy-component-form-key   (-> db :editor :selected-form-key)
                                             :copy-component-path       path

--- a/test/cljs/unit/ataru/virkailija/editor/handlers_test.cljs
+++ b/test/cljs/unit/ataru/virkailija/editor/handlers_test.cljs
@@ -72,11 +72,12 @@
     {:editor {:selected-form-key form-key
               :forms {form-key {:content content}}}}))
 
-(defn to-copy-component [[form-key path]]
+(defn to-copy-component [[form-key path] copy-component-content]
   {:copy-component-path       path
    :copy-component-unique-ids nil
    :copy-component-form-key   form-key
    :copy-component-cut?       true
+   :copy-component-content    copy-component-content
    :copy-component-clonable?  true})
 
 (deftest on-drop-moves-form-component-at-root-level
@@ -85,7 +86,7 @@
         state-before   (as-form [drag-component-1 drag-component-2])
         expected-state (as-form [drag-component-2 drag-component-1])
         copy?          false
-        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path) target-path copy?])
+        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path drag-component-2) target-path copy?])
         content-path   [:editor :forms 1234 :content]]
     (is (= (get-in actual-state content-path)
            (get-in expected-state content-path)))))
@@ -96,7 +97,7 @@
         state-before   (as-form [drag-component-1 {:children [drag-component-2]}])
         expected-state (as-form [{:children [drag-component-1 drag-component-2]}])
         copy?          false
-        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path) target-path copy?])
+        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path drag-component-1) target-path copy?])
         content-path   [:editor :forms 1234 :content]]
     (is (= (get-in actual-state content-path)
            (get-in expected-state content-path)))))
@@ -107,7 +108,7 @@
         state-before   (as-form [{:children [drag-component-1 drag-component-2]}])
         expected-state (as-form [drag-component-1 {:children [drag-component-2]}])
         copy?          false
-        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path) target-path copy?])
+        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path drag-component-1) target-path copy?])
         content-path   [:editor :forms 1234 :content]]
     (is (= (get-in actual-state content-path)
            (get-in expected-state content-path)))))
@@ -118,7 +119,7 @@
         state-before   (as-form [drag-component-1 drag-component-2 {:children []}])
         expected-state (as-form [drag-component-2 drag-component-1 {:children []}])
         copy?          false
-        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path) target-path copy?])
+        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path drag-component-1) target-path copy?])
         content-path   [:editor :forms 1234 :content]]
     (is (= (get-in actual-state content-path)
            (get-in expected-state content-path)))))
@@ -129,7 +130,7 @@
         state-before   (as-form [drag-component-1 drag-component-2])
         expected-state (as-form [drag-component-1 drag-component-2])
         copy?          false
-        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path) target-path copy?])
+        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path drag-component-1) target-path copy?])
         content-path   [:editor :forms 1234 :content]]
     (is (= (get-in actual-state content-path)
            (get-in expected-state content-path)))))
@@ -140,7 +141,7 @@
         state-before   (as-form [drag-component-1 drag-component-2])
         expected-state (as-form [drag-component-2 drag-component-1])
         copy?          false
-        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path) target-path copy?])
+        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path drag-component-1) target-path copy?])
         content-path   [:editor :forms 1234 :content]]
     (is (= (get-in actual-state content-path)
            (get-in expected-state content-path)))))
@@ -151,7 +152,7 @@
         state-before   (as-form [{:children [drag-component-1]}])
         expected-state (as-form [{:children []} drag-component-1])
         copy?          false
-        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path) target-path copy?])
+        actual-state   (h/paste-component state-before [:editor/paste-component (to-copy-component source-path drag-component-1) target-path copy?])
         content-path   [:editor :forms 1234 :content]]
     (is (= (get-in actual-state content-path)
            (get-in expected-state content-path)))))


### PR DESCRIPTION
The problem was that copied contents (form component) gets lost when "form details view" is closed, and the list of forms is reloaded from server. Because of that, the paste was failing. The solution is to remember the copied contents separately, not to rely on it being available in the list of forms. 