### PR TITLE
BUG-2060 Update remaining application time text

### DIFF
--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -45,18 +45,21 @@
    :application-period                          {:fi "Hakuaika"
                                                  :sv "Ansökningstid"
                                                  :en "Application period"}
-   :application-period-hours-left               {:fi "Hakuaikaa jäljellä %s tuntia"
-                                                 :sv "Av ansökningstiden återstår %s timmar"
-                                                 :en "%s hours left in the application period"}
-   :application-period-hour-left                {:fi "Hakuaikaa jäljellä yksi tunti"
-                                                 :sv "Av ansökningstiden återstår en timme"
-                                                 :en "One hour left in the application period"}
-   :application-period-minutes-left             {:fi "Hakuaikaa jäljellä alle %s minuuttia"
-                                                 :sv "Av ansökningstiden återstår %s minuter"
-                                                 :en "Less than %s minutes left in the application period"}
-   :application-period-left-until               {:fi "Hakuaika päättyy %s"
-                                                 :sv "Ansökninstiden utgår %s"
-                                                 :en "Application period ends %s"}
+   :application-period-less-than-day-left       {:fi "Hakuaikaa jäljellä alle vuorokausi"
+                                                 :sv "Av ansökningstiden återstår mindre än en dag"
+                                                 :en "Less than a day left in the application period"}
+   :application-period-less-than-hour-left      {:fi "Hakuaikaa jäljellä alle tunti"
+                                                 :sv "Av ansökningstiden återstår mindre än en timme"
+                                                 :en "Less than one hour left in the application period"}
+   :application-period-less-than-45-min-left    {:fi "Hakuaikaa jäljellä alle 45 min"
+                                                 :sv "Av ansökningstiden återstår 45 minuter"
+                                                 :en "Less than 45 min left in the application period"}
+   :application-period-less-than-30-min-left    {:fi "Hakuaikaa jäljellä alle 30 min"
+                                                 :sv "Av ansökningstiden återstår 30 minuter"
+                                                 :en "Less than 30 min left in the application period"}
+   :application-period-less-than-15-min-left    {:fi "Hakuaikaa jäljellä alle 15 min"
+                                                 :sv "Av ansökningstiden återstår 15 minuter"
+                                                 :en "Less than 15 min left in the application period"}
    :application-priorization-invalid            {:fi "Hakukohteet ovat väärässä ensisijaisuusjärjestyksessä"
                                                  :sv "Fel prioritetsordning för ansökningsmålen"
                                                  :en "Application options are in an invalid order of preference"}

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -46,19 +46,19 @@
                                                  :sv "Ansökningstid"
                                                  :en "Application period"}
    :application-period-less-than-day-left       {:fi "Hakuaikaa jäljellä alle vuorokausi"
-                                                 :sv "Av ansökningstiden återstår mindre än en dag"
+                                                 :sv "Av ansökningstiden återstår mindre än ett dygn"
                                                  :en "Less than a day left in the application period"}
    :application-period-less-than-hour-left      {:fi "Hakuaikaa jäljellä alle tunti"
                                                  :sv "Av ansökningstiden återstår mindre än en timme"
                                                  :en "Less than one hour left in the application period"}
    :application-period-less-than-45-min-left    {:fi "Hakuaikaa jäljellä alle 45 min"
-                                                 :sv "Av ansökningstiden återstår 45 minuter"
+                                                 :sv "Av ansökningstiden återstår mindre än 45 min."
                                                  :en "Less than 45 min left in the application period"}
    :application-period-less-than-30-min-left    {:fi "Hakuaikaa jäljellä alle 30 min"
-                                                 :sv "Av ansökningstiden återstår 30 minuter"
+                                                 :sv "Av ansökningstiden återstår mindre än 30 min."
                                                  :en "Less than 30 min left in the application period"}
    :application-period-less-than-15-min-left    {:fi "Hakuaikaa jäljellä alle 15 min"
-                                                 :sv "Av ansökningstiden återstår 15 minuter"
+                                                 :sv "Av ansökningstiden återstår mindre än 15 min."
                                                  :en "Less than 15 min left in the application period"}
    :application-priorization-invalid            {:fi "Hakukohteet ovat väärässä ensisijaisuusjärjestyksessä"
                                                  :sv "Fel prioritetsordning för ansökningsmålen"

--- a/test/cljs/unit/ataru/hakija/banner_test.cljs
+++ b/test/cljs/unit/ataru/hakija/banner_test.cljs
@@ -1,0 +1,30 @@
+(ns ataru.hakija.banner-test
+  (:require [cljs.test :refer-macros [deftest is]]
+            [clojure.string :refer [includes?]]
+            [re-frame.core :refer [dispatch subscribe]]
+            [ataru.hakija.banner :refer [hakuaika-left-text]]
+            [ataru.util :as util]))
+
+(defn subscription-stub [x]
+  (atom
+    (case x
+      [:application/form-language] :fi)))
+
+(deftest correctly-shows-remaining-time
+  (defn invoke-and-verify [hours minutes substring]
+    (let [actual (hakuaika-left-text hours minutes)
+          text   (second actual)]
+      (is (includes? text substring)))
+    )
+  (with-redefs [subscribe subscription-stub]
+               (invoke-and-verify 0 14 "Hakuaikaa jäljellä alle 15 min")
+               (invoke-and-verify 0 15 "Hakuaikaa jäljellä alle 30 min")
+               (invoke-and-verify 0 29 "Hakuaikaa jäljellä alle 30 min")
+               (invoke-and-verify 0 30 "Hakuaikaa jäljellä alle 45 min")
+               (invoke-and-verify 0 44 "Hakuaikaa jäljellä alle 45 min")
+               (invoke-and-verify 0 45 "Hakuaikaa jäljellä alle tunti")
+               (invoke-and-verify 0 59 "Hakuaikaa jäljellä alle tunti")
+               (invoke-and-verify 1 00 "Hakuaikaa jäljellä alle vuorokausi")
+               (invoke-and-verify 23 59 "Hakuaikaa jäljellä alle vuorokausi")
+               (is (nil? (hakuaika-left-text 24 0)))))
+

--- a/test/cljs/unit/ataru/hakija/banner_test.cljs
+++ b/test/cljs/unit/ataru/hakija/banner_test.cljs
@@ -5,17 +5,14 @@
             [ataru.hakija.banner :refer [hakuaika-left-text]]
             [ataru.util :as util]))
 
-(defn subscription-stub [x]
-  (atom
-    (case x
-      [:application/form-language] :fi)))
-
 (deftest correctly-shows-remaining-time
   (defn invoke-and-verify [hours minutes substring]
     (let [actual (hakuaika-left-text hours minutes)
           text   (second actual)]
       (is (includes? text substring)))
     )
+  (defn subscription-stub [_]
+    (atom :fi))
   (with-redefs [subscribe subscription-stub]
                (invoke-and-verify 0 14 "Hakuaikaa jäljellä alle 15 min")
                (invoke-and-verify 0 15 "Hakuaikaa jäljellä alle 30 min")

--- a/test/cljs/unit/ataru/unit_runner.cljs
+++ b/test/cljs/unit/ataru/unit_runner.cljs
@@ -6,6 +6,7 @@
             [ataru.hakija.application-test]
             [ataru.hakija.application-validators-test]
             [ataru.hakija.rules-test]
+            [ataru.hakija.banner-test]
             [ataru.component-data.value-transformers-test]))
 
 (doo-tests 'ataru.cljs-util-test
@@ -14,4 +15,5 @@
            'ataru.hakija.application-test
            'ataru.hakija.application-validators-test
            'ataru.hakija.rules-test
+           'ataru.hakija.banner-test
            'ataru.component-data.value-transformers-test)


### PR DESCRIPTION
According to Minea's specification: 

Halutaan että kun hakuaikaa on jäljellä 24h lomakkeen ylälaitaan ilmestyy teksti hakuaikaa jäljellä alle vuorokausi, sitten seuraavat: hakuaikaa jäljellä alle tunti, alle 45 min, alle 30min ja alle 15 min.