### PR TITLE
HLE-1135: muutetaan tarkistusmerkki liukukytkimeksi

### DIFF
--- a/resources/less/virkailija-kevyt-valinta.less
+++ b/resources/less/virkailija-kevyt-valinta.less
@@ -139,35 +139,37 @@
 }
 
 .application-handling__kevyt-valinta-checkbox {
-  border-radius: 3px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
+  align-items: center;
+  background-color: @kevyt-valinta-grayed-out-color;
+  border-radius: 11px;
   cursor: pointer;
+  display: flex;
   flex-shrink: 0;
-  height: 19px;
+  height: 22px;
   margin: 0 5px 0 0;
-  width: 19px;
+  transition: all 0.2s ease-in-out;
+  width: 40px;
+}
+
+.application-handling__kevyt-valinta-checkbox-toggle-indicator {
+  background-color: @white;
+  border-radius: 50%;
+  height: 20px;
+  margin: 0 1px;
+  transition: all 0.2s ease-in-out;
+  width: 20px;
 }
 
 .application-handling__kevyt-valinta-checkbox--disabled {
   cursor: default;
 }
 
-.application-handling__kevyt-valinta-checkbox--enabled {
-  color: @kevyt-valinta-unchecked-color;
+.application-handling__kevyt-valinta-checkbox--checked.application-handling__kevyt-valinta-checkbox--enabled {
+  background-color: @light-green;
 }
 
-.application-handling__kevyt-valinta-checkbox--enabled:hover {
-  background-color: @kevyt-valinta-selection-hovered-background-color;
-}
-
-.application-handling__kevyt-valinta-checkbox--checked {
-  align-items: center;
-  display: flex;
-  justify-content: center;
-}
-
-.application-handling__kevyt-valinta-checkbox-checkmark {
-  font-weight: 600;
+.application-handling__kevyt-valinta-checkbox--checked > .application-handling__kevyt-valinta-checkbox-toggle-indicator {
+  transform: translateX(18px);
 }
 
 .application-handling__kevyt-valinta-checkbox-info-container {

--- a/resources/less/virkailija-kevyt-valinta.less
+++ b/resources/less/virkailija-kevyt-valinta.less
@@ -112,7 +112,9 @@
 
 .application-handling__kevyt-valinta-slider-toggle-container {
   align-items: center;
+  display: flex;
   justify-content: flex-start;
+  position: relative;
 }
 
 .application-handling__kevyt-valinta-slider-toggle-container--disabled {
@@ -121,18 +123,17 @@
 
 .application-handling__kevyt-valinta-dropdown-container > :last-child:not(:nth-child(1)),
 .application-handling__kevyt-valinta-slider-toggle-container > :last-child:not(:nth-child(1)) {
-  margin-right: 31px;
+  margin-right: 30px;
 }
 
 .application-handling__kevyt-valinta-slider-toggle-label {
   align-items: center;
   display: flex;
-  margin-left: 5px;
-  position: relative;
-  width: 100%;
+  flex-basis: 74px;
+  margin-right: 5px;
 }
 
-.application-handling__kevyt-valinta-slider-toggle-label .zmdi-info {
+.application-handling__kevyt-valinta-slider-toggle-container .zmdi-info {
   color: @kevyt-valinta-unchecked-color;
   font-size: 21px;
   margin-left: 5px;
@@ -179,10 +180,10 @@
 .application-handling__kevyt-valinta-slider-toggle-info {
   background-color: @kevyt-valinta-unchecked-color;
   color: @white;
-  left: -29px;
+  left: -1px;
   padding: 15px;
   position: absolute;
-  top: 33px;
+  top: 46px;
   user-select: none;
   width: 252px;
   z-index: 20;

--- a/resources/less/virkailija-kevyt-valinta.less
+++ b/resources/less/virkailija-kevyt-valinta.less
@@ -98,7 +98,7 @@
 }
 
 .application-handling__kevyt-valinta-dropdown-container,
-.application-handling__kevyt-valinta-checkbox-container {
+.application-handling__kevyt-valinta-slider-toggle-container {
   display: flex;
   height: 100%;
   width: 100%;
@@ -110,21 +110,21 @@
   position: relative;
 }
 
-.application-handling__kevyt-valinta-checkbox-container {
+.application-handling__kevyt-valinta-slider-toggle-container {
   align-items: center;
   justify-content: flex-start;
 }
 
-.application-handling__kevyt-valinta-checkbox-container--disabled {
+.application-handling__kevyt-valinta-slider-toggle-container--disabled {
   color: @kevyt-valinta-gray-for-disabled;
 }
 
 .application-handling__kevyt-valinta-dropdown-container > :last-child:not(:nth-child(1)),
-.application-handling__kevyt-valinta-checkbox-container > :last-child:not(:nth-child(1)) {
+.application-handling__kevyt-valinta-slider-toggle-container > :last-child:not(:nth-child(1)) {
   margin-right: 31px;
 }
 
-.application-handling__kevyt-valinta-checkbox-label {
+.application-handling__kevyt-valinta-slider-toggle-label {
   align-items: center;
   display: flex;
   margin-left: 5px;
@@ -132,13 +132,13 @@
   width: 100%;
 }
 
-.application-handling__kevyt-valinta-checkbox-label .zmdi-info {
+.application-handling__kevyt-valinta-slider-toggle-label .zmdi-info {
   color: @kevyt-valinta-unchecked-color;
   font-size: 21px;
   margin-left: 5px;
 }
 
-.application-handling__kevyt-valinta-checkbox {
+.application-handling__kevyt-valinta-slider-toggle {
   align-items: center;
   background-color: @kevyt-valinta-grayed-out-color;
   border-radius: 11px;
@@ -151,7 +151,7 @@
   width: 40px;
 }
 
-.application-handling__kevyt-valinta-checkbox-toggle-indicator {
+.application-handling__kevyt-valinta-slider-toggle-toggle-indicator {
   background-color: @white;
   border-radius: 50%;
   height: 20px;
@@ -160,23 +160,23 @@
   width: 20px;
 }
 
-.application-handling__kevyt-valinta-checkbox--disabled {
+.application-handling__kevyt-valinta-slider-toggle--disabled {
   cursor: default;
 }
 
-.application-handling__kevyt-valinta-checkbox--checked.application-handling__kevyt-valinta-checkbox--enabled {
+.application-handling__kevyt-valinta-slider-toggle--checked.application-handling__kevyt-valinta-slider-toggle--enabled {
   background-color: @light-green;
 }
 
-.application-handling__kevyt-valinta-checkbox--checked > .application-handling__kevyt-valinta-checkbox-toggle-indicator {
+.application-handling__kevyt-valinta-slider-toggle--checked > .application-handling__kevyt-valinta-slider-toggle-toggle-indicator {
   transform: translateX(18px);
 }
 
-.application-handling__kevyt-valinta-checkbox-info-container {
+.application-handling__kevyt-valinta-slider-toggle-info-container {
   position: relative;
 }
 
-.application-handling__kevyt-valinta-checkbox-info {
+.application-handling__kevyt-valinta-slider-toggle-info {
   background-color: @kevyt-valinta-unchecked-color;
   color: @white;
   left: -29px;
@@ -188,23 +188,23 @@
   z-index: 20;
 }
 
-.application-handling__kevyt-valinta-checkbox-info-symbol:hover {
+.application-handling__kevyt-valinta-slider-toggle-info-symbol:hover {
   color: @link-color;
 }
 
-.application-handling__kevyt-valinta-checkbox-info-text {
+.application-handling__kevyt-valinta-slider-toggle-info-text {
   display: inline-block;
 }
 
-.application-handling__kevyt-valinta-checkbox-info > .application-handling__kevyt-valinta-checkbox-info-text:not(:last-child) {
+.application-handling__kevyt-valinta-slider-toggle-info > .application-handling__kevyt-valinta-slider-toggle-info-text:not(:last-child) {
   margin-bottom: 10px;
 }
 
-.application-handling__kevyt-valinta-checkbox-info > .application-handling__kevyt-valinta-checkbox-info-text:not(:last-child) {
+.application-handling__kevyt-valinta-slider-toggle-info > .application-handling__kevyt-valinta-slider-toggle-info-text:not(:last-child) {
   margin-bottom: 10px;
 }
 
-.application-handling__kevyt-valinta-checkbox-info-indicator {
+.application-handling__kevyt-valinta-slider-toggle-info-indicator {
   border-bottom: 10px solid #00526C;
   border-left: 13px solid transparent;
   border-right: 13px solid transparent;

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1572,8 +1572,8 @@ You will receive a confirmation of your application to your email."}
    :kevyt-valinta/kesken                 {:fi "Kesken"}})
 
 (def kevyt-valinta-julkaisun-tila-translations
-  {:kevyt-valinta/julkaistu-hakijalle {:fi "Julkaistu hakijalle"}
-   :kevyt-valinta/ei-julkaistu        {:fi "Julkaistu hakijalle"}})
+  {:kevyt-valinta/julkaistu-hakijalle {:fi "Julkaistu"}
+   :kevyt-valinta/ei-julkaistu        {:fi "Ei julkaistu"}})
 
 (def kevyt-valinta-vastaanotto-tila-translations
   {:kevyt-valinta/ei-vastaanotettu-maaraaikana  {:fi "Ei vastaanotettu määräaikana"}

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
@@ -112,7 +112,7 @@
        kevyt-valinta-on-dropdown-value-change
        ongoing-request-property])))
 
-(defn kevyt-valinta-checkbox-selection [kevyt-valinta-property]
+(defn kevyt-valinta-slider-toggle-selection [kevyt-valinta-property]
   (let [lang                                   (re-frame/subscribe [:editor/virkailija-lang])
         ongoing-request-property               (re-frame/subscribe [:virkailija-kevyt-valinta/ongoing-request-property])
         application-key                        (re-frame/subscribe [:state-query [:application :selected-application-and-form :application :key]])
@@ -172,8 +172,7 @@
                        (let [new-value (not @kevyt-valinta-checkbox-value)]
                          (reset! force-show-checkbox? nil)
                          (@kevyt-valinta-on-checkbox-value-change new-value))))}
-        (when @kevyt-valinta-checkbox-value
-          [:i.zmdi.zmdi-check.application-handling__kevyt-valinta-checkbox-checkmark])]
+        [:div.application-handling__kevyt-valinta-checkbox-toggle-indicator]]
        [:div.application-handling__kevyt-valinta-checkbox-label
         [:span @kevyt-valinta-checkbox-label]
         (when-not @show-loader?

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
@@ -113,47 +113,47 @@
        ongoing-request-property])))
 
 (defn kevyt-valinta-slider-toggle-selection [kevyt-valinta-property]
-  (let [lang                                   (re-frame/subscribe [:editor/virkailija-lang])
-        ongoing-request-property               (re-frame/subscribe [:virkailija-kevyt-valinta/ongoing-request-property])
-        application-key                        (re-frame/subscribe [:state-query [:application :selected-application-and-form :application :key]])
+  (let [lang                                        (re-frame/subscribe [:editor/virkailija-lang])
+        ongoing-request-property                    (re-frame/subscribe [:virkailija-kevyt-valinta/ongoing-request-property])
+        application-key                             (re-frame/subscribe [:state-query [:application :selected-application-and-form :application :key]])
         kevyt-valinta-slider-toggle-state           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-selection-state
-                                                                               kevyt-valinta-property
-                                                                               @application-key]))
+                                                                                    kevyt-valinta-property
+                                                                                    @application-key]))
         slider-toggle-disabled?                     (reaction (or @ongoing-request-property
-                                                             (= @kevyt-valinta-slider-toggle-state :checked)))
-        show-loader?                           (reaction (= @ongoing-request-property kevyt-valinta-property))
-        kevyt-valinta-property-values          (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/allowed-kevyt-valinta-property-values
-                                                                               kevyt-valinta-property
-                                                                               @application-key]))
+                                                                  (= @kevyt-valinta-slider-toggle-state :checked)))
+        show-loader?                                (reaction (= @ongoing-request-property kevyt-valinta-property))
+        kevyt-valinta-property-values               (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/allowed-kevyt-valinta-property-values
+                                                                                    kevyt-valinta-property
+                                                                                    @application-key]))
         kevyt-valinta-slider-toggle-values          (reaction (map (fn [kevyt-valinta-property-value]
-                                                                {:value kevyt-valinta-property-value
-                                                                 :label (translations/kevyt-valinta-selection-label kevyt-valinta-property
-                                                                                                                    kevyt-valinta-property-value
-                                                                                                                    @lang)})
-                                                              @kevyt-valinta-property-values))
+                                                                     {:value kevyt-valinta-property-value
+                                                                      :label (translations/kevyt-valinta-selection-label kevyt-valinta-property
+                                                                                                                         kevyt-valinta-property-value
+                                                                                                                         @lang)})
+                                                                   @kevyt-valinta-property-values))
         kevyt-valinta-slider-toggle-value           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-property-value
-                                                                               kevyt-valinta-property
-                                                                               @application-key]))
+                                                                                    kevyt-valinta-property
+                                                                                    @application-key]))
         kevyt-valinta-slider-toggle-label           (reaction (->> @kevyt-valinta-slider-toggle-values
-                                                              (filter (comp (partial = @kevyt-valinta-slider-toggle-value)
-                                                                            :value))
-                                                              (map :label)
-                                                              (first)))
+                                                                   (filter (comp (partial = @kevyt-valinta-slider-toggle-value)
+                                                                                 :value))
+                                                                   (map :label)
+                                                                   (first)))
         ;; kevytvalinta näytetään ainoastaan, kun yksi hakukohde valittuna, ks. :virkailija-kevyt-valinta/show-kevyt-valinta?
-        hakukohde-oid                          (reaction (first @(re-frame/subscribe [:state-query [:application :selected-review-hakukohde-oids]])))
+        hakukohde-oid                               (reaction (first @(re-frame/subscribe [:state-query [:application :selected-review-hakukohde-oids]])))
 
         kevyt-valinta-on-slider-toggle-value-change (reaction (partial on-kevyt-valinta-property-change
-                                                                  kevyt-valinta-property
-                                                                  @hakukohde-oid
-                                                                  @application-key))
+                                                                       kevyt-valinta-property
+                                                                       @hakukohde-oid
+                                                                       @application-key))
         force-show-slider-toggle?                   (reagent/atom nil)
-        kevyt-valinta-dropdowns-open?          (re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-dropdowns-open?])
-        kevyt-valinta-write-rights?            (re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-write-rights?])
+        kevyt-valinta-dropdowns-open?               (re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-dropdowns-open?])
+        kevyt-valinta-write-rights?                 (re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-write-rights?])
         slider-toggle-info-visible?                 (reaction (and @kevyt-valinta-write-rights?
-                                                              (if (some? @force-show-slider-toggle?)
-                                                                @force-show-slider-toggle?
-                                                                (not @kevyt-valinta-slider-toggle-value))
-                                                              (not @kevyt-valinta-dropdowns-open?)))]
+                                                                   (if (some? @force-show-slider-toggle?)
+                                                                     @force-show-slider-toggle?
+                                                                     (not @kevyt-valinta-slider-toggle-value))
+                                                                   (not @kevyt-valinta-dropdowns-open?)))]
     (fn [_]
       [:div.application-handling__kevyt-valinta-slider-toggle-container
        (when @slider-toggle-disabled?

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
@@ -158,6 +158,8 @@
       [:div.application-handling__kevyt-valinta-slider-toggle-container
        (when @slider-toggle-disabled?
          {:class "application-handling__kevyt-valinta-slider-toggle-container--disabled"})
+       [:div.application-handling__kevyt-valinta-slider-toggle-label
+        [:span @kevyt-valinta-slider-toggle-label]]
        [:div.application-handling__kevyt-valinta-slider-toggle
         {:class    (cond-> ""
                            @slider-toggle-disabled?
@@ -185,22 +187,20 @@
                          (reset! force-show-slider-toggle? nil)
                          (@kevyt-valinta-on-slider-toggle-value-change new-value))))}
         [:div.application-handling__kevyt-valinta-slider-toggle-toggle-indicator]]
-       [:div.application-handling__kevyt-valinta-slider-toggle-label
-        [:span @kevyt-valinta-slider-toggle-label]
-        (when-not @show-loader?
-          [:<>
-           [:a
-            {:on-click (fn []
-                         (swap! force-show-slider-toggle? (fnil not @slider-toggle-info-visible?)))}
-            [:div.application-handling__kevyt-valinta-slider-toggle-info-container
-             (when @kevyt-valinta-write-rights?
-               [:i.zmdi.zmdi-info.application-handling__kevyt-valinta-slider-toggle-info-symbol])
-             (when @slider-toggle-info-visible?
-               [:div.application-handling__kevyt-valinta-slider-toggle-info-indicator.animated.fadeIn])]
+       (when-not @show-loader?
+         [:<>
+          [:a
+           {:on-click (fn []
+                        (swap! force-show-slider-toggle? (fnil not @slider-toggle-info-visible?)))}
+           [:div.application-handling__kevyt-valinta-slider-toggle-info-container
+            (when @kevyt-valinta-write-rights?
+              [:i.zmdi.zmdi-info.application-handling__kevyt-valinta-slider-toggle-info-symbol])
             (when @slider-toggle-info-visible?
-              [:div.application-handling__kevyt-valinta-slider-toggle-info.animated.fadeIn
-               [:span.application-handling__kevyt-valinta-slider-toggle-info-text "Julkaisun jälkeen valintatieto näkyy hakijalle Oma opintopolku -palvelussa."]
-               [:span.application-handling__kevyt-valinta-slider-toggle-info-text "Hyväksytyille hakijoille lähetetään myös sähköposti klo 8.00 tai 20.00"]])]])]
+              [:div.application-handling__kevyt-valinta-slider-toggle-info-indicator.animated.fadeIn])]
+           (when @slider-toggle-info-visible?
+             [:div.application-handling__kevyt-valinta-slider-toggle-info.animated.fadeIn
+              [:span.application-handling__kevyt-valinta-slider-toggle-info-text "Julkaisun jälkeen valintatieto näkyy hakijalle Oma opintopolku -palvelussa."]
+              [:span.application-handling__kevyt-valinta-slider-toggle-info-text "Hyväksytyille hakijoille lähetetään myös sähköposti klo 8.00 tai 20.00"]])]])
        (when @show-loader?
          [el/ellipsis-loader])])))
 

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
@@ -116,79 +116,79 @@
   (let [lang                                   (re-frame/subscribe [:editor/virkailija-lang])
         ongoing-request-property               (re-frame/subscribe [:virkailija-kevyt-valinta/ongoing-request-property])
         application-key                        (re-frame/subscribe [:state-query [:application :selected-application-and-form :application :key]])
-        kevyt-valinta-checkbox-state           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-selection-state
+        kevyt-valinta-slider-toggle-state           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-selection-state
                                                                                kevyt-valinta-property
                                                                                @application-key]))
-        checkbox-disabled?                     (reaction (or @ongoing-request-property
-                                                             (= @kevyt-valinta-checkbox-state :checked)))
+        slider-toggle-disabled?                     (reaction (or @ongoing-request-property
+                                                             (= @kevyt-valinta-slider-toggle-state :checked)))
         show-loader?                           (reaction (= @ongoing-request-property kevyt-valinta-property))
         kevyt-valinta-property-values          (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/allowed-kevyt-valinta-property-values
                                                                                kevyt-valinta-property
                                                                                @application-key]))
-        kevyt-valinta-checkbox-values          (reaction (map (fn [kevyt-valinta-property-value]
+        kevyt-valinta-slider-toggle-values          (reaction (map (fn [kevyt-valinta-property-value]
                                                                 {:value kevyt-valinta-property-value
                                                                  :label (translations/kevyt-valinta-selection-label kevyt-valinta-property
                                                                                                                     kevyt-valinta-property-value
                                                                                                                     @lang)})
                                                               @kevyt-valinta-property-values))
-        kevyt-valinta-checkbox-value           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-property-value
+        kevyt-valinta-slider-toggle-value           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-property-value
                                                                                kevyt-valinta-property
                                                                                @application-key]))
-        kevyt-valinta-checkbox-label           (reaction (->> @kevyt-valinta-checkbox-values
-                                                              (filter (comp (partial = @kevyt-valinta-checkbox-value)
+        kevyt-valinta-slider-toggle-label           (reaction (->> @kevyt-valinta-slider-toggle-values
+                                                              (filter (comp (partial = @kevyt-valinta-slider-toggle-value)
                                                                             :value))
                                                               (map :label)
                                                               (first)))
         ;; kevytvalinta näytetään ainoastaan, kun yksi hakukohde valittuna, ks. :virkailija-kevyt-valinta/show-kevyt-valinta?
         hakukohde-oid                          (reaction (first @(re-frame/subscribe [:state-query [:application :selected-review-hakukohde-oids]])))
 
-        kevyt-valinta-on-checkbox-value-change (reaction (partial on-kevyt-valinta-property-change
+        kevyt-valinta-on-slider-toggle-value-change (reaction (partial on-kevyt-valinta-property-change
                                                                   kevyt-valinta-property
                                                                   @hakukohde-oid
                                                                   @application-key))
-        force-show-checkbox?                   (reagent/atom nil)
+        force-show-slider-toggle?                   (reagent/atom nil)
         kevyt-valinta-dropdowns-open?          (re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-dropdowns-open?])
         kevyt-valinta-write-rights?            (re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-write-rights?])
-        checkbox-info-visible?                 (reaction (and @kevyt-valinta-write-rights?
-                                                              (if (some? @force-show-checkbox?)
-                                                                @force-show-checkbox?
-                                                                (not @kevyt-valinta-checkbox-value))
+        slider-toggle-info-visible?                 (reaction (and @kevyt-valinta-write-rights?
+                                                              (if (some? @force-show-slider-toggle?)
+                                                                @force-show-slider-toggle?
+                                                                (not @kevyt-valinta-slider-toggle-value))
                                                               (not @kevyt-valinta-dropdowns-open?)))]
     (fn [_]
-      [:div.application-handling__kevyt-valinta-checkbox-container
-       (when @checkbox-disabled?
-         {:class "application-handling__kevyt-valinta-checkbox-container--disabled"})
-       [:div.application-handling__kevyt-valinta-checkbox
+      [:div.application-handling__kevyt-valinta-slider-toggle-container
+       (when @slider-toggle-disabled?
+         {:class "application-handling__kevyt-valinta-slider-toggle-container--disabled"})
+       [:div.application-handling__kevyt-valinta-slider-toggle
         {:class    (as-> "" classes
-                         (str classes (if @checkbox-disabled?
-                                        " application-handling__kevyt-valinta-checkbox--disabled"
-                                        " application-handling__kevyt-valinta-checkbox--enabled"))
+                         (str classes (if @slider-toggle-disabled?
+                                        " application-handling__kevyt-valinta-slider-toggle--disabled"
+                                        " application-handling__kevyt-valinta-slider-toggle--enabled"))
 
                          (cond-> classes
-                                 @kevyt-valinta-checkbox-value
-                                 (str " application-handling__kevyt-valinta-checkbox--checked")))
-         :on-click (when-not @checkbox-disabled?
+                                 @kevyt-valinta-slider-toggle-value
+                                 (str " application-handling__kevyt-valinta-slider-toggle--checked")))
+         :on-click (when-not @slider-toggle-disabled?
                      (fn []
-                       (let [new-value (not @kevyt-valinta-checkbox-value)]
-                         (reset! force-show-checkbox? nil)
-                         (@kevyt-valinta-on-checkbox-value-change new-value))))}
-        [:div.application-handling__kevyt-valinta-checkbox-toggle-indicator]]
-       [:div.application-handling__kevyt-valinta-checkbox-label
-        [:span @kevyt-valinta-checkbox-label]
+                       (let [new-value (not @kevyt-valinta-slider-toggle-value)]
+                         (reset! force-show-slider-toggle? nil)
+                         (@kevyt-valinta-on-slider-toggle-value-change new-value))))}
+        [:div.application-handling__kevyt-valinta-slider-toggle-toggle-indicator]]
+       [:div.application-handling__kevyt-valinta-slider-toggle-label
+        [:span @kevyt-valinta-slider-toggle-label]
         (when-not @show-loader?
           [:<>
            [:a
             {:on-click (fn []
-                         (swap! force-show-checkbox? (fnil not @checkbox-info-visible?)))}
-            [:div.application-handling__kevyt-valinta-checkbox-info-container
+                         (swap! force-show-slider-toggle? (fnil not @slider-toggle-info-visible?)))}
+            [:div.application-handling__kevyt-valinta-slider-toggle-info-container
              (when @kevyt-valinta-write-rights?
-               [:i.zmdi.zmdi-info.application-handling__kevyt-valinta-checkbox-info-symbol])
-             (when @checkbox-info-visible?
-               [:div.application-handling__kevyt-valinta-checkbox-info-indicator.animated.fadeIn])]
-            (when @checkbox-info-visible?
-              [:div.application-handling__kevyt-valinta-checkbox-info.animated.fadeIn
-               [:span.application-handling__kevyt-valinta-checkbox-info-text "Julkaisun jälkeen valintatieto näkyy hakijalle Oma opintopolku -palvelussa."]
-               [:span.application-handling__kevyt-valinta-checkbox-info-text "Hyväksytyille hakijoille lähetetään myös sähköposti klo 8.00 tai 20.00"]])]])]
+               [:i.zmdi.zmdi-info.application-handling__kevyt-valinta-slider-toggle-info-symbol])
+             (when @slider-toggle-info-visible?
+               [:div.application-handling__kevyt-valinta-slider-toggle-info-indicator.animated.fadeIn])]
+            (when @slider-toggle-info-visible?
+              [:div.application-handling__kevyt-valinta-slider-toggle-info.animated.fadeIn
+               [:span.application-handling__kevyt-valinta-slider-toggle-info-text "Julkaisun jälkeen valintatieto näkyy hakijalle Oma opintopolku -palvelussa."]
+               [:span.application-handling__kevyt-valinta-slider-toggle-info-text "Hyväksytyille hakijoille lähetetään myös sähköposti klo 8.00 tai 20.00"]])]])]
        (when @show-loader?
          [el/ellipsis-loader])])))
 

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
@@ -119,7 +119,7 @@
         kevyt-valinta-slider-toggle-state           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-selection-state
                                                                                     kevyt-valinta-property
                                                                                     @application-key]))
-        slider-toggle-disabled?                     (reaction (or @ongoing-request-property
+        slider-toggle-disabled?                     (reaction (or (some? @ongoing-request-property)
                                                                   (= @kevyt-valinta-slider-toggle-state :checked)))
         show-loader?                                (reaction (= @ongoing-request-property kevyt-valinta-property))
         kevyt-valinta-property-values               (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/allowed-kevyt-valinta-property-values
@@ -159,14 +159,26 @@
        (when @slider-toggle-disabled?
          {:class "application-handling__kevyt-valinta-slider-toggle-container--disabled"})
        [:div.application-handling__kevyt-valinta-slider-toggle
-        {:class    (as-> "" classes
-                         (str classes (if @slider-toggle-disabled?
-                                        " application-handling__kevyt-valinta-slider-toggle--disabled"
-                                        " application-handling__kevyt-valinta-slider-toggle--enabled"))
+        {:class    (cond-> ""
+                           @slider-toggle-disabled?
+                           (str " application-handling__kevyt-valinta-slider-toggle--disabled")
 
-                         (cond-> classes
-                                 @kevyt-valinta-slider-toggle-value
-                                 (str " application-handling__kevyt-valinta-slider-toggle--checked")))
+                           (match [@kevyt-valinta-slider-toggle-state @ongoing-request-property]
+                                  [:unchecked (_ :guard nil?)]
+                                  true
+
+                                  [:unchecked (_ :guard #(not= % kevyt-valinta-property))]
+                                  true
+
+                                  [:checked (_ :guard #(not= % kevyt-valinta-property))]
+                                  true
+
+                                  :else
+                                  false)
+                           (str " application-handling__kevyt-valinta-slider-toggle--enabled")
+
+                           @kevyt-valinta-slider-toggle-value
+                           (str " application-handling__kevyt-valinta-slider-toggle--checked"))
          :on-click (when-not @slider-toggle-disabled?
                      (fn []
                        (let [new-value (not @kevyt-valinta-slider-toggle-value)]

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_julkaisun_tila_view.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_julkaisun_tila_view.cljs
@@ -3,7 +3,7 @@
             [ataru.virkailija.application.kevyt-valinta.virkailija-kevyt-valinta-translations :as translations]))
 
 (defn- kevyt-valinta-julkaisun-tila-selection []
-  [common-view/kevyt-valinta-checkbox-selection :kevyt-valinta/julkaisun-tila])
+  [common-view/kevyt-valinta-slider-toggle-selection :kevyt-valinta/julkaisun-tila])
 
 (defn kevyt-valinta-julkaisun-tila-row []
   [common-view/kevyt-valinta-row


### PR DESCRIPTION
Muutetaan julkaisun tilan tarkistumerkki ns. liukukytkintyyppiseksi valinnaksi. Ks. oheiset kuvat.

# Valinta pois päältä

![image](https://user-images.githubusercontent.com/3083043/72064304-42086480-32e4-11ea-9ab4-6efa4cab277a.png)

# Valinnan muutos kesken (kuvassa muutettu pois päältä -> päälle)

![image](https://user-images.githubusercontent.com/3083043/72064312-4765af00-32e4-11ea-9ea9-0b7b6c110e49.png)

# Valinta päällä

![image](https://user-images.githubusercontent.com/3083043/72064320-4a609f80-32e4-11ea-840f-1a9305d77f4d.png)
