### PR TITLE
Ei palauteta nil-arvoa, koska schema.core vaatii boolean-arvon

### DIFF
--- a/src/clj/ataru/applications/application_access_control.clj
+++ b/src/clj/ataru/applications/application_access_control.clj
@@ -91,7 +91,9 @@
 
 (defn- can-edit-application?
   [rights-by-hakukohde]
-  (some #(contains? (val %) :edit-applications) rights-by-hakukohde))
+  (->> rights-by-hakukohde
+       (some #(contains? (val %) :edit-applications))
+       (true?)))
 
 (defn get-latest-application-by-key
   [organization-service tarjonta-service session application-key]


### PR DESCRIPTION
```
2019-11-27T16:31:26.282+02 ERROR [manifold-pool-2-90] compojure.api.exception: Response validation failed: {:application {:can-edit? (not (instance? java.lang.Boolean nil))}}
clojure.lang.ExceptionInfo: Response validation failed: {:application {:can-edit? (not (instance? java.lang.Boolean nil))}} schema.utils.ErrorContainer@85cf421d
```