### PR TITLE
HLE-1136: ei näytetä valinnan tiloja "perunut", "peruutettu", "peruuntunut"

### DIFF
--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
@@ -274,10 +274,7 @@
    "HYVAKSYTTY"
    "VARASIJALTA_HYVAKSYTTY"
    "HYLATTY"
-   "VARALLA"
-   "PERUUNTUNUT"
-   "PERUNUT"
-   "PERUUTETTU"])
+   "VARALLA"])
 
 (def ^:private julkaisun-tilat
   [false true])
@@ -324,10 +321,15 @@
     (let [{valinnan-tila    :valinnantila
            vastaanotto-tila :vastaanottotila} valinnan-tulos-for-application]
       (case kevyt-valinta-property
-        :kevyt-valinta/valinnan-tila (cond->> valinnan-tilat
-                                              (and (-> valinnan-tila nil? not)
-                                                   (not= valinnan-tila "KESKEN"))
-                                              (remove (partial = "KESKEN")))
+        :kevyt-valinta/valinnan-tila (as-> valinnan-tilat valinnan-tilat'
+                                           (cond->> valinnan-tilat'
+                                                    (and (-> valinnan-tila nil? not)
+                                                         (not= valinnan-tila "KESKEN"))
+                                                    (remove (partial = "KESKEN")))
+
+                                           (cond-> valinnan-tilat'
+                                                   (some #{valinnan-tila} ["PERUUNTUNUT" "PERUNUT" "PERUUTETTU"])
+                                                   (conj valinnan-tila)))
         :kevyt-valinta/julkaisun-tila julkaisun-tilat
         :kevyt-valinta/vastaanotto-tila (cond-> (if korkeakouluhaku?
                                                   vastaanotto-tilat-for-korkeakoulu


### PR DESCRIPTION
Käyttäjä ei näe kevytvalinnan valinnan tilassa tiloja "perunut", "peruutettu" tai "peruuntunut".

Mikäli senhetkinen valinnan tila valinta-tulos-servicessä on jokin näistä, juuri tämä kyseinen valinta näytetään. Toisin sanoen, mikäli käyttäjä muuttaa valinnan tilan jostain näistä kolmesta arvosta joksikin muuksi, ei arvoa voi enää vaihtaa takaisin yhteenkään näistä.