### PR TITLE
HLE-1119: muokkauslinkin voimassaolo 14 päivään

### DIFF
--- a/config/defaults.edn
+++ b/config/defaults.edn
@@ -31,6 +31,7 @@
                    :virkailija                          {:service_url "http://localhost:8350/lomake-editori/"}
                    :environment-name                    "dev"
                    :features                            {}
+                   :secret-link-valid-days              14
                    :attachment-modify-grace-period-days 14
                    :attachment-file-max-size-bytes      10485760
                    :attachment-file-part-max-size-bytes 5242880}

--- a/config/dev.edn
+++ b/config/dev.edn
@@ -33,6 +33,7 @@
                    :environment-name                    "test"
                    :enable-re-frisk                     true
                    :local-dev-logout                    true
+                   :secret-link-valid-days              14
                    :attachment-file-max-size-bytes      10485760
                    :attachment-file-part-max-size-bytes 5242880}
  :temp-files      {:filesystem {:base-path "/tmp"}}

--- a/config/test.edn
+++ b/config/test.edn
@@ -33,6 +33,7 @@
                    :environment-name                    "test"
                    :enable-re-frisk                     true
                    :local-dev-logout                    true
+                   :secret-link-valid-days              14
                    :attachment-file-max-size-bytes      10485760
                    :attachment-file-part-max-size-bytes 5242880}
  :temp-files      {:filesystem {:base-path "/tmp"}}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -35,6 +35,7 @@
                  :virkailija {:service_url "https://{{host_virkailija}}/lomake-editori/"}
                  :environment-name "{{ataru_environment_name}}"
                  :features {:kevyt-valinta {{ataru_kevyt_valinta_enabled | default('false')}}}
+                 :secret-link-valid-days {{ataru_secret_link_valid_days | default('14')}}
                  :attachment-modify-grace-period-days 14
                  :attachment-file-max-size-bytes {{ataru_attachment_file_max_size_bytes}}
                  :attachment-file-part-max-size-bytes {{ataru_attachment_file_part_max_size_bytes}}

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -371,7 +371,7 @@ FROM applications AS a
 JOIN forms AS f ON a.form_id = f.id
 JOIN application_secrets AS las ON las.application_key = a.key
 WHERE las.secret = :secret AND
-      las.created_time > now() - INTERVAL '1 day' * :attachment_modify_grace_period_days AND
+      las.created_time > now() - INTERVAL '1 day' * :secret_link_valid_days AND
       NOT EXISTS (SELECT 1
                   FROM applications AS a2
                   WHERE a2.key = a.key AND

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -371,7 +371,7 @@ FROM applications AS a
 JOIN forms AS f ON a.form_id = f.id
 JOIN application_secrets AS las ON las.application_key = a.key
 WHERE las.secret = :secret AND
-      las.created_time > now() - INTERVAL '30 days' AND
+      las.created_time > now() - INTERVAL '1 day' * :attachment_modify_grace_period_days AND
       NOT EXISTS (SELECT 1
                   FROM applications AS a2
                   WHERE a2.key = a.key AND

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -84,7 +84,7 @@ LEFT JOIN LATERAL (SELECT secret, age(now(), created_time)
                    WHERE application_key = a.key
                    ORDER BY id DESC
                    LIMIT 1) AS las
-  ON las.age < '29 days'
+  ON las.age < (interval '1 day' * :secret_link_valid_days - '1 day')
 WHERE a.person_oid = :person_oid AND
       a.haku IS NOT NULL AND
       ar.state <> 'inactivated' AND

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -640,7 +640,7 @@ WHERE la.key IS NULL\n"
   (when-let [application (->> (exec-db :db
                                        yesql-get-latest-application-by-secret
                                        {:secret secret
-                                        :attachment_modify_grace_period_days (-> config :public-config :attachment-modify-grace-period-days)})
+                                        :secret_link_valid_days (-> config :public-config :secret-link-valid-days)})
                               (first)
                               (unwrap-application))]
     (-> application

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -24,7 +24,8 @@
             [clojure.java.jdbc :as jdbc]
             [schema.core :as s]
             [taoensso.timbre :refer [info warn]]
-            [yesql.core :refer [defqueries]])
+            [yesql.core :refer [defqueries]]
+            [ataru.config.core :refer [config]])
   (:import [java.time
             LocalDateTime
             ZoneId]
@@ -636,7 +637,10 @@ WHERE la.key IS NULL\n"
   (mapv ->kebab-case-kw (exec-db :db yesql-get-application-attachment-reviews {:application_key application-key})))
 
 (defn get-latest-application-by-secret [secret]
-  (when-let [application (->> (exec-db :db yesql-get-latest-application-by-secret {:secret secret})
+  (when-let [application (->> (exec-db :db
+                                       yesql-get-latest-application-by-secret
+                                       {:secret secret
+                                        :attachment_modify_grace_period_days (-> config :public-config :attachment-modify-grace-period-days)})
                               (first)
                               (unwrap-application))]
     (-> application

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -557,7 +557,9 @@ WHERE la.key IS NULL\n"
   [person-oid]
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
     (->> (yesql-get-application-list-by-person-oid-for-omatsivut
-          {:person_oid person-oid} {:connection conn})
+          {:person_oid             person-oid
+           :secret_link_valid_days (-> config :public-config :secret-link-valid-days)}
+          {:connection conn})
          ->kebab-case-kw
          (mapv #(if (nil? (:secret %))
                   (do (info "Refreshing secret for application" (:key %))

--- a/src/cljc/ataru/config.cljc
+++ b/src/cljc/ataru/config.cljc
@@ -1,0 +1,9 @@
+(ns ataru.config
+  #?(:clj
+     (:require [ataru.config.core :refer [config]])))
+
+(defn get-public-config [path]
+  #?(:clj  (get-in config path)
+     :cljs (some-> js/config
+                   (js->clj :keywordize-keys true)
+                   (get-in path))))

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -126,9 +126,9 @@
    :expired-secret-heading                      {:fi "Tämä hakemuslinkki on vanhentunut"
                                                  :en "This application link has expired"
                                                  :sv "Denna ansökningslänk är föråldrad"}
-   :expired-secret-paragraph                    {:fi "Turvallisuussyistä hakemuslinkki on voimassa yhden muokkauskerran tai enintään 30 päivää."
-                                                 :en "For security reasons the link is valid for one application update or a maximum of 30 days."
-                                                 :sv "Av säkerhetsskäl är ansökningslänken i kraft under en session eller i högst 30 dagar."}
+   :expired-secret-paragraph                    {:fi "Turvallisuussyistä hakemuslinkki on voimassa yhden muokkauskerran tai enintään %d päivää."
+                                                 :en "For security reasons the link is valid for one application update or a maximum of %d days."
+                                                 :sv "Av säkerhetsskäl är ansökningslänken i kraft under en session eller i högst %d dagar."}
    :expired-secret-sent                         {:fi "Uusi linkki lähetetty!"
                                                  :en "The new link has been sent!"
                                                  :sv "Den nya länken har skickats!"}

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -87,13 +87,13 @@
             [editable-fields form submit-status]))))))
 
 (defn application-contents []
-  (let [form                                (subscribe [:state-query [:form]])
-        load-failure?                       (subscribe [:state-query [:error :code]])
-        can-apply?                          (subscribe [:application/can-apply?])
-        editing?                            (subscribe [:state-query [:application :editing?]])
-        expired                             (subscribe [:state-query [:application :secret-expired?]])
-        delivery-status                     (subscribe [:state-query [:application :secret-delivery-status]])
-        attachment-modify-grace-period-days (config/get-public-config [:attachment-modify-grace-period-days])]
+  (let [form                   (subscribe [:state-query [:form]])
+        load-failure?          (subscribe [:state-query [:error :code]])
+        can-apply?             (subscribe [:application/can-apply?])
+        editing?               (subscribe [:state-query [:application :editing?]])
+        expired                (subscribe [:state-query [:application :secret-expired?]])
+        delivery-status        (subscribe [:state-query [:application :secret-delivery-status]])
+        secret-link-valid-days (config/get-public-config [:secret-link-valid-days])]
     (fn []
       [:div.application__form-content-area
        (when-not (or @load-failure?
@@ -105,7 +105,7 @@
           [:div.application__secret-expired-icon
            [:i.zmdi.zmdi-lock-outline]]
           [:h2 (get-translation :expired-secret-heading)]
-          [:p (get-translation :expired-secret-paragraph attachment-modify-grace-period-days)]
+          [:p (get-translation :expired-secret-paragraph secret-link-valid-days)]
           [:button.application__secret-resend-button
            {:disabled (some? @delivery-status)
             :on-click #(dispatch [:application/send-new-secret])}

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -1,5 +1,6 @@
 (ns ataru.hakija.application-view
   (:require [clojure.string :refer [trim]]
+            [ataru.config :as config]
             [ataru.hakija.banner :refer [banner]]
             [ataru.hakija.application-form-components :refer [editable-fields]]
             [ataru.hakija.hakija-readonly :as readonly-view]
@@ -86,12 +87,13 @@
             [editable-fields form submit-status]))))))
 
 (defn application-contents []
-  (let [form            (subscribe [:state-query [:form]])
-        load-failure?   (subscribe [:state-query [:error :code]])
-        can-apply?      (subscribe [:application/can-apply?])
-        editing?        (subscribe [:state-query [:application :editing?]])
-        expired         (subscribe [:state-query [:application :secret-expired?]])
-        delivery-status (subscribe [:state-query [:application :secret-delivery-status]])]
+  (let [form                                (subscribe [:state-query [:form]])
+        load-failure?                       (subscribe [:state-query [:error :code]])
+        can-apply?                          (subscribe [:application/can-apply?])
+        editing?                            (subscribe [:state-query [:application :editing?]])
+        expired                             (subscribe [:state-query [:application :secret-expired?]])
+        delivery-status                     (subscribe [:state-query [:application :secret-delivery-status]])
+        attachment-modify-grace-period-days (config/get-public-config [:attachment-modify-grace-period-days])]
     (fn []
       [:div.application__form-content-area
        (when-not (or @load-failure?
@@ -103,7 +105,7 @@
           [:div.application__secret-expired-icon
            [:i.zmdi.zmdi-lock-outline]]
           [:h2 (get-translation :expired-secret-heading)]
-          [:p (get-translation :expired-secret-paragraph)]
+          [:p (get-translation :expired-secret-paragraph attachment-modify-grace-period-days)]
           [:button.application__secret-resend-button
            {:disabled (some? @delivery-status)
             :on-click #(dispatch [:application/send-new-secret])}

--- a/src/cljs/ataru/virkailija/config.cljs
+++ b/src/cljs/ataru/virkailija/config.cljs
@@ -1,4 +1,0 @@
-(ns ataru.virkailija.config)
-
-(def debug?
-  ^boolean js/goog.DEBUG)

--- a/src/cljs/ataru/virkailija/core.cljs
+++ b/src/cljs/ataru/virkailija/core.cljs
@@ -11,7 +11,6 @@
             [ataru.virkailija.virkailija-ajax :refer [post]]
             [ataru.virkailija.routes :as routes]
             [ataru.virkailija.views :as views]
-            [ataru.virkailija.config :as config]
             [ataru.virkailija.editor.handlers]
             [taoensso.timbre :refer-macros [spy info]]
             [ataru.application-common.fx :refer [http]] ; ataru.application-common.fx must be required to have common fx handlers enabled


### PR DESCRIPTION
Muokkauslinkin voimassaolo muutetaan 30 päivästä 14 päivään. Lisäksi jokainen kyseistä arvoa käyttävä kohta lukee tiedon konfiguraatiosta aiemman kovakoodauksen sijaan.