### PR TITLE
HLE-1137: kevytvalinnan tekstit kielikäännöspalveluun

### DIFF
--- a/src/cljc/ataru/application/review_states.cljc
+++ b/src/cljc/ataru/application/review_states.cljc
@@ -1,9 +1,6 @@
 (ns ataru.application.review-states
   (:require [ataru.translations.texts :refer [state-translations
-                                              kevyt-valinta-state-translations
-                                              kevyt-valinta-julkaisun-tila-translations
-                                              kevyt-valinta-vastaanotto-tila-translations
-                                              kevyt-valinta-ilmoittautumisen-tila-translations]]
+                                              virkailija-texts]]
             [ataru.util :as util]
             [clojure.set :refer [difference]]))
 
@@ -32,38 +29,38 @@
    ["rejected" (:rejected state-translations)]])
 
 (def valinnan-tila-selection-state
-  {"HYLATTY"                (:kevyt-valinta/hylatty kevyt-valinta-state-translations)
-   "VARALLA"                (:kevyt-valinta/varalla kevyt-valinta-state-translations)
-   "PERUUNTUNUT"            (:kevyt-valinta/peruuntunut kevyt-valinta-state-translations)
-   "VARASIJALTA_HYVAKSYTTY" (:kevyt-valinta/varasijalta-hyvaksytty kevyt-valinta-state-translations)
-   "HYVAKSYTTY"             (:kevyt-valinta/hyvaksytty kevyt-valinta-state-translations)
-   "PERUNUT"                (:kevyt-valinta/perunut kevyt-valinta-state-translations)
-   "PERUUTETTU"             (:kevyt-valinta/peruutettu kevyt-valinta-state-translations)
-   "KESKEN"                 (:kevyt-valinta/kesken kevyt-valinta-state-translations)})
+  {"HYLATTY"                (:kevyt-valinta/hylatty virkailija-texts)
+   "VARALLA"                (:kevyt-valinta/varalla virkailija-texts)
+   "PERUUNTUNUT"            (:kevyt-valinta/peruuntunut virkailija-texts)
+   "VARASIJALTA_HYVAKSYTTY" (:kevyt-valinta/varasijalta-hyvaksytty virkailija-texts)
+   "HYVAKSYTTY"             (:kevyt-valinta/hyvaksytty virkailija-texts)
+   "PERUNUT"                (:kevyt-valinta/perunut virkailija-texts)
+   "PERUUTETTU"             (:kevyt-valinta/peruutettu virkailija-texts)
+   "KESKEN"                 (:kevyt-valinta/kesken virkailija-texts)})
 
 (def julkaisun-tila-selection-state
-  {true  (:kevyt-valinta/julkaistu-hakijalle kevyt-valinta-julkaisun-tila-translations)
-   false (:kevyt-valinta/ei-julkaistu kevyt-valinta-julkaisun-tila-translations)})
+  {true  (:kevyt-valinta/julkaistu-hakijalle virkailija-texts)
+   false (:kevyt-valinta/ei-julkaistu virkailija-texts)})
 
 (def vastaanotto-tila-selection-state
-  {"EI_VASTAANOTETTU_MAARA_AIKANA" (:kevyt-valinta/ei-vastaanotettu-maaraaikana kevyt-valinta-vastaanotto-tila-translations)
-   "PERUNUT"                       (:kevyt-valinta/perunut kevyt-valinta-vastaanotto-tila-translations)
-   "PERUUTETTU"                    (:kevyt-valinta/peruutettu kevyt-valinta-vastaanotto-tila-translations)
-   "OTTANUT_VASTAAN_TOISEN_PAIKAN" (:kevyt-valinta/ottanut-vastaan-toisen-paikan kevyt-valinta-vastaanotto-tila-translations)
-   "EHDOLLISESTI_VASTAANOTTANUT"   (:kevyt-valinta/ehdollisesti-vastaanottanut kevyt-valinta-vastaanotto-tila-translations)
-   "VASTAANOTTANUT_SITOVASTI"      (:kevyt-valinta/vastaanottanut-sitovasti kevyt-valinta-vastaanotto-tila-translations)
-   "KESKEN"                        (:kevyt-valinta/kesken kevyt-valinta-vastaanotto-tila-translations)
-   "VASTAANOTTANUT"                (:kevyt-valinta/vastaanottanut kevyt-valinta-vastaanotto-tila-translations)})
+  {"EI_VASTAANOTETTU_MAARA_AIKANA" (:kevyt-valinta/ei-vastaanotettu-maaraaikana virkailija-texts)
+   "PERUNUT"                       (:kevyt-valinta/perunut virkailija-texts)
+   "PERUUTETTU"                    (:kevyt-valinta/peruutettu virkailija-texts)
+   "OTTANUT_VASTAAN_TOISEN_PAIKAN" (:kevyt-valinta/ottanut-vastaan-toisen-paikan virkailija-texts)
+   "EHDOLLISESTI_VASTAANOTTANUT"   (:kevyt-valinta/ehdollisesti-vastaanottanut virkailija-texts)
+   "VASTAANOTTANUT_SITOVASTI"      (:kevyt-valinta/vastaanottanut-sitovasti virkailija-texts)
+   "KESKEN"                        (:kevyt-valinta/kesken virkailija-texts)
+   "VASTAANOTTANUT"                (:kevyt-valinta/vastaanottanut virkailija-texts)})
 
 (def ilmoittautumisen-tila-selection-state
-  {"EI_TEHTY"              (:kevyt-valinta/ei-tehty kevyt-valinta-ilmoittautumisen-tila-translations)
-   "LASNA_KOKO_LUKUVUOSI"  (:kevyt-valinta/lasna-koko-lukuvuosi kevyt-valinta-ilmoittautumisen-tila-translations)
-   "POISSA_KOKO_LUKUVUOSI" (:kevyt-valinta/poissa-koko-lukuvuosi kevyt-valinta-ilmoittautumisen-tila-translations)
-   "EI_ILMOITTAUTUNUT"     (:kevyt-valinta/ei-ilmoittautunut kevyt-valinta-ilmoittautumisen-tila-translations)
-   "LASNA_SYKSY"           (:kevyt-valinta/lasna-syksy kevyt-valinta-ilmoittautumisen-tila-translations)
-   "POISSA_SYKSY"          (:kevyt-valinta/poissa-syksy kevyt-valinta-ilmoittautumisen-tila-translations)
-   "LASNA"                 (:kevyt-valinta/lasna kevyt-valinta-ilmoittautumisen-tila-translations)
-   "POISSA"                (:kevyt-valinta/poissa kevyt-valinta-ilmoittautumisen-tila-translations)})
+  {"EI_TEHTY"              (:kevyt-valinta/ei-tehty virkailija-texts)
+   "LASNA_KOKO_LUKUVUOSI"  (:kevyt-valinta/lasna-koko-lukuvuosi virkailija-texts)
+   "POISSA_KOKO_LUKUVUOSI" (:kevyt-valinta/poissa-koko-lukuvuosi virkailija-texts)
+   "EI_ILMOITTAUTUNUT"     (:kevyt-valinta/ei-ilmoittautunut virkailija-texts)
+   "LASNA_SYKSY"           (:kevyt-valinta/lasna-syksy virkailija-texts)
+   "POISSA_SYKSY"          (:kevyt-valinta/poissa-syksy virkailija-texts)
+   "LASNA"                 (:kevyt-valinta/lasna virkailija-texts)
+   "POISSA"                (:kevyt-valinta/poissa virkailija-texts)})
 
 (def application-hakukohde-review-states
   [["unreviewed" (:unreviewed state-translations)]

--- a/src/cljc/ataru/application/review_states.cljc
+++ b/src/cljc/ataru/application/review_states.cljc
@@ -28,7 +28,7 @@
    ["selected" (:selected state-translations)]
    ["rejected" (:rejected state-translations)]])
 
-(def valinnan-tila-i18n-mapping
+(def valinnan-tila-translation-key-mapping
   {"HYLATTY"                :hylatty
    "VARALLA"                :varalla
    "PERUUNTUNUT"            :peruuntunut
@@ -38,11 +38,11 @@
    "PERUUTETTU"             :peruutettu
    "KESKEN"                 :kesken})
 
-(def julkaisun-tila-i18n-mapping
+(def julkaisun-tila-translation-key-mapping
   {true  :julkaistu
    false :ei-julkaistu})
 
-(def vastaanotto-tila-i18n-mapping
+(def vastaanotto-tila-translation-key-mapping
   {"EI_VASTAANOTETTU_MAARA_AIKANA" :ei-vastaanotettu-maaraaikana
    "PERUNUT"                       :perunut
    "PERUUTETTU"                    :peruutettu
@@ -52,7 +52,7 @@
    "KESKEN"                        :kesken
    "VASTAANOTTANUT"                :vastaanottanut})
 
-(def ilmoittautumisen-tila-i18n-mapping
+(def ilmoittautumisen-tila-translation-key-mapping
   {"EI_TEHTY"              :ei-tehty
    "LASNA_KOKO_LUKUVUOSI"  :lasna-koko-lukuvuosi
    "POISSA_KOKO_LUKUVUOSI" :poissa-koko-lukuvuosi

--- a/src/cljc/ataru/application/review_states.cljc
+++ b/src/cljc/ataru/application/review_states.cljc
@@ -28,39 +28,39 @@
    ["selected" (:selected state-translations)]
    ["rejected" (:rejected state-translations)]])
 
-(def valinnan-tila-selection-state
-  {"HYLATTY"                (:kevyt-valinta/hylatty virkailija-texts)
-   "VARALLA"                (:kevyt-valinta/varalla virkailija-texts)
-   "PERUUNTUNUT"            (:kevyt-valinta/peruuntunut virkailija-texts)
-   "VARASIJALTA_HYVAKSYTTY" (:kevyt-valinta/varasijalta-hyvaksytty virkailija-texts)
-   "HYVAKSYTTY"             (:kevyt-valinta/hyvaksytty virkailija-texts)
-   "PERUNUT"                (:kevyt-valinta/perunut virkailija-texts)
-   "PERUUTETTU"             (:kevyt-valinta/peruutettu virkailija-texts)
-   "KESKEN"                 (:kevyt-valinta/kesken virkailija-texts)})
+(def valinnan-tila-i18n-mapping
+  {"HYLATTY"                :kevyt-valinta/hylatty
+   "VARALLA"                :kevyt-valinta/varalla
+   "PERUUNTUNUT"            :kevyt-valinta/peruuntunut
+   "VARASIJALTA_HYVAKSYTTY" :kevyt-valinta/varasijalta-hyvaksytty
+   "HYVAKSYTTY"             :kevyt-valinta/hyvaksytty
+   "PERUNUT"                :kevyt-valinta/perunut
+   "PERUUTETTU"             :kevyt-valinta/peruutettu
+   "KESKEN"                 :kevyt-valinta/kesken})
 
-(def julkaisun-tila-selection-state
-  {true  (:kevyt-valinta/julkaistu-hakijalle virkailija-texts)
-   false (:kevyt-valinta/ei-julkaistu virkailija-texts)})
+(def julkaisun-tila-i18n-mapping
+  {true  :kevyt-valinta/julkaistu-hakijalle
+   false :kevyt-valinta/ei-julkaistu})
 
-(def vastaanotto-tila-selection-state
-  {"EI_VASTAANOTETTU_MAARA_AIKANA" (:kevyt-valinta/ei-vastaanotettu-maaraaikana virkailija-texts)
-   "PERUNUT"                       (:kevyt-valinta/perunut virkailija-texts)
-   "PERUUTETTU"                    (:kevyt-valinta/peruutettu virkailija-texts)
-   "OTTANUT_VASTAAN_TOISEN_PAIKAN" (:kevyt-valinta/ottanut-vastaan-toisen-paikan virkailija-texts)
-   "EHDOLLISESTI_VASTAANOTTANUT"   (:kevyt-valinta/ehdollisesti-vastaanottanut virkailija-texts)
-   "VASTAANOTTANUT_SITOVASTI"      (:kevyt-valinta/vastaanottanut-sitovasti virkailija-texts)
-   "KESKEN"                        (:kevyt-valinta/kesken virkailija-texts)
-   "VASTAANOTTANUT"                (:kevyt-valinta/vastaanottanut virkailija-texts)})
+(def vastaanotto-tila-i18n-mapping
+  {"EI_VASTAANOTETTU_MAARA_AIKANA" :kevyt-valinta/ei-vastaanotettu-maaraaikana
+   "PERUNUT"                       :kevyt-valinta/perunut
+   "PERUUTETTU"                    :kevyt-valinta/peruutettu
+   "OTTANUT_VASTAAN_TOISEN_PAIKAN" :kevyt-valinta/ottanut-vastaan-toisen-paikan
+   "EHDOLLISESTI_VASTAANOTTANUT"   :kevyt-valinta/ehdollisesti-vastaanottanut
+   "VASTAANOTTANUT_SITOVASTI"      :kevyt-valinta/vastaanottanut-sitovasti
+   "KESKEN"                        :kevyt-valinta/kesken
+   "VASTAANOTTANUT"                :kevyt-valinta/vastaanottanut})
 
-(def ilmoittautumisen-tila-selection-state
-  {"EI_TEHTY"              (:kevyt-valinta/ei-tehty virkailija-texts)
-   "LASNA_KOKO_LUKUVUOSI"  (:kevyt-valinta/lasna-koko-lukuvuosi virkailija-texts)
-   "POISSA_KOKO_LUKUVUOSI" (:kevyt-valinta/poissa-koko-lukuvuosi virkailija-texts)
-   "EI_ILMOITTAUTUNUT"     (:kevyt-valinta/ei-ilmoittautunut virkailija-texts)
-   "LASNA_SYKSY"           (:kevyt-valinta/lasna-syksy virkailija-texts)
-   "POISSA_SYKSY"          (:kevyt-valinta/poissa-syksy virkailija-texts)
-   "LASNA"                 (:kevyt-valinta/lasna virkailija-texts)
-   "POISSA"                (:kevyt-valinta/poissa virkailija-texts)})
+(def ilmoittautumisen-tila-i18n-mapping
+  {"EI_TEHTY"              :kevyt-valinta/ei-tehty
+   "LASNA_KOKO_LUKUVUOSI"  :kevyt-valinta/lasna-koko-lukuvuosi
+   "POISSA_KOKO_LUKUVUOSI" :kevyt-valinta/poissa-koko-lukuvuosi
+   "EI_ILMOITTAUTUNUT"     :kevyt-valinta/ei-ilmoittautunut
+   "LASNA_SYKSY"           :kevyt-valinta/lasna-syksy
+   "POISSA_SYKSY"          :kevyt-valinta/poissa-syksy
+   "LASNA"                 :kevyt-valinta/lasna
+   "POISSA"                :kevyt-valinta/poissa})
 
 (def application-hakukohde-review-states
   [["unreviewed" (:unreviewed state-translations)]
@@ -85,12 +85,6 @@
    [:eligibility-state (:eligibility-state state-translations) application-hakukohde-eligibility-states]
    [:payment-obligation (:payment-obligation state-translations) application-payment-obligation-states]
    [:selection-state (:selection-state state-translations) application-hakukohde-selection-states]])
-
-(def kevyt-valinta-hakukohde-review-types
-  {:kevyt-valinta/valinnan-tila         {:fi "Valinta"}
-   :kevyt-valinta/julkaisun-tila        {:fi "Julkaisu"}
-   :kevyt-valinta/vastaanotto-tila      {:fi "Vastaanotto"}
-   :kevyt-valinta/ilmoittautumisen-tila {:fi "Ilmoittautuminen"}})
 
 (def hakukohde-review-types-map
   (util/group-by-first first hakukohde-review-types))

--- a/src/cljc/ataru/application/review_states.cljc
+++ b/src/cljc/ataru/application/review_states.cljc
@@ -29,38 +29,38 @@
    ["rejected" (:rejected state-translations)]])
 
 (def valinnan-tila-i18n-mapping
-  {"HYLATTY"                :kevyt-valinta/hylatty
-   "VARALLA"                :kevyt-valinta/varalla
-   "PERUUNTUNUT"            :kevyt-valinta/peruuntunut
-   "VARASIJALTA_HYVAKSYTTY" :kevyt-valinta/varasijalta-hyvaksytty
-   "HYVAKSYTTY"             :kevyt-valinta/hyvaksytty
-   "PERUNUT"                :kevyt-valinta/perunut
-   "PERUUTETTU"             :kevyt-valinta/peruutettu
-   "KESKEN"                 :kevyt-valinta/kesken})
+  {"HYLATTY"                :hylatty
+   "VARALLA"                :varalla
+   "PERUUNTUNUT"            :peruuntunut
+   "VARASIJALTA_HYVAKSYTTY" :varasijalta-hyvaksytty
+   "HYVAKSYTTY"             :hyvaksytty
+   "PERUNUT"                :perunut
+   "PERUUTETTU"             :peruutettu
+   "KESKEN"                 :kesken})
 
 (def julkaisun-tila-i18n-mapping
-  {true  :kevyt-valinta/julkaistu-hakijalle
-   false :kevyt-valinta/ei-julkaistu})
+  {true  :julkaistu
+   false :ei-julkaistu})
 
 (def vastaanotto-tila-i18n-mapping
-  {"EI_VASTAANOTETTU_MAARA_AIKANA" :kevyt-valinta/ei-vastaanotettu-maaraaikana
-   "PERUNUT"                       :kevyt-valinta/perunut
-   "PERUUTETTU"                    :kevyt-valinta/peruutettu
-   "OTTANUT_VASTAAN_TOISEN_PAIKAN" :kevyt-valinta/ottanut-vastaan-toisen-paikan
-   "EHDOLLISESTI_VASTAANOTTANUT"   :kevyt-valinta/ehdollisesti-vastaanottanut
-   "VASTAANOTTANUT_SITOVASTI"      :kevyt-valinta/vastaanottanut-sitovasti
-   "KESKEN"                        :kevyt-valinta/kesken
-   "VASTAANOTTANUT"                :kevyt-valinta/vastaanottanut})
+  {"EI_VASTAANOTETTU_MAARA_AIKANA" :ei-vastaanotettu-maaraaikana
+   "PERUNUT"                       :perunut
+   "PERUUTETTU"                    :peruutettu
+   "OTTANUT_VASTAAN_TOISEN_PAIKAN" :ottanut-vastaan-toisen-paikan
+   "EHDOLLISESTI_VASTAANOTTANUT"   :ehdollisesti-vastaanottanut
+   "VASTAANOTTANUT_SITOVASTI"      :vastaanottanut-sitovasti
+   "KESKEN"                        :kesken
+   "VASTAANOTTANUT"                :vastaanottanut})
 
 (def ilmoittautumisen-tila-i18n-mapping
-  {"EI_TEHTY"              :kevyt-valinta/ei-tehty
-   "LASNA_KOKO_LUKUVUOSI"  :kevyt-valinta/lasna-koko-lukuvuosi
-   "POISSA_KOKO_LUKUVUOSI" :kevyt-valinta/poissa-koko-lukuvuosi
-   "EI_ILMOITTAUTUNUT"     :kevyt-valinta/ei-ilmoittautunut
-   "LASNA_SYKSY"           :kevyt-valinta/lasna-syksy
-   "POISSA_SYKSY"          :kevyt-valinta/poissa-syksy
-   "LASNA"                 :kevyt-valinta/lasna
-   "POISSA"                :kevyt-valinta/poissa})
+  {"EI_TEHTY"              :ei-tehty
+   "LASNA_KOKO_LUKUVUOSI"  :lasna-koko-lukuvuosi
+   "POISSA_KOKO_LUKUVUOSI" :poissa-koko-lukuvuosi
+   "EI_ILMOITTAUTUNUT"     :ei-ilmoittautunut-maaraaikana
+   "LASNA_SYKSY"           :lasna-syksy
+   "POISSA_SYKSY"          :poissa-syksy
+   "LASNA"                 :lasna
+   "POISSA"                :poissa})
 
 (def application-hakukohde-review-states
   [["unreviewed" (:unreviewed state-translations)]

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1582,7 +1582,11 @@ You will receive a confirmation of your application to your email."}
    :kevyt-valinta/lasna-syksy                       {:fi "Läsnä syksy, poissa kevät"}
    :kevyt-valinta/poissa-syksy                      {:fi "Poissa syksy, läsnä kevät"}
    :kevyt-valinta/lasna                             {:fi "Läsnä, keväällä alkava koulutus"}
-   :kevyt-valinta/poissa                            {:fi "Poissa, keväällä alkava koulutus"}})
+   :kevyt-valinta/poissa                            {:fi "Poissa, keväällä alkava koulutus"}
+   :kevyt-valinta/valinta                           {:fi "Valinta"}
+   :kevyt-valinta/julkaisu                          {:fi "Julkaisu"}
+   :kevyt-valinta/vastaanotto                       {:fi "Vastaanotto"}
+   :kevyt-valinta/ilmoittautuminen                  {:fi "Ilmoittautuminen"}})
 
 (def state-translations
   {:active                 {:fi "Aktiivinen"

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1553,47 +1553,36 @@ You will receive a confirmation of your application to your email."}
                                                      :en "Multiple values"}
    :autosave-disabled                               {:fi "Automaattitalletus: pois päältä"
                                                      :sv "Automatspar: av"
-                                                     :en "Auto-save: disabled"}})
-
-(def kevyt-valinta-state-translations
-  {:kevyt-valinta/hylatty                {:fi "Hylätty"
-                                          :sv "Underkänd"
-                                          :en "Rejected"}
-   :kevyt-valinta/varalla                {:fi "Varalla"
-                                          :sv "På reserv"
-                                          :en "On reserve place"}
-   :kevyt-valinta/peruuntunut            {:fi "Peruuntunut"}
-   :kevyt-valinta/varasijalta-hyvaksytty {:fi "Varasijalta hyväksytty"}
-   :kevyt-valinta/hyvaksytty             {:fi "Hyväksytty"
-                                          :sv "Godkänd"
-                                          :en "Selected"}
-   :kevyt-valinta/perunut                {:fi "Perunut"}
-   :kevyt-valinta/peruutettu             {:fi "Peruutettu"}
-   :kevyt-valinta/kesken                 {:fi "Kesken"}})
-
-(def kevyt-valinta-julkaisun-tila-translations
-  {:kevyt-valinta/julkaistu-hakijalle {:fi "Julkaistu hakijalle"}
-   :kevyt-valinta/ei-julkaistu        {:fi "Julkaistu hakijalle"}})
-
-(def kevyt-valinta-vastaanotto-tila-translations
-  {:kevyt-valinta/ei-vastaanotettu-maaraaikana  {:fi "Ei vastaanotettu määräaikana"}
-   :kevyt-valinta/perunut                       {:fi "Perunut"}
-   :kevyt-valinta/peruutettu                    {:fi "Peruutettu"}
-   :kevyt-valinta/ottanut-vastaan-toisen-paikan {:fi "Ottanut vastaan toisen paikan"}
-   :kevyt-valinta/ehdollisesti-vastaanottanut   {:fi "Ehdollisesti vastaanottanut"}
-   :kevyt-valinta/vastaanottanut-sitovasti      {:fi "Vastaanottanut sitovasti"}
-   :kevyt-valinta/kesken                        {:fi "Kesken"}
-   :kevyt-valinta/vastaanottanut                {:fi "Vastaanottanut"}})
-
-(def kevyt-valinta-ilmoittautumisen-tila-translations
-  {:kevyt-valinta/ei-tehty              {:fi "Ei tehty"}
-   :kevyt-valinta/lasna-koko-lukuvuosi  {:fi "Läsnä (koko lukuvuosi)"}
-   :kevyt-valinta/poissa-koko-lukuvuosi {:fi "Poissa (koko lukuvuosi)"}
-   :kevyt-valinta/ei-ilmoittautunut     {:fi "Ei ilmoittautunut määräaikana"}
-   :kevyt-valinta/lasna-syksy           {:fi "Läsnä syksy, poissa kevät"}
-   :kevyt-valinta/poissa-syksy          {:fi "Poissa syksy, läsnä kevät"}
-   :kevyt-valinta/lasna                 {:fi "Läsnä, keväällä alkava koulutus"}
-   :kevyt-valinta/poissa                {:fi "Poissa, keväällä alkava koulutus"}})
+                                                     :en "Auto-save: disabled"}
+   :kevyt-valinta/hylatty                           {:fi "Hylätty"
+                                                     :sv "Underkänd"
+                                                     :en "Rejected"}
+   :kevyt-valinta/varalla                           {:fi "Varalla"
+                                                     :sv "På reserv"
+                                                     :en "On reserve place"}
+   :kevyt-valinta/peruuntunut                       {:fi "Peruuntunut"}
+   :kevyt-valinta/varasijalta-hyvaksytty            {:fi "Varasijalta hyväksytty"}
+   :kevyt-valinta/hyvaksytty                        {:fi "Hyväksytty"
+                                                     :sv "Godkänd"
+                                                     :en "Selected"}
+   :kevyt-valinta/julkaistu-hakijalle               {:fi "Julkaistu hakijalle"}
+   :kevyt-valinta/ei-julkaistu                      {:fi "Julkaistu hakijalle"}
+   :kevyt-valinta/ei-vastaanotettu-maaraaikana      {:fi "Ei vastaanotettu määräaikana"}
+   :kevyt-valinta/perunut                           {:fi "Perunut"}
+   :kevyt-valinta/peruutettu                        {:fi "Peruutettu"}
+   :kevyt-valinta/ottanut-vastaan-toisen-paikan     {:fi "Ottanut vastaan toisen paikan"}
+   :kevyt-valinta/ehdollisesti-vastaanottanut       {:fi "Ehdollisesti vastaanottanut"}
+   :kevyt-valinta/vastaanottanut-sitovasti          {:fi "Vastaanottanut sitovasti"}
+   :kevyt-valinta/kesken                            {:fi "Kesken"}
+   :kevyt-valinta/vastaanottanut                    {:fi "Vastaanottanut"}
+   :kevyt-valinta/ei-tehty                          {:fi "Ei tehty"}
+   :kevyt-valinta/lasna-koko-lukuvuosi              {:fi "Läsnä (koko lukuvuosi)"}
+   :kevyt-valinta/poissa-koko-lukuvuosi             {:fi "Poissa (koko lukuvuosi)"}
+   :kevyt-valinta/ei-ilmoittautunut                 {:fi "Ei ilmoittautunut määräaikana"}
+   :kevyt-valinta/lasna-syksy                       {:fi "Läsnä syksy, poissa kevät"}
+   :kevyt-valinta/poissa-syksy                      {:fi "Poissa syksy, läsnä kevät"}
+   :kevyt-valinta/lasna                             {:fi "Läsnä, keväällä alkava koulutus"}
+   :kevyt-valinta/poissa                            {:fi "Poissa, keväällä alkava koulutus"}})
 
 (def state-translations
   {:active                 {:fi "Aktiivinen"

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1554,39 +1554,43 @@ You will receive a confirmation of your application to your email."}
    :autosave-disabled                               {:fi "Automaattitalletus: pois päältä"
                                                      :sv "Automatspar: av"
                                                      :en "Auto-save: disabled"}
-   :kevyt-valinta/hylatty                           {:fi "Hylätty"
+   :hylatty                                         {:fi "Hylätty"
                                                      :sv "Underkänd"
                                                      :en "Rejected"}
-   :kevyt-valinta/varalla                           {:fi "Varalla"
+   :varalla                                         {:fi "Varalla"
                                                      :sv "På reserv"
                                                      :en "On reserve place"}
-   :kevyt-valinta/peruuntunut                       {:fi "Peruuntunut"}
-   :kevyt-valinta/varasijalta-hyvaksytty            {:fi "Varasijalta hyväksytty"}
-   :kevyt-valinta/hyvaksytty                        {:fi "Hyväksytty"
+   :peruuntunut                                     {:fi "Peruuntunut"}
+   :varasijalta-hyvaksytty                          {:fi "Varasijalta hyväksytty"}
+   :hyvaksytty                                      {:fi "Hyväksytty"
                                                      :sv "Godkänd"
                                                      :en "Selected"}
-   :kevyt-valinta/julkaistu-hakijalle               {:fi "Julkaistu hakijalle"}
-   :kevyt-valinta/ei-julkaistu                      {:fi "Julkaistu hakijalle"}
-   :kevyt-valinta/ei-vastaanotettu-maaraaikana      {:fi "Ei vastaanotettu määräaikana"}
-   :kevyt-valinta/perunut                           {:fi "Perunut"}
-   :kevyt-valinta/peruutettu                        {:fi "Peruutettu"}
-   :kevyt-valinta/ottanut-vastaan-toisen-paikan     {:fi "Ottanut vastaan toisen paikan"}
-   :kevyt-valinta/ehdollisesti-vastaanottanut       {:fi "Ehdollisesti vastaanottanut"}
-   :kevyt-valinta/vastaanottanut-sitovasti          {:fi "Vastaanottanut sitovasti"}
-   :kevyt-valinta/kesken                            {:fi "Kesken"}
-   :kevyt-valinta/vastaanottanut                    {:fi "Vastaanottanut"}
-   :kevyt-valinta/ei-tehty                          {:fi "Ei tehty"}
-   :kevyt-valinta/lasna-koko-lukuvuosi              {:fi "Läsnä (koko lukuvuosi)"}
-   :kevyt-valinta/poissa-koko-lukuvuosi             {:fi "Poissa (koko lukuvuosi)"}
-   :kevyt-valinta/ei-ilmoittautunut                 {:fi "Ei ilmoittautunut määräaikana"}
-   :kevyt-valinta/lasna-syksy                       {:fi "Läsnä syksy, poissa kevät"}
-   :kevyt-valinta/poissa-syksy                      {:fi "Poissa syksy, läsnä kevät"}
-   :kevyt-valinta/lasna                             {:fi "Läsnä, keväällä alkava koulutus"}
-   :kevyt-valinta/poissa                            {:fi "Poissa, keväällä alkava koulutus"}
-   :kevyt-valinta/valinta                           {:fi "Valinta"}
-   :kevyt-valinta/julkaisu                          {:fi "Julkaisu"}
-   :kevyt-valinta/vastaanotto                       {:fi "Vastaanotto"}
-   :kevyt-valinta/ilmoittautuminen                  {:fi "Ilmoittautuminen"}})
+   :julkaistu                                       {:fi "Julkaistu"}
+   :ei-julkaistu                                    {:fi "Ei julkaistu"}
+   :ei-vastaanotettu-maaraaikana                    {:fi "Ei vastaanotettu määräaikana"}
+   :perunut                                         {:fi "Perunut"}
+   :peruutettu                                      {:fi "Peruutettu"}
+   :ottanut-vastaan-toisen-paikan                   {:fi "Ottanut vastaan toisen paikan"}
+   :ehdollisesti-vastaanottanut                     {:fi "Ehdollisesti vastaanottanut"}
+   :vastaanottanut-sitovasti                        {:fi "Vastaanottanut sitovasti"}
+   :kesken                                          {:fi "Kesken"
+                                                     :sv "Inte färdig"
+                                                     :en "Incomplete"}
+   :vastaanottanut                                  {:fi "Vastaanottanut"}
+   :ei-tehty                                        {:fi "Ei tehty"}
+   :lasna-koko-lukuvuosi                            {:fi "Läsnä (koko lukuvuosi)"}
+   :poissa-koko-lukuvuosi                           {:fi "Poissa (koko lukuvuosi)"}
+   :ei-ilmoittautunut-maaraaikana                   {:fi "Ei ilmoittautunut määräaikana"}
+   :lasna-syksy                                     {:fi "Läsnä syksy, poissa kevät"}
+   :poissa-syksy                                    {:fi "Poissa syksy, läsnä kevät"}
+   :lasna                                           {:fi "Läsnä, keväällä alkava koulutus"}
+   :poissa                                          {:fi "Poissa, keväällä alkava koulutus"}
+   :valinta                                         {:fi "Valinta"
+                                                     :sv "Antagning"
+                                                     :en "Selection"}
+   :julkaisu                                        {:fi "Julkaisu"}
+   :vastaanotto                                     {:fi "Vastaanotto"}
+   :ilmoittautuminen                                {:fi "Ilmoittautuminen"}})
 
 (def state-translations
   {:active                 {:fi "Aktiivinen"

--- a/src/cljc/ataru/translations/translation_util.cljc
+++ b/src/cljc/ataru/translations/translation_util.cljc
@@ -26,12 +26,3 @@
     (cond-> text
             (some? params)
             (format-string params))))
-
-(defn get-virkailija-translation [key lang params]
-  (if-let [text-value (get virkailija-texts key)]
-    (if (fn? text-value)
-      (-> text-value
-          (apply params)
-          (get lang))
-      (get text-value lang))
-    (println "No key found in translations:" key)))

--- a/src/cljc/ataru/translations/translation_util.cljc
+++ b/src/cljc/ataru/translations/translation_util.cljc
@@ -1,5 +1,7 @@
 (ns ataru.translations.translation-util
-  (:require [ataru.translations.texts :refer [translation-mapping virkailija-texts]]))
+  (:require [ataru.translations.texts :refer [translation-mapping virkailija-texts]]
+            #?@(:cljs [[goog.string :as gstring]
+                       [goog.string.format]])))
 
 (defn get-translations [lang]
   (clojure.walk/prewalk (fn [x]
@@ -13,10 +15,17 @@
                              :sv "Översättning inte tillgänglig. Var vänlig och kontakta administrationen."
                              :en "Translation not available. Please contact an administrator."})
 
-(defn get-translation [key lang texts]
-  (-> texts
-      (get key not-found-translations)
-      (get lang)))
+(defn- format-string [text params]
+  #?(:cljs (apply gstring/format text params)
+     :clj  (apply format text params)))
+
+(defn get-translation [key lang texts & params]
+  (let [text (-> texts
+                 (get key not-found-translations)
+                 (get lang))]
+    (cond-> text
+            (some? params)
+            (format-string params))))
 
 (defn get-virkailija-translation [key lang params]
   (if-let [text-value (get virkailija-texts key)]

--- a/src/cljc/ataru/translations/translation_util.cljc
+++ b/src/cljc/ataru/translations/translation_util.cljc
@@ -13,8 +13,8 @@
                              :sv "Översättning inte tillgänglig. Var vänlig och kontakta administrationen."
                              :en "Translation not available. Please contact an administrator."})
 
-(defn get-translation [key lang]
-  (-> translation-mapping
+(defn get-translation [key lang texts]
+  (-> texts
       (get key not-found-translations)
       (get lang)))
 

--- a/src/cljc/ataru/translations/translation_util.cljc
+++ b/src/cljc/ataru/translations/translation_util.cljc
@@ -9,11 +9,13 @@
                             (get lang)))
                         translation-mapping))
 
+(def not-found-translations {:fi "Käännöstä ei ole saatavilla. Ole hyvä ja ota yhteyttä ylläpitoon."
+                             :sv "Översättning inte tillgänglig. Var vänlig och kontakta administrationen."
+                             :en "Translation not available. Please contact an administrator."})
+
 (defn get-translation [key lang]
   (-> translation-mapping
-      (get key {:fi "Käännöstä ei ole saatavilla. Ole hyvä ja ota yhteyttä ylläpitoon."
-                :sv "Översättning inte tillgänglig. Var vänlig och kontakta administrationen."
-                :en "Translation not available. Please contact an administrator."})
+      (get key not-found-translations)
       (get lang)))
 
 (defn get-virkailija-translation [key lang params]

--- a/src/cljc/ataru/translations/translation_util.cljc
+++ b/src/cljc/ataru/translations/translation_util.cljc
@@ -26,3 +26,10 @@
     (cond-> text
             (some? params)
             (format-string params))))
+
+(defn get-hakija-translation [key lang & params]
+  (apply get-translation
+         key
+         lang
+         translation-mapping
+         params))

--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -2,10 +2,12 @@
   (:require [markdown.core :refer [md->html]]
             [markdown.transformers :refer [transformer-vector]]
             [reagent.core :as reagent]
+            [re-frame.core :as re-frame]
             [clojure.string :as string]
             [goog.string :as s]
             [ataru.util :as util]
-            [ataru.cljs-util :refer [valid-uuid? get-translation get-virkailija-translation]])
+            [ataru.cljs-util :refer [valid-uuid? get-virkailija-translation]]
+            [ataru.translations.translation-util :as translations])
   (:import (goog.html.sanitizer HtmlSanitizer)))
 
 (defn answer-key [field-data]
@@ -80,7 +82,8 @@
                             (js/clearTimeout @timeout)
                             (reset!
                              timeout
-                             (js/setTimeout #(set-markdown-height component scroll-height) 200)))]
+                             (js/setTimeout #(set-markdown-height component scroll-height) 200)))
+         lang             (re-frame/subscribe [:application/form-language])]
      (reagent/create-class
       {:component-did-mount
        (fn [component]
@@ -117,8 +120,16 @@
               [:button.application__form-info-text-collapse-button
                {:on-click (fn [] (swap! collapsed not))}
                (if @collapsed
-                 [:span (str (get-translation :read-more) " ") [:i.zmdi.zmdi-hc-lg.zmdi-chevron-down]]
-                 [:span (str (get-translation :read-less) " ") [:i.zmdi.zmdi-hc-lg.zmdi-chevron-up]])])]))}))))
+                 [:span (str (translations/get-hakija-translation
+                               :read-more
+                               @lang)
+                             " ")
+                  [:i.zmdi.zmdi-hc-lg.zmdi-chevron-down]]
+                 [:span (str (translations/get-hakija-translation
+                               :read-less
+                               @lang)
+                             " ")
+                  [:i.zmdi.zmdi-hc-lg.zmdi-chevron-up]])])]))}))))
 
 (defn render-paragraphs [s]
   (->> (clojure.string/split s "\n")

--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -6,7 +6,7 @@
             [clojure.string :as string]
             [goog.string :as s]
             [ataru.util :as util]
-            [ataru.cljs-util :refer [valid-uuid? get-virkailija-translation]]
+            [ataru.cljs-util :refer [valid-uuid?]]
             [ataru.translations.translation-util :as translations])
   (:import (goog.html.sanitizer HtmlSanitizer)))
 
@@ -253,10 +253,10 @@
                    (not (include? id)))
       [:div.editor-form__id-container
        [:a.editor-form__copy-question-id
-        {:data-tooltip  (s/format (get-virkailija-translation (if answer? :copy-answer-id :copy-question-id))
+        {:data-tooltip  (s/format @(re-frame/subscribe [:editor/virkailija-translation (if answer? :copy-answer-id :copy-question-id)])
                           id)
          :on-mouse-down #(copy id)}
         "id"]
        (when (and (not (false? shared-use-warning?)) (not (valid-uuid? id)))
          [:span.editor-form__id-fixed
-          (get-virkailija-translation :id-in-shared-use)])])))
+          @(re-frame/subscribe [:editor/virkailija-translation :id-in-shared-use])])])))

--- a/src/cljs/ataru/application_common/fx.cljs
+++ b/src/cljs/ataru/application_common/fx.cljs
@@ -5,7 +5,8 @@
             [cljs.core.async :as async]
             [ataru.hakija.has-applied :refer [has-applied]]
             [ataru.hakija.application-validators :as validator]
-            [ataru.cljs-util :as util]))
+            [ataru.cljs-util :as util]
+            [ataru.translations.translation-util :as tu]))
 
 (defn http [caller-id
             {:keys [method
@@ -136,7 +137,8 @@
 
 (defn- confirm-window-close!
   [event]
-  (let [warning-label   (util/get-translation :window-close-warning)
+  (let [lang            @(re-frame/subscribe [:application/form-language])
+        warning-label   (tu/get-hakija-translation :window-close-warning lang)
         values-changed? @(re-frame/subscribe [:state-query [:application :values-changed?]])
         submit-status   @(re-frame/subscribe [:state-query [:application :submit-status]])]
     (when (and (some? values-changed?)

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -180,17 +180,12 @@
 (defn get-virkailija-label [key]
   (get @(subscribe [:editor/virkailija-texts]) key))
 
-(defn- format-string [text params]
-  (apply gstring/format text params))
-
 (defn get-virkailija-translation [key & params]
-  (let [lang @(subscribe [:editor/virkailija-lang])
-        text (get (get-virkailija-label key)
-                  lang
-                  (get tu/not-found-translations lang))]
-    (cond-> text
-            (some? params)
-            (format-string params))))
+  (apply translation-util/get-translation
+         key
+         @(subscribe [:editor/virkailija-lang])
+         @(subscribe [:editor/virkailija-texts])
+         params))
 
 (defn modify-event? [event]
   (some #{(:event-type event)} ["updated-by-applicant" "updated-by-virkailija"]))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -170,12 +170,5 @@
   (comp (partial resize-vector target-length)
         (fnil identity [])))
 
-(defn get-virkailija-translation [key & params]
-  (apply translation-util/get-translation
-         key
-         @(subscribe [:editor/virkailija-lang])
-         @(subscribe [:editor/virkailija-texts])
-         params))
-
 (defn modify-event? [event]
   (some #{(:event-type event)} ["updated-by-applicant" "updated-by-virkailija"]))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -179,11 +179,17 @@
 (defn get-virkailija-label [key]
   (get @(subscribe [:editor/virkailija-texts]) key))
 
-(defn get-virkailija-translation [key]
-  (let [lang @(subscribe [:editor/virkailija-lang])]
-    (get (get-virkailija-label key)
-         lang
-         (get tu/not-found-translations lang))))
+(defn- format-string [text params]
+  (apply gstring/format text params))
+
+(defn get-virkailija-translation [key & params]
+  (let [lang @(subscribe [:editor/virkailija-lang])
+        text (get (get-virkailija-label key)
+                  lang
+                  (get tu/not-found-translations lang))]
+    (cond-> text
+            (some? params)
+            (format-string params))))
 
 (defn modify-event? [event]
   (some #{(:event-type event)} ["updated-by-applicant" "updated-by-virkailija"]))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -1,5 +1,6 @@
 (ns ataru.cljs-util
-  (:require [clojure.string :refer [join]]
+  (:require [ataru.translations.translation-util :as tu]
+            [clojure.string :refer [join]]
             [cljs.core.match :refer-macros [match]]
             [cljs.reader :as reader :refer [read-string]]
             [cljs-uuid-utils.core :as uuid]
@@ -179,7 +180,10 @@
   (get @(subscribe [:editor/virkailija-texts]) key))
 
 (defn get-virkailija-translation [key]
-  (get (get-virkailija-label key) @(subscribe [:editor/virkailija-lang]) (str key)))
+  (let [lang @(subscribe [:editor/virkailija-lang])]
+    (get (get-virkailija-label key)
+         lang
+         (get tu/not-found-translations lang))))
 
 (defn modify-event? [event]
   (some #{(:event-type event)} ["updated-by-applicant" "updated-by-virkailija"]))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -171,17 +171,11 @@
         (fnil identity [])))
 
 (defn get-translation [key & params]
-  (if (some? params)
-    (apply gstring/format
-           (translation-util/get-translation
-             key
-             @(subscribe [:application/form-language])
-             texts/translation-mapping)
-           params)
-    (translation-util/get-translation
-      key
-      @(subscribe [:application/form-language])
-      texts/translation-mapping)))
+  (apply translation-util/get-translation
+         key
+         @(subscribe [:application/form-language])
+         texts/translation-mapping
+         params))
 
 (defn get-virkailija-label [key]
   (get @(subscribe [:editor/virkailija-texts]) key))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -170,13 +170,6 @@
   (comp (partial resize-vector target-length)
         (fnil identity [])))
 
-(defn get-translation [key & params]
-  (apply translation-util/get-translation
-         key
-         @(subscribe [:application/form-language])
-         texts/translation-mapping
-         params))
-
 (defn get-virkailija-translation [key & params]
   (apply translation-util/get-translation
          key

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -13,7 +13,8 @@
             [goog.string.format]
             [ataru.translations.translation-util :as translation-util]
             [goog.string :as gstring]
-            [goog.string.format])
+            [goog.string.format]
+            [ataru.translations.texts :as texts])
   (:import [goog.net Cookies]))
 
 (def wrap-scroll-to
@@ -172,9 +173,15 @@
 (defn get-translation [key & params]
   (if (some? params)
     (apply gstring/format
-      (translation-util/get-translation key @(subscribe [:application/form-language]))
-      params)
-    (translation-util/get-translation key @(subscribe [:application/form-language]))))
+           (translation-util/get-translation
+             key
+             @(subscribe [:application/form-language])
+             texts/translation-mapping)
+           params)
+    (translation-util/get-translation
+      key
+      @(subscribe [:application/form-language])
+      texts/translation-mapping)))
 
 (defn get-virkailija-label [key]
   (get @(subscribe [:editor/virkailija-texts]) key))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -177,9 +177,6 @@
          texts/translation-mapping
          params))
 
-(defn get-virkailija-label [key]
-  (get @(subscribe [:editor/virkailija-texts]) key))
-
 (defn get-virkailija-translation [key & params]
   (apply translation-util/get-translation
          key

--- a/src/cljs/ataru/hakija/application_hakukohde_component.cljs
+++ b/src/cljs/ataru/hakija/application_hakukohde_component.cljs
@@ -3,7 +3,7 @@
     [re-frame.core :refer [subscribe dispatch dispatch-sync]]
     [ataru.application-common.application-field-common :refer [scroll-to-anchor]]
     [ataru.util :as util]
-    [ataru.cljs-util :refer [get-translation]]
+    [ataru.translations.translation-util :as translations]
     [reagent.core :as r]))
 
 (defn hilighted-text->span [idx {:keys [text hilight]}]
@@ -30,12 +30,13 @@
 
 (defn- selected-hakukohde-row-remove
   [hakukohde-oid disabled?]
-  [:button.application__selected-hakukohde-row--remove
-   {:data-hakukohde-oid hakukohde-oid
-    :disabled           disabled?
-    :on-click           (when (not disabled?)
-                          hakukohde-remove-event-handler)}
-   (get-translation :remove)])
+  (let [lang @(subscribe [:application/form-language])]
+    [:button.application__selected-hakukohde-row--remove
+     {:data-hakukohde-oid hakukohde-oid
+      :disabled           disabled?
+      :on-click           (when (not disabled?)
+                            hakukohde-remove-event-handler)}
+     (translations/get-hakija-translation :remove lang)]))
 
 (defn- selected-hakukohde-increase-priority
   [hakukohde-oid priority-number disabled?]
@@ -65,16 +66,17 @@
      [selected-hakukohde-decrease-priority hakukohde-oid priority-number disabled?]]))
 
 (defn- offending-priorization [should-be-higher should-be-lower]
-  [:div.application__selected-hakukohde-row--offending-priorization
-   [:i.zmdi.zmdi-alert-circle]
-   [:div
-    [:div.application__selected-hakukohde-row--offending-priorization-heading
-     (get-translation :application-priorization-invalid)]
-    [:div
-     (first (get-translation :should-be-higher-priorization-than))
-     [:em (str "\"" @(subscribe [:application/hakukohde-label should-be-higher]) "\"")]
-     (last (get-translation :should-be-higher-priorization-than))
-     [:em (str "\"" @(subscribe [:application/hakukohde-label should-be-lower]) "\"")]]]])
+  (let [lang @(subscribe [:application/form-language])]
+    [:div.application__selected-hakukohde-row--offending-priorization
+     [:i.zmdi.zmdi-alert-circle]
+     [:div
+      [:div.application__selected-hakukohde-row--offending-priorization-heading
+       (translations/get-hakija-translation :application-priorization-invalid lang)]
+      [:div
+       (first (translations/get-hakija-translation :should-be-higher-priorization-than lang))
+       [:em (str "\"" @(subscribe [:application/hakukohde-label should-be-higher]) "\"")]
+       (last (translations/get-hakija-translation :should-be-higher-priorization-than lang))
+       [:em (str "\"" @(subscribe [:application/hakukohde-label should-be-lower]) "\"")]]]]))
 
 (defn- selected-hakukohde-row
   [hakukohde-oid]
@@ -83,7 +85,8 @@
         haku-editable?                     @(subscribe [:application/hakukohteet-editable?])
         hakukohde-editable?                @(subscribe [:application/hakukohde-editable? hakukohde-oid])
         [should-be-lower should-be-higher] @(subscribe [:application/hakukohde-offending-priorization? hakukohde-oid])
-        rajaavat-hakukohteet               @(subscribe [:application/rajaavat-hakukohteet hakukohde-oid])]
+        rajaavat-hakukohteet               @(subscribe [:application/rajaavat-hakukohteet hakukohde-oid])
+        lang                               @(subscribe [:application/form-language])]
     [:div.application__selected-hakukohde-row.animated
      {:class (if deleting? "fadeOut" "fadeIn")}
      (when prioritize-hakukohteet?
@@ -96,11 +99,11 @@
       (when (not hakukohde-editable?)
         [:div.application__hakukohde-application-period-ended
          [:i.zmdi.zmdi-lock]
-         (get-translation :not-editable-application-period-ended)])
+         (translations/get-hakija-translation :not-editable-application-period-ended lang)])
       (when (not-empty rajaavat-hakukohteet)
         [:div.application__search-hit-hakukohde-row--limit-reached
          [:h3.application__search-hit-hakukohde-row--limit-reached-heading
-          (get-translation :application-limit-reached-in-hakukohderyhma)]
+          (translations/get-hakija-translation :application-limit-reached-in-hakukohderyhma lang)]
          (doall (for [hakukohde rajaavat-hakukohteet]
                   ^{:key (str "limitting-hakukohde-" (:oid hakukohde))}
                   [:div.application__search-hit-hakukohde-row--limitting-hakukohde
@@ -125,7 +128,8 @@
         aria-description-id  (str "hakukohde-search-hit-description-" hakukohde-oid)
         hakukohde-editable?  @(subscribe [:application/hakukohde-editable? hakukohde-oid])
         hakukohteet-full?    @(subscribe [:application/hakukohteet-full? hakukohde-oid])
-        rajaavat-hakukohteet @(subscribe [:application/rajaavat-hakukohteet hakukohde-oid])]
+        rajaavat-hakukohteet @(subscribe [:application/rajaavat-hakukohteet hakukohde-oid])
+        lang                 @(subscribe [:application/form-language])]
     [:div.application__search-hit-hakukohde-row
      [:div.application__search-hit-hakukohde-row--content
       [:div.application__hakukohde-header
@@ -137,12 +141,12 @@
       (when (not hakukohde-editable?)
         [:div.application__hakukohde-application-period-ended
          [:i.zmdi.zmdi-lock]
-         (get-translation :not-selectable-application-period-ended)])
+         (translations/get-hakija-translation :not-selectable-application-period-ended lang)])
       (when (and (not hakukohde-selected?)
                  (not-empty rajaavat-hakukohteet))
         [:div.application__search-hit-hakukohde-row--limit-reached
          [:h3.application__search-hit-hakukohde-row--limit-reached-heading
-          (get-translation :application-limit-reached-in-hakukohderyhma)]
+          (translations/get-hakija-translation :application-limit-reached-in-hakukohderyhma lang)]
          (doall (for [hakukohde rajaavat-hakukohteet]
                   ^{:key (str "limitting-hakukohde-" (:oid hakukohde))}
                   [:div.application__search-hit-hakukohde-row--limitting-hakukohde
@@ -158,13 +162,14 @@
                                   (not-empty rajaavat-hakukohteet))
           :aria-labelledby    aria-header-id
           :aria-describedby   aria-description-id}
-         (get-translation :add)])]]))
+         (translations/get-hakija-translation :add lang)])]]))
 
 (defn- hakukohde-selection-search
   []
   (let [hakukohde-hits         (subscribe [:application/hakukohde-hits])
         prioritize-hakukohteet (subscribe [:application/prioritize-hakukohteet?])
-        search-input           (r/atom @(subscribe [:application/hakukohde-query]))]
+        search-input           (r/atom @(subscribe [:application/hakukohde-query]))
+        lang                   (subscribe [:application/form-language])]
     (fn []
       [:div.application__hakukohde-selection
        [:div.application__hakukohde-selection-search-arrow-up
@@ -178,8 +183,8 @@
          [:input.application__form-text-input-in-box
           {:on-change   #(do (reset! search-input (.-value (.-target %)))
                              (dispatch [:application/hakukohde-query-change search-input]))
-           :title       (get-translation :search-application-options)
-           :placeholder (get-translation :search-application-options)
+           :title       (translations/get-hakija-translation :search-application-options @lang)
+           :placeholder (translations/get-hakija-translation :search-application-options @lang)
            :value       @search-input}]
          (when (not (empty? @search-input))
            [:div.application__form-clear-text-input-in-box
@@ -191,7 +196,7 @@
          (if (and
                (empty? @hakukohde-hits)
                (not (clojure.string/blank? @search-input)))
-           [:div.application__hakukohde-selection-search-no-hits (get-translation :no-hakukohde-search-hits)]
+           [:div.application__hakukohde-selection-search-no-hits (translations/get-hakija-translation :no-hakukohde-search-hits @lang)]
            (for [hakukohde-oid @hakukohde-hits]
              ^{:key (str "found-hakukohde-row-" hakukohde-oid)}
              [search-hit-hakukohde-row hakukohde-oid]))]
@@ -199,7 +204,7 @@
           [:div.application__show_more_hakukohdes_container
            [:span.application__show_more_hakukohdes
             {:on-click #(dispatch [:application/show-more-hakukohdes])}
-            (get-translation :show-more)]])]])))
+            (translations/get-hakija-translation :show-more @lang)]])]])))
 
 (defn- hakukohde-selection-header
   [field-descriptor]
@@ -208,15 +213,16 @@
    [scroll-to-anchor field-descriptor]])
 
 (defn- select-new-hakukohde-row []
-  (when @(subscribe [:application/hakukohteet-editable?])
-    (if @(subscribe [:application/hakukohteet-full?])
-      (let [max-hakukohteet @(subscribe [:application/max-hakukohteet])]
-        [:span.application__hakukohde-max-selected
-         (get-translation :applications_at_most max-hakukohteet)])
-      [:div.application__hakukohde-selection-open-search-wrapper
-       [:a.application__hakukohde-selection-open-search
-        {:on-click hakukohde-search-toggle-event-handler}
-        (get-translation :add-application-option)]])))
+  (let [lang @(subscribe [:application/form-language])]
+    (when @(subscribe [:application/hakukohteet-editable?])
+      (if @(subscribe [:application/hakukohteet-full?])
+        (let [max-hakukohteet @(subscribe [:application/max-hakukohteet])]
+          [:span.application__hakukohde-max-selected
+           (translations/get-hakija-translation :applications_at_most max-hakukohteet lang)])
+        [:div.application__hakukohde-selection-open-search-wrapper
+         [:a.application__hakukohde-selection-open-search
+          {:on-click hakukohde-search-toggle-event-handler}
+          (translations/get-hakija-translation :add-application-option lang)]]))))
 
 (defn hakukohteet
   [field-descriptor]

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -8,6 +8,7 @@
             [ataru.hakija.rules :as rules]
             [ataru.hakija.resumable-upload :as resumable-upload]
             [ataru.hakija.try-selection :refer [try-selection]]
+            [ataru.translations.translation-util :as translations]
             [cljs.core.match :refer-macros [match]]
             [ataru.hakija.application :refer [create-initial-answers
                                               create-application-to-submit
@@ -1349,7 +1350,7 @@
   :application/set-page-title
   (fn [{:keys [db]}]
     (let [lang-kw       (keyword (-> db :form :selected-language))
-          title-prefix  (util/get-translation :page-title)
+          title-prefix  (translations/get-hakija-translation :page-title lang-kw)
           title-suffix  (or
                           (lang-kw (-> db :form :tarjonta :haku-name))
                           (-> db :form :name lang-kw))]

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -3,7 +3,7 @@
             [ataru.hakija.banner :refer [banner]]
             [ataru.hakija.application-form-components :refer [editable-fields]]
             [ataru.hakija.hakija-readonly :as readonly-view]
-            [ataru.cljs-util :as util :refer [get-translation]]
+            [ataru.translations.translation-util :as translations]
             [re-frame.core :refer [subscribe dispatch]]
             [cljs.core.match :refer-macros [match]]
             [cljs-time.core :refer [to-default-time-zone now after?]]
@@ -28,10 +28,11 @@
         cannot-edit-because-in-processing? @(subscribe [:application/cannot-edit-because-in-processing?])
         editing?                           @(subscribe [:application/editing?])
         virkailija?                        @(subscribe [:application/virkailija?])
+        lang                               @(subscribe [:application/form-language])
         apply-dates                        (when-let [hakuaika @(subscribe [:application/haku-aika])]
                                              (if (:jatkuva-haku? hakuaika)
-                                               (get-translation :continuous-period)
-                                               [:span (str (get-translation :application-period)
+                                               (translations/get-hakija-translation :continuous-period lang)
+                                               [:span (str (translations/get-hakija-translation :application-period lang)
                                                            " "
                                                            (-> hakuaika :label :start selected-lang)
                                                            " - "
@@ -40,7 +41,7 @@
                                                 [:br]
                                                 (when (and (not (:on hakuaika))
                                                            (not virkailija?))
-                                                  (str " (" (get-translation :not-within-application-period) ")"))]))]
+                                                  (str " (" (translations/get-hakija-translation :not-within-application-period lang) ")"))]))]
     [:div
      [:div.application__header-container
       [:h1.application__header (or (-> form :tarjonta :haku-name selected-lang)
@@ -66,7 +67,7 @@
                 (not virkailija?))
        [:div.application__sub-header-container
         [:span.application__sub-header-modifying-prevented
-         (get-translation :application-processed-cant-modify)]])]))
+         (translations/get-hakija-translation :application-processed-cant-modify lang)]])]))
 
 (defn readonly-fields [form]
   (let [application (subscribe [:state-query [:application]])]
@@ -91,7 +92,8 @@
         can-apply?      (subscribe [:application/can-apply?])
         editing?        (subscribe [:state-query [:application :editing?]])
         expired         (subscribe [:state-query [:application :secret-expired?]])
-        delivery-status (subscribe [:state-query [:application :secret-delivery-status]])]
+        delivery-status (subscribe [:state-query [:application :secret-delivery-status]])
+        lang            (subscribe [:application/form-language])]
     (fn []
       [:div.application__form-content-area
        (when-not (or @load-failure?
@@ -102,15 +104,15 @@
          [:div.application__secret-expired
           [:div.application__secret-expired-icon
            [:i.zmdi.zmdi-lock-outline]]
-          [:h2 (get-translation :expired-secret-heading)]
-          [:p (get-translation :expired-secret-paragraph)]
+          [:h2 (translations/get-hakija-translation :expired-secret-heading @lang)]
+          [:p (translations/get-hakija-translation :expired-secret-paragraph @lang)]
           [:button.application__secret-resend-button
            {:disabled (some? @delivery-status)
             :on-click #(dispatch [:application/send-new-secret])}
            (if (= :completed @delivery-status)
-             (get-translation :expired-secret-sent)
-             (get-translation :expired-secret-button))]
-          [:p (get-translation :expired-secret-contact)]])
+             (translations/get-hakija-translation :expired-secret-sent @lang)
+             (translations/get-hakija-translation :expired-secret-button @lang))]
+          [:p (translations/get-hakija-translation :expired-secret-contact @lang)]])
 
        ^{:key (:id @form)}
        [application-header]
@@ -128,14 +130,15 @@
 (defn- submit-notification
   [hidden?]
   (fn []
-    [:div.application__submitted-submit-notification
-     [:div.application__submitted-submit-notification-inner
-      [:h1.application__submitted-submit-notification-heading
-       (get-translation :application-submitted)]]
-     [:div.application__submitted-submit-notification-inner
-      [:a.application__send-feedback-button.application__send-feedback-button--enabled
-       {:on-click #(reset! hidden? true)}
-       (get-translation :application-submitted-ok)]]]))
+    (let [lang @(subscribe [:application/form-language])]
+      [:div.application__submitted-submit-notification
+       [:div.application__submitted-submit-notification-inner
+        [:h1.application__submitted-submit-notification-heading
+         (translations/get-hakija-translation :application-submitted lang)]]
+       [:div.application__submitted-submit-notification-inner
+        [:a.application__send-feedback-button.application__send-feedback-button--enabled
+         {:on-click #(reset! hidden? true)}
+         (translations/get-hakija-translation :application-submitted-ok lang)]]])))
 
 (defn feedback-form
   [feedback-hidden?]
@@ -145,7 +148,8 @@
         rating-status     (subscribe [:state-query [:application :feedback :status]])
         virkailija-secret (subscribe [:state-query [:application :virkailija-secret]])
         show-feedback?    (reaction (and (= :submitted @submit-status)
-                                         (not @feedback-hidden?)))]
+                                         (not @feedback-hidden?)))
+        lang              (subscribe [:application/form-language])]
     (fn []
       (let [rated?     (= :rating-given @rating-status)
             submitted? (= :feedback-submitted @rating-status)]
@@ -156,7 +160,7 @@
             [:i.zmdi.zmdi-close.close-details-button-mark]]
            [:div.application-feedback-form-container
             (when (not submitted?)
-              [:h2.application-feedback-form__header (get-translation :feedback-header)])
+              [:h2.application-feedback-form__header (translations/get-hakija-translation :feedback-header @lang)])
             (when (not submitted?)
               [:div.application-feedback-form__rating-container.animated.zoomIn
                {:on-click      #(dispatch [:application/rating-submit (star-number-from-event %)])
@@ -175,13 +179,13 @@
                (let [stars-selected (or @stars @star-hovered)]
                  (if (and (int? stars-selected)
                           (< 0 stars-selected 6))
-                   (get (get-translation :feedback-ratings) stars-selected)
+                   (get (translations/get-hakija-translation :feedback-ratings @lang) stars-selected)
                    (gstring/unescapeEntities "&nbsp;")))])
             (when (not submitted?)
               [:div.application-feedback-form__text-feedback-container
                [:textarea.application__form-text-input.application__form-text-area.application__form-text-area__size-medium
                 {:on-change   #(dispatch [:application/rating-update-feedback (.-value (.-target %))])
-                 :placeholder (get-translation :feedback-text-placeholder)
+                 :placeholder (translations/get-hakija-translation :feedback-text-placeholder @lang)
                  :max-length  2000}]])
             (when (and (not submitted?)
                        rated?)
@@ -189,17 +193,17 @@
                {:on-click (fn [evt]
                             (.preventDefault evt)
                             (dispatch [:application/rating-feedback-submit]))}
-               (get-translation :feedback-send)])
+               (translations/get-hakija-translation :feedback-send @lang)])
             (when (and (not submitted?)
                        (not rated?))
               [:a.application__send-feedback-button.application__send-feedback-button--disabled
-               (get-translation :feedback-send)])
+               (translations/get-hakija-translation :feedback-send @lang)])
             (when (not submitted?)
-              [:div.application-feedback-form__disclaimer (get-translation :feedback-disclaimer)])
+              [:div.application-feedback-form__disclaimer (translations/get-hakija-translation :feedback-disclaimer @lang)])
             (when submitted?
               [:div.application__thanks
                [:i.zmdi.zmdi-thumb-up.application__thanks-icon]
-               [:span.application__thanks-text (get-translation :feedback-thanks)]])]])))))
+               [:span.application__thanks-text (translations/get-hakija-translation :feedback-thanks @lang)]])]])))))
 
 (defn- submitted-overlay
   []
@@ -215,14 +219,15 @@
          (when (not @submit-notification-hidden?) [submit-notification submit-notification-hidden?])]))))
 
 (defn error-display []
-  (let [error-code (subscribe [:state-query [:error :code]])]
+  (let [error-code (subscribe [:state-query [:error :code]])
+        lang       (subscribe [:application/form-language])]
     (fn [] (if-let [error-code @error-code]
              [:div.application__message-display
               {:class (if (some #(= error-code %) [:inactivated :network-offline])
                         "application__message-display--warning"
                         "application__message-display--error")}
               [:div.application__message-display--exclamation [:i.zmdi.zmdi-alert-triangle]]
-              [:div.application__message-display--details (get-translation error-code)]]))))
+              [:div.application__message-display--details (translations/get-hakija-translation error-code @lang)]]))))
 
 (defn form-view []
   [:div

--- a/src/cljs/ataru/hakija/pohjakoulutusristiriita.cljs
+++ b/src/cljs/ataru/hakija/pohjakoulutusristiriita.cljs
@@ -1,7 +1,6 @@
 (ns ataru.hakija.pohjakoulutusristiriita
   (:require [ataru.application-common.application-field-common :as common]
-            [ataru.cljs-util :as cljs-util :refer [get-translation]]
-            [ataru.util :as util]
+            [ataru.translations.translation-util :as translations]
             [re-frame.core :as re-frame]))
 
 (defn hakukohteet-wo-applicable-base-education
@@ -25,25 +24,26 @@
   (fn [db _] (hakukohteet-wo-applicable-base-education db)))
 
 (defn pohjakoulutusristiriita [field-descriptor]
-  [:div.application__wrapper-element
-   [:div.application__wrapper-heading
-    [:div.application__pohjakoulutusristiriita-alert
-     [:i.zmdi.zmdi-alert-circle]]
-    [common/scroll-to-anchor field-descriptor]]
-   [:div.application__wrapper-contents
-    [:div.application__form-field
-     [:div.application__pohjakoulutusristiriita-text
-      [common/markdown-paragraph
-       (get-in field-descriptor [:text @(re-frame/subscribe [:application/form-language])])]]
-     [:ul.application__pohjakoulutusristiriita-hakukohde-list
-      (doall
-       (for [oid @(re-frame/subscribe [:application/hakukohteet-wo-applicable-base-education])]
-         ^{:key (str "hakukohde-" oid)}
-         [:li.application__pohjakoulutusristiriita-hakukohde
-          [:p.application__pohjakoulutusristiriita-hakukohde-label
-           @(re-frame/subscribe [:application/hakukohde-label oid])]
-          [:p.application__pohjakoulutusristiriita-hakukohde-description
-           @(re-frame/subscribe [:application/hakukohde-description oid])]]))]
-     [:div.application__pohjakoulutusristiriita-hakukohteet-link
-      [:a {:href "#scroll-to-hakukohteet"}
-       (get-translation :muokkaa-hakukohteita)]]]]])
+  (let [lang @(re-frame/subscribe [:application/form-language])]
+    [:div.application__wrapper-element
+     [:div.application__wrapper-heading
+      [:div.application__pohjakoulutusristiriita-alert
+       [:i.zmdi.zmdi-alert-circle]]
+      [common/scroll-to-anchor field-descriptor]]
+     [:div.application__wrapper-contents
+      [:div.application__form-field
+       [:div.application__pohjakoulutusristiriita-text
+        [common/markdown-paragraph
+         (get-in field-descriptor [:text @(re-frame/subscribe [:application/form-language])])]]
+       [:ul.application__pohjakoulutusristiriita-hakukohde-list
+        (doall
+          (for [oid @(re-frame/subscribe [:application/hakukohteet-wo-applicable-base-education])]
+            ^{:key (str "hakukohde-" oid)}
+            [:li.application__pohjakoulutusristiriita-hakukohde
+             [:p.application__pohjakoulutusristiriita-hakukohde-label
+              @(re-frame/subscribe [:application/hakukohde-label oid])]
+             [:p.application__pohjakoulutusristiriita-hakukohde-description
+              @(re-frame/subscribe [:application/hakukohde-description oid])]]))]
+       [:div.application__pohjakoulutusristiriita-hakukohteet-link
+        [:a {:href "#scroll-to-hakukohteet"}
+         (translations/get-hakija-translation :muokkaa-hakukohteita lang)]]]]]))

--- a/src/cljs/ataru/virkailija/application/attachments/liitepyynto_information_request_view.cljs
+++ b/src/cljs/ataru/virkailija/application/attachments/liitepyynto_information_request_view.cljs
@@ -1,10 +1,7 @@
 (ns ataru.virkailija.application.attachments.liitepyynto-information-request-view
-  (:require [ataru.cljs-util :as cu]
-            [ataru.translations.texts :as texts]
-            [ataru.virkailija.date-time-picker :as date-time-picker]
+  (:require [ataru.virkailija.date-time-picker :as date-time-picker]
             ataru.virkailija.application.attachments.liitepyynto-information-request-subs
             ataru.virkailija.application.attachments.liitepyynto-information-request-handlers
-            [reagent.core :as reagent]
             [re-frame.core :as re-frame]))
 
 (defn send-toggle [application-key liitepyynto-key]
@@ -41,64 +38,62 @@
    {:for (str "liitepyynto-information-request-toggle-"
               application-key "-"
               (name liitepyynto-key))}
-   (cu/get-virkailija-translation :liitepyynto-deadline)])
+   @(re-frame/subscribe [:editor/virkailija-translation :liitepyynto-deadline])])
 
 (defn deadline-date-input [application-key liitepyynto-key]
   (let [value     (re-frame/subscribe
-                   [:liitepyynto-information-request/deadline-date
-                    application-key
-                    liitepyynto-key])
+                    [:liitepyynto-information-request/deadline-date
+                     application-key
+                     liitepyynto-key])
         on-change (fn [value]
                     (re-frame/dispatch
-                     [:liitepyynto-information-request/set-deadline-date
-                      application-key
-                      liitepyynto-key
-                      value]))]
-    (fn [_ _]
-      [date-time-picker/date-picker
-       (str "liitepyynto-deadline__date-input-"
-            application-key "-" (name liitepyynto-key))
-       "liitepyynto-deadline__date-input"
-       @value
-       (if (= "" @value) (cu/get-virkailija-translation :required) "")
-       on-change])))
+                      [:liitepyynto-information-request/set-deadline-date
+                       application-key
+                       liitepyynto-key
+                       value]))]
+    [date-time-picker/date-picker
+     (str "liitepyynto-deadline__date-input-"
+          application-key "-" (name liitepyynto-key))
+     "liitepyynto-deadline__date-input"
+     @value
+     (if (= "" @value) @(re-frame/subscribe [:editor/virkailija-translation :required]) "")
+     on-change]))
 
 (defn deadline-time-input [application-key liitepyynto-key]
   (let [value     (re-frame/subscribe
-                   [:liitepyynto-information-request/deadline-time
-                    application-key
-                    liitepyynto-key])
+                    [:liitepyynto-information-request/deadline-time
+                     application-key
+                     liitepyynto-key])
         on-change (fn [value]
                     (re-frame/dispatch
-                     [:liitepyynto-information-request/set-deadline-time
-                      application-key
-                      liitepyynto-key
-                      value])
+                      [:liitepyynto-information-request/set-deadline-time
+                       application-key
+                       liitepyynto-key
+                       value])
                     (re-frame/dispatch
-                     [:liitepyynto-information-request/debounced-save-deadline
-                      application-key
-                      liitepyynto-key]))]
-    (fn [_ _]
-      [date-time-picker/time-picker
-       (str "liitepyynto-deadline__time-input-"
-            application-key "-" (name liitepyynto-key))
-       "liitepyynto-deadline__time-input"
-       @value
-       (if (= "" @value) (cu/get-virkailija-translation :required) "")
-       on-change])))
+                      [:liitepyynto-information-request/debounced-save-deadline
+                       application-key
+                       liitepyynto-key]))]
+    [date-time-picker/time-picker
+     (str "liitepyynto-deadline__time-input-"
+          application-key "-" (name liitepyynto-key))
+     "liitepyynto-deadline__time-input"
+     @value
+     (if (= "" @value) @(re-frame/subscribe [:editor/virkailija-translation :required]) "")
+     on-change]))
 
 (defn deadline-date-label [application-key liitepyynto-key]
   [:label.liitepyynto-deadline__date-label
    {:for (str "liitepyynto-deadline__date-input-"
               application-key "-" (name liitepyynto-key))}
-   (cu/get-virkailija-translation :liitepyynto-deadline-date)])
+   @(re-frame/subscribe [:editor/virkailija-translation :liitepyynto-deadline-date])])
 
 (defn deadline-time-label [application-key liitepyynto-key]
   [:label.liitepyynto-deadline__time-label
    {:for (str "liitepyynto-deadline__time-input-"
               application-key "-" (name liitepyynto-key))}
-   (cu/get-virkailija-translation :liitepyynto-deadline-time)])
+   @(re-frame/subscribe [:editor/virkailija-translation :liitepyynto-deadline-time])])
 
 (defn deadline-error []
   [:span.liitepyynto-deadline__error
-   (cu/get-virkailija-translation :liitepyynto-deadline-error)])
+   @(re-frame/subscribe [:editor/virkailija-translation :liitepyynto-deadline-error])])

--- a/src/cljs/ataru/virkailija/application/attachments/virkailija_attachment_view.cljs
+++ b/src/cljs/ataru/virkailija/application/attachments/virkailija_attachment_view.cljs
@@ -2,7 +2,6 @@
   (:require [ataru.application.application-states :as application-states]
             [ataru.application.review-states :as review-states]
             [ataru.virkailija.application.attachments.virkailija-attachment-subs :as attachment-subs]
-            [ataru.cljs-util :as cu]
             [ataru.util :as u]
             [reagent.core :as reagent]
             [re-frame.core :as re-frame]
@@ -62,7 +61,7 @@
 
 (defn- attachment-skimming-filename [selected-attachment]
   (let [download-label     (gstring/format "%s (%s)"
-                                           (cu/get-virkailija-translation :load-attachment-in-skimming)
+                                           @(re-frame/subscribe [:editor/virkailija-translation :load-attachment-in-skimming])
                                            (-> selected-attachment :size u/size-bytes->str))
         download-url       (download-url selected-attachment)
         filename           (-> selected-attachment :filename)
@@ -79,13 +78,13 @@
        (cond (= :download-only display-capability)
              [:div.attachment-skimming-header__cannot-display-text.animated.fadeIn
               [:div.attachment-skimming-header__cannot-display-text-indicator]
-              [:span (cu/get-virkailija-translation :cannot-display-file-type-in-attachment-skimming)]]
+              [:span @(re-frame/subscribe [:editor/virkailija-translation :cannot-display-file-type-in-attachment-skimming])]]
              (and (= :provide-preview display-capability)
                   (> page-count pages-to-display))
              [:div.attachment-skimming-header__partial-preview-text.animated.fadeIn
               [:div.attachment-skimming-header__partial-preview-text-indicator]
               [:span
-               (cu/get-virkailija-translation :partial-preview-in-attachment-skimming)
+               @(re-frame/subscribe [:editor/virkailija-translation :partial-preview-in-attachment-skimming])
                (gstring/format "1%s%s/%s" non-breaking-range-dash pages-to-display page-count)]])]]]))
 
 (defn- attachment-skimming-state-list []

--- a/src/cljs/ataru/virkailija/application/hyvaksynnan_ehto/view.cljs
+++ b/src/cljs/ataru/virkailija/application/hyvaksynnan_ehto/view.cljs
@@ -1,7 +1,6 @@
 (ns ataru.virkailija.application.hyvaksynnan-ehto.view
   (:require [re-frame.core :as re-frame]
             [reagent.core :as r]
-            [ataru.cljs-util :as cu]
             [ataru.util :as util]
             ataru.virkailija.application.hyvaksynnan-ehto.subs))
 
@@ -30,7 +29,7 @@
                                           hakukohde-oid])))}]
      [:label.hyvaksynnan-ehto-ehdollisesti-hyvaksyttavissa__label
       {:for (str "hyvaksynnan-ehto-ehdollisesti-hyvaksyttavissa-" application-key "-" hakukohde-oid)}
-      (cu/get-virkailija-translation :ehdollisesti-hyvaksyttavissa)]]))
+      @(re-frame/subscribe [:editor/virkailija-translation :ehdollisesti-hyvaksyttavissa])]]))
 
 (defn ehto-koodi
   [_ _]
@@ -242,7 +241,7 @@
                                               application-key
                                               hakukohde-oid])]
          [:span.hyvaksynnan-ehto-error__text
-          (cu/get-virkailija-translation :operation-failed)])]
+          @(re-frame/subscribe [:editor/virkailija-translation :operation-failed])])]
       (when @(re-frame/subscribe [:hyvaksynnan-ehto/show-ehto-koodi?
                                   application-key
                                   hakukohde-oid])

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/view/virkailija_kevyt_valinta_common_view.cljs
@@ -1,6 +1,6 @@
 (ns ataru.virkailija.application.kevyt-valinta.view.virkailija-kevyt-valinta-common-view
   (:require [ataru.application-common.loaders.ellipsis-loader :as el]
-            [ataru.virkailija.application.kevyt-valinta.virkailija-kevyt-valinta-translations :as translations]
+            [ataru.virkailija.application.kevyt-valinta.virkailija-kevyt-valinta-translations :as i18n-mapping]
             [reagent.core :as reagent]
             [re-frame.core :as re-frame])
   (:require-macros [cljs.core.match :refer [match]]
@@ -39,19 +39,19 @@
                  "application-handling__kevyt-valinta-dropdown-chevron-open")}]]
      (when dropdown-open?
        [:div.application-handling__kevyt-valinta-dropdown.application-handling__kevyt-valinta-dropdown-item-list.animated.fadeIn
-        (map (fn [{value :value label :label}]
-               (let [current-value? (= value kevyt-valinta-property-value)]
-                 ^{:key (str (name kevyt-valinta-property) "-" value)}
-                 [:div.application-handling__kevyt-valinta-dropdown-item
-                  {:on-click (fn []
-                               (if current-value?
-                                 (re-frame/dispatch [:virkailija-kevyt-valinta/toggle-kevyt-valinta-dropdown kevyt-valinta-property])
-                                 (kevyt-valinta-on-dropdown-value-change value)))}
-                  [:span
-                   (when current-value?
-                     {:class "application-handling__kevyt-valinta-dropdown-label--selected"})
-                   label]]))
-             kevyt-valinta-dropdown-values)])]))
+        (doall (map (fn [{value :value label :label}]
+                      (let [current-value? (= value kevyt-valinta-property-value)]
+                        ^{:key (str (name kevyt-valinta-property) "-" value)}
+                        [:div.application-handling__kevyt-valinta-dropdown-item
+                         {:on-click (fn []
+                                      (if current-value?
+                                        (re-frame/dispatch [:virkailija-kevyt-valinta/toggle-kevyt-valinta-dropdown kevyt-valinta-property])
+                                        (kevyt-valinta-on-dropdown-value-change value)))}
+                         [:span
+                          (when current-value?
+                            {:class "application-handling__kevyt-valinta-dropdown-label--selected"})
+                          label]]))
+                    kevyt-valinta-dropdown-values))])]))
 
 (defn- kevyt-valinta-checkmark [kevyt-valinta-property application-key]
   (let [checkmark-state @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-checkmark-state kevyt-valinta-property application-key])
@@ -72,16 +72,16 @@
 
 (defn kevyt-valinta-dropdown-selection [kevyt-valinta-property]
   (let [ongoing-request-property               @(re-frame/subscribe [:virkailija-kevyt-valinta/ongoing-request-property])
-        lang                                   @(re-frame/subscribe [:editor/virkailija-lang])
         application-key                        @(re-frame/subscribe [:state-query [:application :selected-application-and-form :application :key]])
         kevyt-valinta-property-values          @(re-frame/subscribe [:virkailija-kevyt-valinta/allowed-kevyt-valinta-property-values
                                                                      kevyt-valinta-property
                                                                      application-key])
         kevyt-valinta-dropdown-values          (map (fn [kevyt-valinta-property-value]
                                                       {:value kevyt-valinta-property-value
-                                                       :label (translations/kevyt-valinta-selection-label kevyt-valinta-property
-                                                                                                          kevyt-valinta-property-value
-                                                                                                          lang)})
+                                                       :label (let [translation-key (i18n-mapping/kevyt-valinta-value-translation-key
+                                                                                      kevyt-valinta-property
+                                                                                      kevyt-valinta-property-value)]
+                                                                @(re-frame/subscribe [:editor/virkailija-translation translation-key]))})
                                                     kevyt-valinta-property-values)
         kevyt-valinta-property-value           @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-property-value
                                                                      kevyt-valinta-property
@@ -113,8 +113,7 @@
        ongoing-request-property])))
 
 (defn kevyt-valinta-checkbox-selection [kevyt-valinta-property]
-  (let [lang                                   (re-frame/subscribe [:editor/virkailija-lang])
-        ongoing-request-property               (re-frame/subscribe [:virkailija-kevyt-valinta/ongoing-request-property])
+  (let [ongoing-request-property               (re-frame/subscribe [:virkailija-kevyt-valinta/ongoing-request-property])
         application-key                        (re-frame/subscribe [:state-query [:application :selected-application-and-form :application :key]])
         kevyt-valinta-checkbox-state           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-selection-state
                                                                                kevyt-valinta-property
@@ -127,9 +126,10 @@
                                                                                @application-key]))
         kevyt-valinta-checkbox-values          (reaction (map (fn [kevyt-valinta-property-value]
                                                                 {:value kevyt-valinta-property-value
-                                                                 :label (translations/kevyt-valinta-selection-label kevyt-valinta-property
-                                                                                                                    kevyt-valinta-property-value
-                                                                                                                    @lang)})
+                                                                 :label (let [translation-key (i18n-mapping/kevyt-valinta-value-translation-key
+                                                                                                kevyt-valinta-property
+                                                                                                kevyt-valinta-property-value)]
+                                                                          @(re-frame/subscribe [:editor/virkailija-translation translation-key]))})
                                                               @kevyt-valinta-property-values))
         kevyt-valinta-checkbox-value           (reaction @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-property-value
                                                                                kevyt-valinta-property
@@ -194,9 +194,9 @@
          [el/ellipsis-loader])])))
 
 (defn kevyt-valinta-row [kevyt-valinta-property selection-component]
-  (let [lang                          @(re-frame/subscribe [:editor/virkailija-lang])
-        application-key               @(re-frame/subscribe [:state-query [:application :selected-application-and-form :application :key]])
-        kevyt-valinta-label           (translations/kevyt-valinta-review-type-label kevyt-valinta-property lang)
+  (let [application-key               @(re-frame/subscribe [:state-query [:application :selected-application-and-form :application :key]])
+        kevyt-valinta-label           (let [translation-key (i18n-mapping/kevyt-valinta-label-translation-key kevyt-valinta-property)]
+                                        @(re-frame/subscribe [:editor/virkailija-translation translation-key]))
         kevyt-valinta-selection-state @(re-frame/subscribe [:virkailija-kevyt-valinta/kevyt-valinta-selection-state
                                                             kevyt-valinta-property
                                                             application-key])

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_translations.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_translations.cljs
@@ -1,19 +1,17 @@
 (ns ataru.virkailija.application.kevyt-valinta.virkailija-kevyt-valinta-translations
   (:require [ataru.application.review-states :as review-states]))
 
-(defn kevyt-valinta-selection-label [kevyt-valinta-property
-                                     kevyt-valinta-property-value
-                                     lang]
-  (let [valinta-tulos-service->translation-mapping (case kevyt-valinta-property
-                                                     :kevyt-valinta/valinnan-tila review-states/valinnan-tila-selection-state
-                                                     :kevyt-valinta/julkaisun-tila review-states/julkaisun-tila-selection-state
-                                                     :kevyt-valinta/vastaanotto-tila review-states/vastaanotto-tila-selection-state
-                                                     :kevyt-valinta/ilmoittautumisen-tila review-states/ilmoittautumisen-tila-selection-state)]
-    (-> valinta-tulos-service->translation-mapping
-        (get kevyt-valinta-property-value)
-        lang)))
+(defn kevyt-valinta-value-translation-key [kevyt-valinta-property kevyt-valinta-property-value]
+  (let [i18n-mapping (case kevyt-valinta-property
+                       :kevyt-valinta/valinnan-tila review-states/valinnan-tila-i18n-mapping
+                       :kevyt-valinta/julkaisun-tila review-states/julkaisun-tila-i18n-mapping
+                       :kevyt-valinta/vastaanotto-tila review-states/vastaanotto-tila-i18n-mapping
+                       :kevyt-valinta/ilmoittautumisen-tila review-states/ilmoittautumisen-tila-i18n-mapping)]
+    (get i18n-mapping kevyt-valinta-property-value)))
 
-(defn kevyt-valinta-review-type-label [review-type lang]
-  (get-in review-states/kevyt-valinta-hakukohde-review-types
-          [review-type lang]
-          (str review-type)))
+(defn kevyt-valinta-label-translation-key [kevyt-valinta-property]
+  (case kevyt-valinta-property
+    :kevyt-valinta/valinnan-tila :kevyt-valinta/valinta
+    :kevyt-valinta/julkaisun-tila :kevyt-valinta/julkaisu
+    :kevyt-valinta/vastaanotto-tila :kevyt-valinta/vastaanotto
+    :kevyt-valinta/ilmoittautumisen-tila :kevyt-valinta/ilmoittautuminen))

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_translations.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_translations.cljs
@@ -11,7 +11,7 @@
 
 (defn kevyt-valinta-label-translation-key [kevyt-valinta-property]
   (case kevyt-valinta-property
-    :kevyt-valinta/valinnan-tila :kevyt-valinta/valinta
-    :kevyt-valinta/julkaisun-tila :kevyt-valinta/julkaisu
-    :kevyt-valinta/vastaanotto-tila :kevyt-valinta/vastaanotto
-    :kevyt-valinta/ilmoittautumisen-tila :kevyt-valinta/ilmoittautuminen))
+    :kevyt-valinta/valinnan-tila :valinta
+    :kevyt-valinta/julkaisun-tila :julkaisu
+    :kevyt-valinta/vastaanotto-tila :vastaanotto
+    :kevyt-valinta/ilmoittautumisen-tila :ilmoittautuminen))

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_translations.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_translations.cljs
@@ -3,10 +3,10 @@
 
 (defn kevyt-valinta-value-translation-key [kevyt-valinta-property kevyt-valinta-property-value]
   (let [i18n-mapping (case kevyt-valinta-property
-                       :kevyt-valinta/valinnan-tila review-states/valinnan-tila-i18n-mapping
-                       :kevyt-valinta/julkaisun-tila review-states/julkaisun-tila-i18n-mapping
-                       :kevyt-valinta/vastaanotto-tila review-states/vastaanotto-tila-i18n-mapping
-                       :kevyt-valinta/ilmoittautumisen-tila review-states/ilmoittautumisen-tila-i18n-mapping)]
+                       :kevyt-valinta/valinnan-tila review-states/valinnan-tila-translation-key-mapping
+                       :kevyt-valinta/julkaisun-tila review-states/julkaisun-tila-translation-key-mapping
+                       :kevyt-valinta/vastaanotto-tila review-states/vastaanotto-tila-translation-key-mapping
+                       :kevyt-valinta/ilmoittautumisen-tila review-states/ilmoittautumisen-tila-translation-key-mapping)]
     (get i18n-mapping kevyt-valinta-property-value)))
 
 (defn kevyt-valinta-label-translation-key [kevyt-valinta-property]

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -1501,7 +1501,7 @@
              :on-change #(dispatch [:application/toggle-only-selected-hakukohteet])}]
            [:label
             {:for "application-handling__review-checkbox--only-selected-hakukohteet"}
-            @(subscribe [:editor/virkailija-lang :only-selected-hakukohteet])]])]
+            @(subscribe [:editor/virkailija-translation :only-selected-hakukohteet])]])]
        [application-review-note-input]
        (->> (if @only-selected-hakukohteet
               @notes-for-selected

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -1,7 +1,7 @@
 (ns ataru.virkailija.application.view
   (:require [ataru.application.application-states :as application-states]
             [ataru.application.review-states :as review-states]
-            [ataru.cljs-util :as cljs-util :refer [get-virkailija-translation]]
+            [ataru.cljs-util :as cljs-util]
             [ataru.translations.texts :refer [state-translations general-texts]]
             [ataru.util :as util]
             [ataru.virkailija.application.application-search-control :refer [application-search-control]]
@@ -63,21 +63,21 @@
       [:span.application-handling__excel-request-container
        [:a.application-handling__excel-download-link.editor-form__control-button.editor-form__control-button--enabled.editor-form__control-button--variable-width
         {:on-click #(dispatch [:application/set-excel-popup-visibility true])}
-        (get-virkailija-translation :load-excel)]
+        @(subscribe [:editor/virkailija-translation :load-excel])]
        (when @visible?
          [:div.application-handling__popup__excel.application-handling__excel-request-popup
           [:div.application-handling__mass-edit-review-states-title-container
            [:h4.application-handling__mass-edit-review-states-title
-            (get-virkailija-translation :excel-request)]
+            @(subscribe [:editor/virkailija-translation :excel-request])]
            [:button.virkailija-close-button
             {:on-click #(dispatch [:application/set-excel-popup-visibility false])}
             [:i.zmdi.zmdi-close]]]
           [:div.application-handling__excel-request-row
-           [:div.application-handling__excel-request-heading (get-virkailija-translation :excel-included-ids)]]
+           [:div.application-handling__excel-request-heading @(subscribe [:editor/virkailija-translation :excel-included-ids])]]
           [:div.application-handling__excel-request-row
            [:textarea.application-handling__information-request-message-area.application-handling__information-request-message-area--large
             {:value       (or @included-ids "")
-             :placeholder (get-virkailija-translation :excel-include-all-placeholder)
+             :placeholder @(subscribe [:editor/virkailija-translation :excel-include-all-placeholder])
              :on-change   #(dispatch [:application/set-excel-request-included-ids (-> % .-target .-value)])}]]
           [:div.application-handling__excel-request-row
            [:form#excel-download-link
@@ -112,7 +112,7 @@
              :on-click (fn [e]
                          (.submit (.getElementById js/document "excel-download-link")))}
             [:span
-             (str (get-virkailija-translation :load-excel)
+             (str @(subscribe [:editor/virkailija-translation :load-excel])
                   (when @loading? " "))
              (when @loading?
                [:i.zmdi.zmdi-spinner.spin])]]]])])))
@@ -190,12 +190,12 @@
         [:span.application-handling__mass-edit-review-states-container
          [:a.application-handling__mass-edit-review-states-link.editor-form__control-button.editor-form__control-button--enabled.editor-form__control-button--variable-width
           {:on-click #(dispatch [:application/set-mass-update-popup-visibility true])}
-          (get-virkailija-translation :mass-edit)]
+          @(subscribe [:editor/virkailija-translation :mass-edit])]
          (when @visible?
            [:div.application-handling__mass-edit-review-states-popup.application-handling__popup
             [:div.application-handling__mass-edit-review-states-title-container
              [:h4.application-handling__mass-edit-review-states-title
-              (get-virkailija-translation :mass-edit)]
+              @(subscribe [:editor/virkailija-translation :mass-edit])]
              [:button.virkailija-close-button
               {:on-click #(dispatch [:application/set-mass-update-popup-visibility false])}
               [:i.zmdi.zmdi-close]]]
@@ -204,7 +204,7 @@
                @(subscribe [:application/haku-name haku-oid])
                (when hakukohde-oid
                  (str ", " @(subscribe [:application/hakukohde-name hakukohde-oid])))])
-            [:h4.application-handling__mass-edit-review-states-heading (get-virkailija-translation :from-state)]
+            [:h4.application-handling__mass-edit-review-states-heading @(subscribe [:editor/virkailija-translation :from-state])]
 
             (if @from-list-open?
               (into [:div.application-handling__review-state-list.application-handling__review-state-list--opened
@@ -216,7 +216,7 @@
                  (reset! submit-button-state :submit))
                (selected-or-default-mass-review-state-label selected-from-review-state from-states @review-state-counts)))
 
-            [:h4.application-handling__mass-edit-review-states-heading (get-virkailija-translation :to-state)]
+            [:h4.application-handling__mass-edit-review-states-heading @(subscribe [:editor/virkailija-translation :to-state])]
 
             (if @to-list-open?
               (into [:div.application-handling__review-state-list.application-handling__review-state-list--opened
@@ -237,7 +237,7 @@
                  {:on-click #(when-not button-disabled? (reset! submit-button-state :confirm))
                   :disabled button-disabled?}
                  [:span
-                  (str (get-virkailija-translation :change)
+                  (str @(subscribe [:editor/virkailija-translation :change])
                        (when @loading? " "))
                   (when @loading?
                     [:i.zmdi.zmdi-spinner.spin])]])
@@ -255,7 +255,7 @@
                               (reset! selected-to-review-state nil)
                               (reset! from-list-open? false)
                               (reset! to-list-open? false)))}
-               (get-virkailija-translation :confirm-change)])])]))))
+               @(subscribe [:editor/virkailija-translation :confirm-change])])])]))))
 
 (declare application-information-request-contains-modification-link)
 
@@ -271,18 +271,18 @@
       [:span.application-handling__mass-information-request-container
        [:a.application-handling__mass-information-request-link.editor-form__control-button.editor-form__control-button--enabled.editor-form__control-button--variable-width
         {:on-click #(dispatch [:application/set-mass-information-request-popup-visibility true])}
-        (get-virkailija-translation :mass-information-request)]
+        @(subscribe [:editor/virkailija-translation :mass-information-request])]
        (when @visible?
          [:div.application-handling__popup.application-handling__mass-information-request-popup
           [:div.application-handling__mass-edit-review-states-title-container
            [:h4.application-handling__mass-edit-review-states-title
-            (get-virkailija-translation :mass-information-request)]
+            @(subscribe [:editor/virkailija-translation :mass-information-request])]
            [:button.virkailija-close-button
             {:on-click #(dispatch [:application/set-mass-information-request-popup-visibility false])}
             [:i.zmdi.zmdi-close]]]
-          [:p (gstring/format (get-virkailija-translation :mass-information-request-email-n-recipients) @applications-count)]
+          [:p @(subscribe [:editor/virkailija-translation :mass-information-request-email-n-recipients @applications-count])]
           [:div.application-handling__information-request-row
-           [:div.application-handling__information-request-info-heading (get-virkailija-translation :mass-information-request-subject)]
+           [:div.application-handling__information-request-info-heading @(subscribe [:editor/virkailija-translation :mass-information-request-subject])]
            [:div.application-handling__information-request-text-input-container
             [:input.application-handling__information-request-text-input
              {:value     @subject
@@ -302,28 +302,28 @@
                            "application-handling__send-information-request-button--enabled"
                            "application-handling__send-information-request-button--disabled")
                :on-click #(dispatch [:application/confirm-mass-information-request])}
-              (get-virkailija-translation :mass-information-request-send)]
+              @(subscribe [:editor/virkailija-translation :mass-information-request-send])]
 
              :loading-applications
              [:button.application-handling__send-information-request-button.application-handling__send-information-request-button--disabled
               {:disabled true}
-              [:span (str (get-virkailija-translation :mass-information-request-send) " ")
+              [:span (str @(subscribe [:editor/virkailija-translation :mass-information-request-send]) " ")
                [:i.zmdi.zmdi-spinner.spin]]]
 
              :confirm
              [:button.application-handling__send-information-request-button.application-handling__send-information-request-button--confirm
               {:on-click #(dispatch [:application/submit-mass-information-request])}
-              (gstring/format (get-virkailija-translation :mass-information-request-confirm-n-messages) @applications-count)]
+              @(subscribe [:editor/virkailija-translation :mass-information-request-confirm-n-messages @applications-count])]
 
              :submitting
              [:div.application-handling__information-request-status
               [:i.zmdi.zmdi-hc-lg.zmdi-spinner.spin.application-handling__information-request-status-icon]
-              (get-virkailija-translation :mass-information-request-sending-messages)]
+              @(subscribe [:editor/virkailija-translation :mass-information-request-sending-messages])]
 
              :submitted
              [:div.application-handling__information-request-status
               [:i.zmdi.zmdi-hc-lg.zmdi-check-circle.application-handling__information-request-status-icon.application-handling__information-request-status-icon--sent]
-              (get-virkailija-translation :mass-information-request-messages-sent)])]])])))
+              @(subscribe [:editor/virkailija-translation :mass-information-request-messages-sent])])]])])))
 
 (defn- closed-row
   [on-click label]
@@ -341,7 +341,7 @@
        :checked   ensisijaisesti?
        :on-change #(dispatch [:application/set-ensisijaisesti
                               (not ensisijaisesti?)])}]
-     [:span (get-virkailija-translation :ensisijaisesti)]]))
+     [:span @(subscribe [:editor/virkailija-translation :ensisijaisesti])]]))
 
 (defn haku-applications-heading
   [_]
@@ -368,7 +368,7 @@
                            @(subscribe [:application/hakukohderyhma-name
                                         selected-hakukohderyhma-oid])
                            :else
-                           (get-virkailija-translation :all-hakukohteet)))
+                           @(subscribe [:editor/virkailija-translation :all-hakukohteet])))
          (when @list-opened
            [h-and-h/popup
             [h-and-h/search-input
@@ -500,7 +500,7 @@
                    review-states/application-hakukohde-processing-states
                    processing-state
                    @lang)
-                 (get-virkailija-translation :unprocessed))
+                 @(subscribe [:editor/virkailija-translation :unprocessed]))
                (when show-state-email-icon?
                  [:i.zmdi.zmdi-email.application-handling__list-row-email-icon])]]
              (when (:selection-state review-settings true)
@@ -513,7 +513,7 @@
                      review-states/application-hakukohde-selection-states
                      selection-state
                      @lang)
-                   (get-virkailija-translation :incomplete))]])]))
+                   @(subscribe [:editor/virkailija-translation :incomplete]))]])]))
         application-hakukohde-oids))))
 
 (defn- application-attachment-states
@@ -554,7 +554,8 @@
       :id       (str "application-list-row-" (:key application))}
      [:div.application-handling__list-row-person-info
       [:span.application-handling__list-row--application-applicant
-       [:span.application-handling__list-row--applicant-name (or applicant [:span.application-handling__list-row--applicant-unknown (get-virkailija-translation :unknown)])]
+       [:span.application-handling__list-row--applicant-name (or applicant [:span.application-handling__list-row--applicant-unknown
+                                                                            @(subscribe [:editor/virkailija-translation :unknown])])]
        [:span.application-handling__list-row--applicant-details (or (-> application :person :ssn) (-> application :person :dob))]]
       [:span.application-handling__list-row--application-time
        [:span.application-handling__list-row--time-day day]
@@ -635,7 +636,7 @@
                                                                                 []
                                                                                 (map first states)))])
                                           (dispatch [:application/reload-applications]))}]
-                    [:span (get-virkailija-translation :all)]]]]
+                    [:span @(subscribe [:editor/virkailija-translation :all])]]]]
                  (mapv
                    (fn [[review-state-id review-state-label]]
                      (let [filter-selected? (contains? (set @filter-sub) review-state-id)]
@@ -677,8 +678,8 @@
         [:span.application-handling__created-time-column-header
          {:on-click #(dispatch [:application/toggle-shown-time-column])}
          (if (= "created-time" @selected-time-column)
-           (get-virkailija-translation :last-modified)
-           (get-virkailija-translation :submitted-at))]
+           @(subscribe [:editor/virkailija-translation :last-modified])
+           @(subscribe [:editor/virkailija-translation :submitted-at]))]
         " |"
         [:i.zmdi
          {:on-click #(dispatch [:application/update-sort @selected-time-column])
@@ -718,33 +719,32 @@
 
 (defn- application-base-education-filters
   [filters-checkboxes]
-  (let [checkboxes            [[:pohjakoulutus_yo (get-virkailija-translation :pohjakoulutus_yo)]
-                               [:pohjakoulutus_lk (get-virkailija-translation :pohjakoulutus_lk)]
-                               [:pohjakoulutus_yo_kansainvalinen_suomessa (get-virkailija-translation :pohjakoulutus_yo_kansainvalinen_suomessa)]
-                               [:pohjakoulutus_yo_ammatillinen (get-virkailija-translation :pohjakoulutus_yo_ammatillinen)]
-                               [:pohjakoulutus_am (get-virkailija-translation :pohjakoulutus_am)]
-                               [:pohjakoulutus_amt (get-virkailija-translation :pohjakoulutus_amt)]
-                               [:pohjakoulutus_kk (get-virkailija-translation :pohjakoulutus_kk)]
-                               [:pohjakoulutus_yo_ulkomainen (get-virkailija-translation :pohjakoulutus_yo_ulkomainen)]
-                               [:pohjakoulutus_kk_ulk (get-virkailija-translation :pohjakoulutus_kk_ulk)]
-                               [:pohjakoulutus_ulk (get-virkailija-translation :pohjakoulutus_ulk)]
-                               [:pohjakoulutus_avoin (get-virkailija-translation :pohjakoulutus_avoin)]
-                               [:pohjakoulutus_muu (get-virkailija-translation :pohjakoulutus_muu)]]
+  (let [checkboxes            [[:pohjakoulutus_yo @(subscribe [:editor/virkailija-translation :pohjakoulutus_yo])]
+                               [:pohjakoulutus_lk @(subscribe [:editor/virkailija-translation :pohjakoulutus_lk])]
+                               [:pohjakoulutus_yo_kansainvalinen_suomessa @(subscribe [:editor/virkailija-translation :pohjakoulutus_yo_kansainvalinen_suomessa])]
+                               [:pohjakoulutus_yo_ammatillinen @(subscribe [:editor/virkailija-translation :pohjakoulutus_yo_ammatillinen])]
+                               [:pohjakoulutus_am @(subscribe [:editor/virkailija-translation :pohjakoulutus_am])]
+                               [:pohjakoulutus_amt @(subscribe [:editor/virkailija-translation :pohjakoulutus_amt])]
+                               [:pohjakoulutus_kk @(subscribe [:editor/virkailija-translation :pohjakoulutus_kk])]
+                               [:pohjakoulutus_yo_ulkomainen @(subscribe [:editor/virkailija-translation :pohjakoulutus_yo_ulkomainen])]
+                               [:pohjakoulutus_kk_ulk @(subscribe [:editor/virkailija-translation :pohjakoulutus_kk_ulk])]
+                               [:pohjakoulutus_ulk @(subscribe [:editor/virkailija-translation :pohjakoulutus_ulk])]
+                               [:pohjakoulutus_avoin @(subscribe [:editor/virkailija-translation :pohjakoulutus_avoin])]
+                               [:pohjakoulutus_muu @(subscribe [:editor/virkailija-translation :pohjakoulutus_muu])]]
         all-filters-selected? (subscribe [:application/all-pohjakoulutus-filters-selected?])]
-    (fn []
-      [:div.application-handling__filter-group
-       [:h3.application-handling__filter-group-heading (get-virkailija-translation :base-education)]
-       [:label.application-handling__filter-checkbox-label.application-handling__filter-checkbox-label--all
-        {:key   (str "application-filter-pohjakoulutus-any")
-         :class (when @all-filters-selected? "application-handling__filter-checkbox-label--checked")}
-        [:input.application-handling__filter-checkbox
-         {:type      "checkbox"
-          :checked   @all-filters-selected?
-          :on-change #(dispatch [:application/toggle-all-pohjakoulutus-filters @all-filters-selected?])}]
-        [:span "Kaikki"]]
-       (->> checkboxes
-            (map (fn [[id label]] (application-filter-checkbox filters-checkboxes label :base-education id)))
-            (doall))])))
+    [:div.application-handling__filter-group
+     [:h3.application-handling__filter-group-heading @(subscribe [:editor/virkailija-translation :base-education])]
+     [:label.application-handling__filter-checkbox-label.application-handling__filter-checkbox-label--all
+      {:key   (str "application-filter-pohjakoulutus-any")
+       :class (when @all-filters-selected? "application-handling__filter-checkbox-label--checked")}
+      [:input.application-handling__filter-checkbox
+       {:type      "checkbox"
+        :checked   @all-filters-selected?
+        :on-change #(dispatch [:application/toggle-all-pohjakoulutus-filters @all-filters-selected?])}]
+      [:span "Kaikki"]]
+     (->> checkboxes
+          (map (fn [[id label]] (application-filter-checkbox filters-checkboxes label :base-education id)))
+          (doall))]))
 
 (defn- select-rajaava-hakukohde [opened?]
   (let [ryhman-ensisijainen-hakukohde @(subscribe [:state-query [:application :rajaus-hakukohteella-value]])]
@@ -752,7 +752,7 @@
      [:button.application-handling__ensisijaisesti-hakukohteeseen-popup-button
       {:on-click #(swap! opened? not)}
       (if (nil? ryhman-ensisijainen-hakukohde)
-        (get-virkailija-translation :all-hakukohteet)
+        @(subscribe [:editor/virkailija-translation :all-hakukohteet])
         (or @(subscribe [:application/hakukohde-name ryhman-ensisijainen-hakukohde])
             [:i.zmdi.zmdi-spinner.spin]))]
      (when @opened?
@@ -809,7 +809,7 @@
                       (swap! filters-visible not))}
         [:span
          (gstring/format "%s (%d"
-                         (get-virkailija-translation :filter-applications)
+                         @(subscribe [:editor/virkailija-translation :filter-applications])
                          @applications-count)]
         (when @fetching?
           [:span "+ "
@@ -820,7 +820,7 @@
           [:span.application-handling__filters-count-separator "|"]
           [:a
            {:on-click #(dispatch [:application/remove-filters])}
-           (get-virkailija-translation :remove-filters)
+           @(subscribe [:editor/virkailija-translation :remove-filters])
            " (" @enabled-filter-count ")"]])
        (when @filters-visible
          [:div.application-handling__filters-popup
@@ -832,25 +832,25 @@
            [:div.application-handling__popup-column
             (when @show-ensisijaisesti?
               [:div.application-handling__filter-group
-               [:h3.application-handling__filter-group-heading (get-virkailija-translation :ensisijaisuus)]
+               [:h3.application-handling__filter-group-heading @(subscribe [:editor/virkailija-translation :ensisijaisuus])]
                [ensisijaisesti]
                (when @show-rajaa-hakukohteella?
                  [select-rajaava-hakukohde rajaava-hakukohde-opened?])])
             [:div.application-handling__filter-group
-             [:h3.application-handling__filter-group-heading (get-virkailija-translation :ssn)]
-             [application-filter-checkbox filters-checkboxes (get-virkailija-translation :without-ssn) :only-ssn :without-ssn]
-             [application-filter-checkbox filters-checkboxes (get-virkailija-translation :with-ssn) :only-ssn :with-ssn]]
+             [:h3.application-handling__filter-group-heading @(subscribe [:editor/virkailija-translation :ssn])]
+             [application-filter-checkbox filters-checkboxes @(subscribe [:editor/virkailija-translation :without-ssn]) :only-ssn :without-ssn]
+             [application-filter-checkbox filters-checkboxes @(subscribe [:editor/virkailija-translation :with-ssn]) :only-ssn :with-ssn]]
             [:div.application-handling__filter-group
-             [:h3.application-handling__filter-group-heading (get-virkailija-translation :identifying)]
-             [application-filter-checkbox filters-checkboxes (get-virkailija-translation :unidentified) :only-identified :unidentified]
-             [application-filter-checkbox filters-checkboxes (get-virkailija-translation :identified) :only-identified :identified]]
+             [:h3.application-handling__filter-group-heading @(subscribe [:editor/virkailija-translation :identifying])]
+             [application-filter-checkbox filters-checkboxes @(subscribe [:editor/virkailija-translation :unidentified]) :only-identified :unidentified]
+             [application-filter-checkbox filters-checkboxes @(subscribe [:editor/virkailija-translation :identified]) :only-identified :identified]]
             [:div.application-handling__filter-group
-             [:h3.application-handling__filter-group-heading (get-virkailija-translation :active-status)]
-             [application-filter-checkbox filters-checkboxes (get-virkailija-translation :active-status-active) :active-status :active]
-             [application-filter-checkbox filters-checkboxes (get-virkailija-translation :active-status-passive) :active-status :passive]]]
+             [:h3.application-handling__filter-group-heading @(subscribe [:editor/virkailija-translation :active-status])]
+             [application-filter-checkbox filters-checkboxes @(subscribe [:editor/virkailija-translations :active-status-active]) :active-status :active]
+             [application-filter-checkbox filters-checkboxes @(subscribe [:editor/virkailija-translation :active-status-passive]) :active-status :passive]]]
            [:div.application-handling__popup-column
             [:div.application-handling__filter-group
-             [:h3.application-handling__filter-group-heading (get-virkailija-translation :handling-notes)]
+             [:h3.application-handling__filter-group-heading @(subscribe [:editor/virkailija-translation :handling-notes])]
              (when (some? @selected-hakukohde-oid)
                [:div.application-handling__filter-hakukohde-name
                 @(subscribe [:application/hakukohde-name @selected-hakukohde-oid])])
@@ -864,7 +864,7 @@
              (when @show-eligibility-set-automatically-filter
                [:div.application-handling__filter-group
                 [:div.application-handling__filter-group-title
-                 (get-virkailija-translation :eligibility-set-automatically)]
+                 @(subscribe [:editor/virkailija-translation :eligibility-set-automatically])]
                 [:div.application-handling__filter-group-checkboxes
                  [application-filter-checkbox
                   filters-checkboxes
@@ -887,13 +887,13 @@
              :on-click (fn [_]
                          (reset! filters-visible false)
                          (dispatch [:application/apply-filters]))}
-            (get-virkailija-translation :filters-apply-button)]
+            @(subscribe [:editor/virkailija-translation :filters-apply-button])]
            [:a.editor-form__control-button.editor-form__control-button--variable-width
             {:class    (if @filters-changed?
                          "editor-form__control-button--enabled"
                          "editor-form__control-button--disabled")
              :on-click #(dispatch [:application/undo-filters])}
-            (get-virkailija-translation :filters-cancel-button)]]])])))
+            @(subscribe [:editor/virkailija-translation :filters-cancel-button])]]])])))
 
 (defn- application-list-header [applications]
   (let [review-settings (subscribe [:state-query [:application :review-settings :config]])]
@@ -901,27 +901,27 @@
      [:span.application-handling__list-row--applicant
       [application-list-basic-column-header
        "applicant-name"
-       (get-virkailija-translation :applicant)]
+       @(subscribe [:editor/virkailija-translation :applicant])]
       [application-filters]]
      [created-time-column-header]
      (when (:attachment-handling @review-settings true)
        [:span.application-handling__list-row--attachment-state
         [hakukohde-state-filter-controls
          :attachment-state-filter
-         (get-virkailija-translation :attachments)
+         @(subscribe [:editor/virkailija-translation :attachments])
          review-states/attachment-hakukohde-review-types-with-no-requirements
          (subscribe [:state-query [:application :attachment-state-counts]])]])
      [:span.application-handling__list-row--state
       [hakukohde-state-filter-controls
        :processing-state-filter
-       (get-virkailija-translation :processing-state)
+       @(subscribe [:editor/virkailija-translation :processing-state])
        review-states/application-hakukohde-processing-states
        (subscribe [:state-query [:application :review-state-counts]])]]
      (when (:selection-state @review-settings true)
        [:span.application-handling__list-row--selection
         [hakukohde-state-filter-controls
          :selection-state-filter
-         (get-virkailija-translation :selection)
+         @(subscribe [:editor/virkailija-translation :selection])
          review-states/application-hakukohde-selection-states
          (subscribe [:state-query [:application :selection-state-counts]])]])]))
 
@@ -940,12 +940,10 @@
      (if multiple-values?
        [:span
         [icon-many-checked]
-        [:span (get-virkailija-translation :multiple-values)]
-        ]
+        [:span @(subscribe [:editor/virkailija-translation :multiple-values])]]
        [:span
         [icon-check]
-        [:span label]
-        ])]))
+        [:span label]])]))
 
 (defn review-state-row [state-name current-review-state lang multiple-values? [review-state-id review-state-label]]
   (if (or (= current-review-state review-state-id)
@@ -977,7 +975,7 @@
     (fn []
       (let [active? (= "active" @state)]
         [:div.application-handling__review-deactivate-row
-         [:span.application-handling__review-deactivate-label (get-virkailija-translation :application-state)]
+         [:span.application-handling__review-deactivate-label @(subscribe [:editor/virkailija-translation :application-state])]
          [:div.application-handling__review-deactivate-toggle
           [:div.application-handling__review-deactivate-toggle-slider
            {:class    (cond-> ""
@@ -987,10 +985,10 @@
             :on-click #(when @can-edit?
                          (dispatch [:application/set-application-activeness (not active?)]))}
            [:div.application-handling__review-deactivate-toggle-label-left
-            (get-virkailija-translation :active)]
+            @(subscribe [:editor/virkailija-translation :active])]
            [:div.application-handling__review-deactivate-toggle-divider]
            [:div.application-handling__review-deactivate-toggle-label-right
-            (get-virkailija-translation :passive)]]]]))))
+            @(subscribe [:editor/virkailija-translation :passive])]]]]))))
 
 (defn- hakukohde-name [hakukohde-oid]
   (if-let [hakukohde-name @(subscribe [:application/hakukohde-name
@@ -1036,7 +1034,7 @@
                {:on-click (when-not (= 1 hakukohde-count) toggle-list-open)
                 :class (when (= 1 hakukohde-count) "application-handling__review-state-row--disabled")}
                (gstring/format "%s (%d)"
-                 (get-virkailija-translation :hakukohteet)
+                 @(subscribe [:editor/virkailija-translation :hakukohteet])
                  hakukohde-count)
                (when-not (= 1 hakukohde-count)
                  (if @list-opened
@@ -1062,7 +1060,7 @@
   (let [note                (subscribe [:state-query [:application :review-notes note-idx]])
         name                (reaction (if (and (:first-name @note) (:last-name @note))
                                         (str (:first-name @note) " " (:last-name @note))
-                                        (get-virkailija-translation :unknown-virkailija)))
+                                        @(subscribe [:editor/virkailija-translation :unknown-virkailija])))
         created-time        (reaction (when-let [created-time (:created-time @note)]
                                         (temporal/time->short-str created-time)))
         notes               (reaction (:notes @note))
@@ -1097,7 +1095,7 @@
                          (remove-note)
                          (start-removing-note)))}
          (if @removing?
-           (get-virkailija-translation :confirm-delete)
+           @(subscribe [:editor/virkailija-translation :confirm-delete])
            [:i.zmdi.zmdi-close])]]
        (when-not @details-folded?
          [:div.application-handling__review-note-details-row
@@ -1116,10 +1114,10 @@
                 (util/non-blank-val (:name org) [@lang :fi :sv :en])]]))]])
        [:div.application-handling__review-note-content
         (when (:hakukohde @note)
-          {:data-tooltip (str (get-virkailija-translation :eligibility-explanation)
+          {:data-tooltip (str @(subscribe [:editor/virkailija-translation :eligibility-explanation])
                               (when (not= "form" (:hakukohde @note))
                                 (gstring/format " %s %s"
-                                  (get-virkailija-translation :for-hakukohde)
+                                  @(subscribe [:editor/virkailija-translation :for-hakukohde])
                                   @hakukohde-name)))})
         @notes]])))
 
@@ -1140,7 +1138,7 @@
       [:div.application-handling__review-state-selected-container
        [:textarea.application-handling__review-note-input
         {:value       @review-note
-         :placeholder (get-virkailija-translation :rejection-reason)
+         :placeholder @(subscribe [:editor/virkailija-translation :rejection-reason])
          :on-change   (fn [event]
                         (let [note (.. event -target -value)]
                           (dispatch [:state-update #(assoc-in % [:application :notes note-state-path state-name] note)])))}]
@@ -1151,7 +1149,7 @@
          :class    (if button-enabled?
                      "application-handling__review-note-submit-button--enabled"
                      "application-handling__review-note-submit-button--disabled")}
-        (get-virkailija-translation :add)]
+        @(subscribe [:editor/virkailija-translation :add])]
        (->> @selected-notes-idx
             (map (fn [idx]
                    ^{:key (str "application-review-note-" idx)}
@@ -1183,11 +1181,11 @@
             (cond (and (= :eligibility-state kw)
                        @eligibility-automatically-checked?)
                   [:i.zmdi.zmdi-check-circle.zmdi-hc-lg.application-handling__eligibility-automatically-checked
-                   {:title (get-virkailija-translation :eligibility-set-automatically)}]
+                   {:title @(subscribe [:editor/virkailija-translation :eligibility-set-automatically])}]
                   (and (= :payment-obligation kw)
                        @payment-obligation-automatically-checked?)
                   [:i.zmdi.zmdi-check-circle.zmdi-hc-lg.application-handling__eligibility-automatically-checked
-                   {:title (get-virkailija-translation :payment-obligation-set-automatically)}])]
+                   {:title @(subscribe [:editor/virkailija-translation :payment-obligation-set-automatically])}])]
            (if @list-opened
              (into [:div.application-handling__review-state-list.application-handling__review-state-list--opened
                      {:on-click list-click}]
@@ -1248,7 +1246,7 @@
                         {:on-click (fn [e]
                                      (.stopPropagation e)
                                      (dispatch [:application/open-application-version-history event]))}
-                        (get-virkailija-translation :compare)]]
+                        @(subscribe [:editor/virkailija-translation :compare])]]
    [:ul.application-handling__event-row-update-list
     (for [[key field] @(subscribe [:application/changes-made-for-event (:id event)])]
       [:li
@@ -1281,36 +1279,36 @@
                  (:new-review-state event)
                  lang)]
       [[:span label " " (or (virkailija-initials-span event)
-                            (get-virkailija-translation :unknown))]
+                            @(subscribe [:editor/virkailija-translation :unknown]))]
        nil])
 
     {:event-type "updated-by-applicant"}
     (update-event
      (gstring/format "%s %d %s"
-                     (get-virkailija-translation :from-applicant)
+                     @(subscribe [:editor/virkailija-translation :from-applicant])
                      (count @(subscribe [:application/changes-made-for-event (:id event)]))
-                     (get-virkailija-translation :changes))
+                     @(subscribe [:editor/virkailija-translation :changes]))
      event)
 
     {:event-type "updated-by-virkailija"}
     (update-event
      [:span
-      (or (virkailija-initials-span event) (get-virkailija-translation :unknown))
+      (or (virkailija-initials-span event) @(subscribe [:editor/virkailija-translation :unknown]))
       (gstring/format " %s %d %s"
-                      (get-virkailija-translation :did)
+                      @(subscribe [:editor/virkailija-translation :did])
                       (count @(subscribe [:application/changes-made-for-event (:id event)]))
-                      (get-virkailija-translation :changes))]
+                      @(subscribe [:editor/virkailija-translation :changes]))]
      event)
 
     {:event-type "received-from-applicant"}
-    [[:span (get-virkailija-translation :application-received)]
+    [[:span @(subscribe [:editor/virkailija-translation :application-received])]
      nil]
 
     {:event-type "received-from-virkailija"}
     [[:span
       (virkailija-initials-span event)
       " "
-      (get-virkailija-translation :submitted-application)]
+      @(subscribe [:editor/virkailija-translation :submitted-application])]
      nil]
 
     {:event-type "hakukohde-review-state-change"}
@@ -1341,30 +1339,30 @@
 
     {:event-type "eligibility-state-automatically-changed"}
     [[:span
-      (get-virkailija-translation :eligibility)
+      @(subscribe [:editor/virkailija-translation :eligibility])
       ": "
       (some #(when (= (:new-review-state event) (first %))
                (get (second %) lang))
             review-states/application-hakukohde-eligibility-states)
       [:i.zmdi.zmdi-check-circle.zmdi-hc-lg.application-handling__eligibility-automatically-checked
-       {:title (get-virkailija-translation :eligibility-set-automatically)}]]
+       {:title @(subscribe [:editor/virkailija-translation :eligibility-set-automatically])}]]
      [:span @(subscribe [:application/hakukohde-and-tarjoaja-name (:hakukohde event)])]]
 
     {:event-type "payment-obligation-automatically-changed"}
     [[:span
-      (get-virkailija-translation :payment-obligation)
+      @(subscribe [:editor/virkailija-translation :payment-obligation])
       ": "
       (some #(when (= (:new-review-state event) (first %))
                (get (second %) lang))
             review-states/application-payment-obligation-states)
       [:i.zmdi.zmdi-check-circle.zmdi-hc-lg.application-handling__eligibility-automatically-checked
-       {:title (get-virkailija-translation :payment-obligation-set-automatically)}]]
+       {:title @(subscribe [:editor/virkailija-translation :payment-obligation-set-automatically])}]]
      [:span @(subscribe [:application/hakukohde-and-tarjoaja-name (:hakukohde event)])]]
 
     {:event-type "attachment-review-state-change"}
     [[:span
       (gstring/format "%s: %s "
-                      (get-virkailija-translation :attachment)
+                      @(subscribe [:editor/virkailija-translation :attachment])
                       (application-states/get-review-state-label-by-name
                        review-states/attachment-hakukohde-review-types
                        (:new-review-state event)
@@ -1373,39 +1371,39 @@
      nil]
 
     {:event-type "modification-link-sent"}
-    [[:span (get-virkailija-translation :confirmation-sent)]
+    [[:span @(subscribe [:editor/virkailija-translation :confirmation-sent])]
      nil]
 
     {:event-type "field-deadline-set"}
-    [[:span (str (get-virkailija-translation :liitepyynto-deadline-set) " ")
+    [[:span (str @(subscribe [:editor/virkailija-translation :liitepyynto-deadline-set]) " ")
       (virkailija-initials-span event)]
      [:div
       [:div
-       [:span (str (get-virkailija-translation :attachment) ": ")]
+       [:span (str @(subscribe [:editor/virkailija-translation :attachment]) ": ")]
        [:span @(subscribe [:application/field-label (:review-key event)])]]
       [:div
-       [:span (str (get-virkailija-translation :liitepyynto-deadline-date) ": ")]
+       [:span (str @(subscribe [:editor/virkailija-translation :liitepyynto-deadline-date]) ": ")]
        [:span (t/time->short-str (:new-review-state event))]]
       (event-organizations-list event lang)]]
 
     {:event-type "field-deadline-unset"}
-    [[:span (str (get-virkailija-translation :liitepyynto-deadline-unset) " ")
+    [[:span (str @(subscribe [:editor/virkailija-translation :liitepyynto-deadline-unset]) " ")
       (virkailija-initials-span event)]
      [:div
       [:div
-       [:span (str (get-virkailija-translation :attachment) ": ")]
+       [:span (str @(subscribe [:editor/virkailija-translation :attachment]) ": ")]
        [:span @(subscribe [:application/field-label (:review-key event)])]]
       (event-organizations-list event lang)]]
 
     {:event-type "ehto-hakukohteessa-set"}
-    [[:span (get-virkailija-translation :ehdollisesti-hyvaksyttavissa)]
+    [[:span @(subscribe [:editor/virkailija-translation :ehdollisesti-hyvaksyttavissa])]
      [:div
       [:div @(subscribe [:application/hakukohde-and-tarjoaja-name (:hakukohde event)])]
       [:div.application-handling__event-row--ehto-hakukohteessa
        (util/non-blank-val (:ehto event) [lang :fi :sv :en])]]]
 
     {:event-type "ehto-hakukohteessa-unset"}
-    [[:span (get-virkailija-translation :ei-ehdollisesti-hyvaksyttavissa)]
+    [[:span @(subscribe [:editor/virkailija-translation :ei-ehdollisesti-hyvaksyttavissa])]
      [:div
       [:div
        [:span @(subscribe [:application/hakukohde-and-tarjoaja-name (:hakukohde event)])]]]]
@@ -1413,8 +1411,8 @@
     {:subject _ :message _ :message-type message-type}
     [[:span
       (if (= message-type "mass-information-request")
-        (get-virkailija-translation :mass-information-request-sent)
-        (get-virkailija-translation :information-request-sent))
+        @(subscribe [:editor/virkailija-translation :mass-information-request-sent])
+        @(subscribe [:editor/virkailija-translation :information-request-sent]))
       " "
       (virkailija-initials-span event)]
      [:div.application-handling__event-row--message
@@ -1424,7 +1422,7 @@
        (:message event)]]]
 
     :else
-    [[:span (get-virkailija-translation :unknown)]
+    [[:span @(subscribe [:editor/virkailija-translation :unknown])]
      nil]))
 
 (defn event-row
@@ -1451,7 +1449,7 @@
 
 (defn application-review-events []
   [:div.application-handling__event-list
-   [:div.application-handling__review-header (get-virkailija-translation :events)]
+   [:div.application-handling__review-header @(subscribe [:editor/virkailija-translation :events])]
    (doall
     (map-indexed
      (fn [i event]
@@ -1483,7 +1481,7 @@
                      (if @only-selected-hakukohteet
                        (dispatch [:application/add-review-notes @input-value nil])
                        (dispatch [:application/add-review-note @input-value nil])))}
-        (get-virkailija-translation :add)]])))
+        @(subscribe [:editor/virkailija-translation :add])]])))
 
 (defn application-review-notes []
   (let [notes                            (subscribe [:application/review-note-indexes-excluding-eligibility])
@@ -1493,7 +1491,7 @@
     (fn []
       [:div.application-handling__review-row--nocolumn
        [:div.application-handling__review-header
-        (get-virkailija-translation :notes)
+        @(subscribe [:editor/virkailija-translation :notes])
         (when (< 0 (count @selected-review-hakukohde))
           [:div.application-handling__review-filters
            [:input.application-handling__review-checkbox
@@ -1503,7 +1501,7 @@
              :on-change #(dispatch [:application/toggle-only-selected-hakukohteet])}]
            [:label
             {:for "application-handling__review-checkbox--only-selected-hakukohteet"}
-            (get-virkailija-translation :only-selected-hakukohteet)]])]
+            @(subscribe [:editor/virkailija-lang :only-selected-hakukohteet])]])]
        [application-review-note-input]
        (->> (if @only-selected-hakukohteet
               @notes-for-selected
@@ -1542,7 +1540,7 @@
           (when @settings-visible?
             [review-settings-checkbox :score])
           [:div.application-handling__review-header.application-handling__review-header--points
-           (get-virkailija-translation :points)]
+           @(subscribe [:editor/virkailija-translation :points])]
           [:input.application-handling__score-input
            {:type      "text"
             :value     @display-value
@@ -1567,14 +1565,14 @@
       :class  (when (or @settings-visible? (not @can-edit?))
                 "application-handling__button--disabled")
       :target "_blank"}
-     (get-virkailija-translation (if superuser?
-                                   :edit-application-with-rewrite
-                                   :edit-application))]))
+     @(subscribe [:editor/virkailija-translation (if superuser?
+                                                   :edit-application-with-rewrite
+                                                   :edit-application)])]))
 
 (defn- application-information-request-recipient []
   (let [email (subscribe [:state-query [:application :selected-application-and-form :application :answers :email :value]])]
     [:div.application-handling__information-request-row
-     [:div.application-handling__information-request-info-heading (get-virkailija-translation :receiver)]
+     [:div.application-handling__information-request-info-heading @(subscribe [:editor/virkailija-translation :receiver])]
      [:div @email]]))
 
 (defn- application-information-request-subject []
@@ -1602,8 +1600,8 @@
   (let [enabled?      (subscribe [:application/information-request-submit-enabled?])
         request-state (subscribe [:state-query [:application :information-request :state]])
         button-text   (reaction (if (= @request-state :submitting)
-                                  (get-virkailija-translation :sending-information-request)
-                                  (get-virkailija-translation :send-information-request)))]
+                                  @(subscribe [:editor/virkailija-translation :sending-information-request])
+                                  @(subscribe [:editor/virkailija-translation :send-information-request])))]
     (fn []
       [:div.application-handling__information-request-row
        [:button.application-handling__send-information-request-button
@@ -1618,7 +1616,7 @@
 (defn- application-information-request-header []
   (let [request-state (subscribe [:state-query [:application :information-request :state]])]
     [:div.application-handling__information-request-header
-     (get-virkailija-translation :send-information-request-to-applicant)
+     @(subscribe [:editor/virkailija-translation :send-information-request-to-applicant])
      (when (nil? @request-state)
        [:i.zmdi.zmdi-close-circle.application-handling__information-request-close-button
         {:on-click #(dispatch [:application/set-information-request-window-visibility false])}])]))
@@ -1627,12 +1625,12 @@
   [:div.application-handling__information-request-row.application-handling__information-request-row--checkmark-container
    [:div.application-handling__information-request-submitted-loader]
    [:div.application-handling__information-request-submitted-checkmark]
-   [:span.application-handling__information-request-submitted-text (get-virkailija-translation :information-request-sent)]])
+   [:span.application-handling__information-request-submitted-text @(subscribe [:editor/virkailija-translation :information-request-sent])]])
 
 (defn- application-information-request-contains-modification-link []
   [:div.application-handling__information-request-row
    [:p.application-handling__information-request-contains-modification-link
-    (get-virkailija-translation :edit-link-sent-automatically)]])
+    @(subscribe [:editor/virkailija-translation :edit-link-sent-automatically])]])
 
 (defn- application-information-request []
   (let [window-visible?      (subscribe [:state-query [:application :information-request :visible?]])
@@ -1656,7 +1654,7 @@
         [:div.application-handling__information-request-show-container-link
          [:a
           {:on-click #(dispatch [:application/set-information-request-window-visibility true])}
-          (get-virkailija-translation :send-information-request-to-applicant)]]))))
+          @(subscribe [:editor/virkailija-translation :send-information-request-to-applicant])]]))))
 
 (defn- application-resend-modify-link []
   (let [recipient         (subscribe [:state-query [:application :selected-application-and-form :application :answers :email :value]])
@@ -1674,7 +1672,7 @@
                      (if (or @settings-visible? (not @can-edit?))
                        " application-handling__send-information-request-button--cursor-default"
                        " application-handling__send-information-request-button--cursor-pointer"))}
-     [:div (get-virkailija-translation :send-confirmation-email-to-applicant)]
+     [:div @(subscribe [:editor/virkailija-translation :send-confirmation-email-to-applicant])]
      [:div.application-handling__resend-modify-application-link-email-text @recipient]]))
 
 (defn- application-resend-modify-link-confirmation []
@@ -1683,7 +1681,7 @@
       [:div.application-handling__resend-modify-link-confirmation.application-handling__button.animated.fadeIn
        {:class (when (= @state :disappearing) "animated fadeOut")}
        [:div.application-handling__resend-modify-link-confirmation-indicator]
-       (get-virkailija-translation :send-edit-link-to-applicant)])))
+       @(subscribe [:editor/virkailija-translation :send-edit-link-to-applicant])])))
 
 (defn- attachment-review-row [selected-attachment-keys all-similar-attachments lang]
   (let [list-opened (r/atom false)]
@@ -1798,8 +1796,10 @@
         [:div.application-handling__attachment-review-header
          [:div
           (gstring/format "%s %s (%d)"
-                          (if (= "form" (second (first (vals reviews)))) (get-virkailija-translation :of-form) (get-virkailija-translation :of-hakukohde))
-                          (.toLowerCase (get-virkailija-translation :attachments))
+                          (if (= "form" (second (first (vals reviews))))
+                            @(subscribe [:editor/virkailija-translation :of-form])
+                            @(subscribe [:editor/virkailija-translation :of-hakukohde]))
+                          (.toLowerCase @(subscribe [:editor/virkailija-translation :attachments]))
                           (count (keys reviews)))]]
         [:div.application__attachment-review-row
          [:div.application__attachment-review-info-row
@@ -1813,7 +1813,7 @@
                                                        selected-attachment-keys)]
                            (dispatch [:virkailija-attachments/toggle-attachment-selection attachments-to-toggle])))}]
           [:p.application__attachment-review-row-label
-           (get-virkailija-translation :select-all)]
+           @(subscribe [:editor/virkailija-translation :select-all])]
           [:div.application-handling__excel-request-row
            [:form#attachment-download-link
             {:action "/lomake-editori/api/files/zip"
@@ -1829,7 +1829,7 @@
             {:disabled (empty? selected-attachment-keys)
              :on-click (fn [e]
                          (.submit (.getElementById js/document "attachment-download-link")))}
-            (get-virkailija-translation :load-attachments)]]]]
+            @(subscribe [:editor/virkailija-translation :load-attachments])]]]]
         (doall (for [all-similar-attachments (vals reviews)]
                  ^{:key (:key (ffirst all-similar-attachments))}
                  [attachment-review-row selected-attachment-keys all-similar-attachments lang]))])]))
@@ -1863,7 +1863,7 @@
               [:div.application-handling__review-settings-indicator-inner]]
              [:div.application-handling__review-settings-header
               [:i.zmdi.zmdi-account.application-handling__review-settings-header-icon]
-              [:span.application-handling__review-settings-header-text (get-virkailija-translation :settings)]]]
+              [:span.application-handling__review-settings-header-text @(subscribe [:editor/virkailija-translation :settings])]]]
             [:div.application-handling__review
              (when show-attachment-review?
                [attachment-review-area attachment-reviews-for-hakukohde @lang])
@@ -1884,7 +1884,7 @@
                         [:span [:i.zmdi.zmdi-chevron-right] [:i.zmdi.zmdi-chevron-right]]
                         [:span [:i.zmdi.zmdi-chevron-left] [:i.zmdi.zmdi-chevron-left]])]
                      (gstring/format "%s (%d)"
-                                     (get-virkailija-translation :attachments)
+                                     @(subscribe [:editor/virkailija-translation :attachments])
                                      (count (keys attachment-reviews-for-hakukohde)))]])
                  [application-hakukohde-review-inputs review-states/hakukohde-review-types]])
               (when @(subscribe [:application/show-info-request-ui?])
@@ -1901,12 +1901,12 @@
 
 (defn notification [link-params]
   (fn [{:keys [text link-text href on-click]}]
-    [:div.application__message-display--details-notification (get-virkailija-translation text)
+    [:div.application__message-display--details-notification @(subscribe [:editor/virkailija-translation text])
      [:a.application-handling__form-outdated--button.application-handling__button
       {:href     href
        :target   "_blank"
        :on-click on-click}
-      [:span (get-virkailija-translation link-text)]]]))
+      [:span @(subscribe [:editor/virkailija-translation link-text])]]]))
 
 (defn notifications-display []
   (fn []
@@ -1971,14 +1971,14 @@
                :target "_blank"}
               [:i.zmdi.zmdi-account-circle.application-handling__review-area-main-heading-person-icon]
               [:span.application-handling__review-area-main-heading-person-oid
-               (str (get-virkailija-translation :student) " " person-oid)]])
+               (str @(subscribe [:editor/virkailija-translation :student]) " " person-oid)]])
            (when person-oid
              [:a
               {:href   (str "/suoritusrekisteri/#/opiskelijat?henkilo=" person-oid)
                :target "_blank"}
               [:i.zmdi.zmdi-collection-text.application-handling__review-area-main-heading-person-icon]
               [:span.application-handling__review-area-main-heading-person-oid
-               (get-virkailija-translation :person-completed-education)]])
+               @(subscribe [:editor/virkailija-translation :person-completed-education])]])
            (when (> applications-count 1)
              [:a.application-handling__review-area-main-heading-applications-link
               {:on-click (fn [_]
@@ -1987,7 +1987,7 @@
                                            "?term=" (or ssn email))]))}
               [:i.zmdi.zmdi-collection-text.application-handling__review-area-main-heading-person-icon]
               [:span.application-handling__review-area-main-heading-person-oid
-               (str (get-virkailija-translation :view-applications) " (" applications-count ")")]])]]
+               (str @(subscribe [:editor/virkailija-translation :view-applications]) " (" applications-count ")")]])]]
          [notifications-display]])
       (when (not (contains? (:answers application) :hakukohteet))
         [:ul.application-handling__hakukohteet-list
@@ -2000,11 +2000,11 @@
       [:a.application-handling__navigation-link
        {:on-click #(dispatch [:application/navigate-application-list -1])}
        [:i.zmdi.zmdi-chevron-left]
-       (str " " (get-virkailija-translation :navigate-applications-back))]
+       (str " " @(subscribe [:editor/virkailija-translation :navigate-applications-back]))]
       [:span.application-handling__navigation-link-divider "|"]
       [:a.application-handling__navigation-link
        {:on-click #(dispatch [:application/navigate-application-list 1])}
-       (str (get-virkailija-translation :navigate-applications-forward) " ")
+       (str @(subscribe [:editor/virkailija-translation :navigate-applications-forward]) " ")
        [:i.zmdi.zmdi-chevron-right]]]]))
 
 (defn close-application []
@@ -2082,11 +2082,11 @@
   (let [event (subscribe [:application/selected-event])]
     (fn []
       (let [changed-by (if (= (:event-type @event) "updated-by-applicant")
-                         (.toLowerCase (get-virkailija-translation :applicant))
+                         (.toLowerCase @(subscribe [:editor/virkailija-translation :applicant]))
                          (str (:first-name @event) " " (:last-name @event)))]
         [:div.application-handling__version-history-header
          [:div.application-handling__version-history-header-text
-          (str (get-virkailija-translation :diff-from-changes)
+          (str @(subscribe [:editor/virkailija-translation :diff-from-changes])
                " "
                (t/time->short-str (or (:time @event) (:created-time @event))))]
          [:div.application-handling__version-history-header-sub-text
@@ -2094,9 +2094,9 @@
            changed-by]
           [:span
            (gstring/format " %s %s %s"
-                           (get-virkailija-translation :changed)
+                           @(subscribe [:editor/virkailija-translation :changed])
                            changes-amount
-                           (get-virkailija-translation :answers))]]]))))
+                           @(subscribe [:editor/virkailija-translation :answers]))]]]))))
 
 (defn- application-version-history-list-value [values]
   [:ol.application-handling__version-history-list-value
@@ -2154,12 +2154,12 @@
     (breadcrumb-label history-item)]
    [application-version-history-sub-row
     [:span.application-handling__version-history-value-label
-     (get-virkailija-translation :diff-removed)]
+     @(subscribe [:editor/virkailija-translation :diff-removed])]
     [:div.application-handling__version-history-value.application-handling__version-history-value__old
      (application-version-history-value (:old history-item))]]
    [application-version-history-sub-row
     [:span.application-handling__version-history-value-label
-     (get-virkailija-translation :diff-added)]
+     @(subscribe [:editor/virkailija-translation :diff-added])]
     [:div.application-handling__version-history-value.application-handling__version-history-value__new
      (application-version-history-value (:new history-item))]]])
 

--- a/src/cljs/ataru/virkailija/date_time_picker.cljs
+++ b/src/cljs/ataru/virkailija/date_time_picker.cljs
@@ -1,7 +1,7 @@
 (ns ataru.virkailija.date-time-picker
-  (:require [ataru.cljs-util :as cu]
-            [cljs-time.format :as f]
-            [reagent.core :as reagent]))
+  (:require [cljs-time.format :as f]
+            [reagent.core :as reagent]
+            [re-frame.core :as re-frame]))
 
 (defn- iso-date-string->finnish-date-string [date-s]
   (if (= "" date-s)
@@ -51,10 +51,11 @@
 
 (defn date-picker
   [id class value invalid on-change]
-  (let [supports-date? (reagent/atom nil)
-        input-value    (reagent/atom "")
-        valid?         (reagent/atom true)
-        invalid-text   (reagent/atom invalid)]
+  (let [supports-date?           (reagent/atom nil)
+        input-value              (reagent/atom "")
+        valid?                   (reagent/atom true)
+        invalid-text             (reagent/atom invalid)
+        invalid-date-format-i18n (re-frame/subscribe [:editor/virkailija-translation :invalid-date-format])]
     (reagent/create-class
      {:component-did-mount
       (fn [component]
@@ -62,7 +63,7 @@
           (.setCustomValidity
            dom-node
            (if (not @valid?)
-             (cu/get-virkailija-translation :invalid-date-format)
+             @invalid-date-format-i18n
              @invalid-text))
           (reset! supports-date? (= "date" (.-type dom-node)))))
       :component-did-update
@@ -70,7 +71,7 @@
         (.setCustomValidity
          (reagent/dom-node component)
          (if (not @valid?)
-           (cu/get-virkailija-translation :invalid-date-format)
+           @invalid-date-format-i18n
            @invalid-text)))
       :reagent-render
       (fn [id class value invalid on-change]
@@ -96,10 +97,11 @@
 
 (defn time-picker
   [id class value invalid on-change]
-  (let [supports-time? (reagent/atom nil)
-        input-value    (reagent/atom "")
-        valid?         (reagent/atom true)
-        invalid-text   (reagent/atom invalid)]
+  (let [supports-time?           (reagent/atom nil)
+        input-value              (reagent/atom "")
+        valid?                   (reagent/atom true)
+        invalid-text             (reagent/atom invalid)
+        invalid-date-format-i18n (re-frame/subscribe [:editor/virkailija-translation :invalid-date-format])]
     (reagent/create-class
      {:component-did-mount
       (fn [component]
@@ -107,7 +109,7 @@
           (.setCustomValidity
            dom-node
            (if (not @valid?)
-             (cu/get-virkailija-translation :invalid-time-format)
+             @invalid-date-format-i18n
              @invalid-text))
           (reset! supports-time? (= "time" (.-type dom-node)))))
       :component-did-update
@@ -115,7 +117,7 @@
         (.setCustomValidity
          (reagent/dom-node component)
          (if (not @valid?)
-           (cu/get-virkailija-translation :invalid-time-format)
+           @invalid-date-format-i18n
            @invalid-text)))
       :reagent-render
       (fn [id class value invalid on-change]

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -2,7 +2,7 @@
   (:require
    [ataru.application-common.application-field-common :refer [copy-link]]
    [ataru.util :as cutil]
-   [ataru.cljs-util :as util :refer [cljs->str str->cljs new-uuid get-virkailija-translation]]
+   [ataru.cljs-util :as util :refer [cljs->str str->cljs new-uuid]]
    [ataru.component-data.component :as component]
    [ataru.koodisto.koodisto-whitelist :as koodisto-whitelist]
    [ataru.virkailija.editor.components.followup-question :refer [followup-question followup-question-overlay]]
@@ -46,7 +46,7 @@
      [:label.editor-form__checkbox-label
       {:for   id
        :class (when disabled? "editor-form__checkbox-label--disabled")}
-      (get-virkailija-translation key)]]))
+      @(subscribe [:editor/virkailija-translation key])]]))
 
 (defn- repeater-checkbox
   [path initial-content]
@@ -63,7 +63,7 @@
      [:label.editor-form__checkbox-label
       {:for   id
        :class (when component-locked? "editor-form__checkbox-label--disabled")}
-      (get-virkailija-translation :multiple-answers)]]))
+      @(subscribe [:editor/virkailija-translation :multiple-answers])]]))
 
 (defn- belongs-to-hakukohteet-modal
   [path id selected-hakukohteet selected-hakukohderyhmat hidden-disabled?]
@@ -100,7 +100,7 @@
         [h-and-h/popup
          [:div.belongs-to-hakukohteet-modal__no-haku-row
           [:p.belongs-to-hakukohteet-modal__no-haku
-           (get-virkailija-translation :set-haku-to-form)]]
+           @(subscribe [:editor/virkailija-translation :set-haku-to-form])]]
          nil
          nil
          #(dispatch [:editor/hide-belongs-to-hakukohteet-modal id])]))))
@@ -148,13 +148,13 @@
            :class    (when @form-locked? "belongs-to-hakukohteet__modal-toggle--disabled")
            :on-click (when-not @form-locked?
                        (if @show-modal? on-click-hide on-click-show))}
-          (str (get-virkailija-translation :visibility-on-form) " ")]
+          (str @(subscribe [:editor/virkailija-translation :visibility-on-form]) " ")]
          [:span.belongs-to-hakukohteet__modal-toggle-label
           (cond (and (empty? visible))
-                (get-virkailija-translation :visible-to-all)
+                @(subscribe [:editor/virkailija-translation :visible-to-all])
 
                 :else
-                (get-virkailija-translation :visible-to-hakukohteet))]
+                @(subscribe [:editor/virkailija-translation :visible-to-hakukohteet]))]
          (when @show-modal?
            [belongs-to-hakukohteet-modal path
             id
@@ -195,16 +195,16 @@
            :class    (when @component-locked? "belongs-to-hakukohteet__modal-toggle--disabled")
            :on-click (when-not @component-locked?
                        (if @show-modal? on-click-hide on-click-show))}
-          (str (get-virkailija-translation :visibility-on-form) " ")]
+          (str @(subscribe [:editor/virkailija-translation :visibility-on-form]) " ")]
          [:span.belongs-to-hakukohteet__modal-toggle-label
           (cond @hidden?
-                (get-virkailija-translation :hidden)
+                @(subscribe [:editor/virkailija-translation :hidden])
 
                 (and (empty? visible))
-                (get-virkailija-translation :visible-to-all)
+                @(subscribe [:editor/virkailija-translation :visible-to-all])
 
                 :else
-                (get-virkailija-translation :visible-to-hakukohteet))]
+                @(subscribe [:editor/virkailija-translation :visible-to-hakukohteet]))]
          (when @show-modal?
            [belongs-to-hakukohteet-modal path
             (:id initial-content)
@@ -224,58 +224,58 @@
     :enabled
     [:button.editor-form__component-button
      {:on-click #(dispatch [:editor/copy-component path true])}
-     (get-virkailija-translation :cut-element)]
+     @(subscribe [:editor/virkailija-translation :cut-element])]
     :active
     [:button.editor-form__component-button
      {:on-click #(dispatch [:editor/cancel-copy-component])}
-     (get-virkailija-translation :cancel-cut)]
+     @(subscribe [:editor/virkailija-translation :cancel-cut])]
     :disabled
     [:button.editor-form__component-button
      {:disabled true}
-     (get-virkailija-translation :cut-element)]))
+     @(subscribe [:editor/virkailija-translation :cut-element])]))
 
 (defn- copy-component-button [path]
   (case @(subscribe [:editor/component-button-state path :copy])
     :enabled
     [:button.editor-form__component-button
      {:on-click #(dispatch [:editor/copy-component path false])}
-     (get-virkailija-translation :copy-element)]
+     @(subscribe [:editor/virkailija-translation :copy-element])]
     :active
     [:button.editor-form__component-button
      {:on-click #(dispatch [:editor/cancel-copy-component])}
-     (get-virkailija-translation :cancel-copy)]
+     @(subscribe [:editor/virkailija-translation :cancel-copy])]
     :disabled
     [:button.editor-form__component-button
      {:disabled true}
-     (get-virkailija-translation :copy-element)]))
+     @(subscribe [:editor/virkailija-translation :copy-element])]))
 
 (defn- remove-component-button [path]
   (case @(subscribe [:editor/component-button-state path :remove])
     :enabled
     [:button.editor-form__component-button
      {:on-click #(dispatch [:editor/start-remove-component path])}
-     (get-virkailija-translation :remove)]
+     @(subscribe [:editor/virkailija-translation :remove])]
     :confirm
     [:div.editor-form__component-button-group
      [:button.editor-form__component-button.editor-form__component-button--confirm
       {:on-click (fn [_] (dispatch [:editor/confirm-remove-component path]))}
-      (get-virkailija-translation :confirm-delete)]
+      @(subscribe [:editor/virkailija-translation :confirm-delete])]
      [:button.editor-form__component-button
       {:on-click #(dispatch [:editor/cancel-remove-component path])}
-      (get-virkailija-translation :cancel-remove)]]
+      @(subscribe [:editor/virkailija-translation :cancel-remove])]]
     :disabled
     [:button.editor-form__component-button
      {:disabled true}
-     (get-virkailija-translation :remove)]))
+     @(subscribe [:editor/virkailija-translation :remove])]))
 
 (defn- header-metadata
   [path metadata]
   [:div
    [:span.editor-form__component-main-header-metadata
     (s/format "%s %s, %s %s %s"
-              (get-virkailija-translation :created-by)
+              @(subscribe [:editor/virkailija-translation :created-by])
               (-> metadata :created-by :name)
-              (get-virkailija-translation :last-modified-by)
+              @(subscribe [:editor/virkailija-translation :last-modified-by])
               (if (= (-> metadata :created-by :oid)
                      (-> metadata :modified-by :oid))
                 ""
@@ -401,20 +401,20 @@
    [:div
     [:div.editor-form__markdown-help-arrow-left]
     [:div.editor-form__markdown-help-content
-     [:span (get-virkailija-translation :md-help-title)]
+     [:span @(subscribe [:editor/virkailija-translation :md-help-title])]
      [:br]
-     [:span (get-virkailija-translation :md-help-bold)]
+     [:span @(subscribe [:editor/virkailija-translation :md-help-bold])]
      [:br]
-     [:span (get-virkailija-translation :md-help-cursive)]
+     [:span @(subscribe [:editor/virkailija-translation :md-help-cursive])]
      [:br]
-     [:span (get-virkailija-translation :md-help-link)]
+     [:span @(subscribe [:editor/virkailija-translation :md-help-link])]
      [:br]
      [:a {:href          "https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet"
           :target        "_blank"
           :on-mouse-down (fn [evt]
                            (let [url (.getAttribute (-> evt .-target) "href")]
                              (.open js/window url "_blank")))}
-      (get-virkailija-translation :md-help-more)]]]])
+      @(subscribe [:editor/virkailija-translation :md-help-more])]]]])
 
 (defn input-field [path lang dispatch-fn {:keys [class value-fn tag placeholder]
                                           :or   {tag :input}}]
@@ -501,7 +501,7 @@
         [:label
          {:for   id
           :class (when @component-locked? "disabled")}
-         (get-virkailija-translation :info-addon)]]
+         @(subscribe [:editor/virkailija-translation :info-addon])]]
        (when @checked?
          (let [collapsed-id (util/new-uuid)]
            [:div.editor-form__info-addon-checkbox
@@ -516,7 +516,7 @@
             [:label
              {:for   collapsed-id
               :class (when @component-locked? "editor-form__checkbox-label--disabled")}
-             (get-virkailija-translation :collapse-info-text)]]))
+             @(subscribe [:editor/virkailija-translation :collapse-info-text])]]))
        (when @checked?
          [:div.editor-form__info-addon-inputs
           (->> (input-fields-with-lang
@@ -550,7 +550,7 @@
     (fn [component-id path]
       [:div
        [:div.editor-form__additional-params-container
-        [:header.editor-form__component-item-header (get-virkailija-translation :shape)]
+        [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :shape])]
         [:select.editor-form__decimal-places-selector
          {:value     (or @decimal-places "")
           :disabled  @component-locked?
@@ -559,15 +559,15 @@
                              value   (when (not-empty new-val)
                                        (js/parseInt new-val))]
                          (dispatch [:editor/set-decimals-value component-id value path])))}
-         [:option {:value "" :key 0} (get-virkailija-translation :integer)]
+         [:option {:value "" :key 0} @(subscribe [:editor/virkailija-translation :integer])]
          (doall
            (for [i (range 1 5)]
-             [:option {:value i :key i} (str i " " (get-virkailija-translation :decimals))]))]]
+             [:option {:value i :key i} (str i " " @(subscribe [:editor/virkailija-translation :decimals]))]))]]
        [:div.editor-form__additional-params-container
         [:label.editor-form__range-label
          {:for   min-id
           :class (when @component-locked? "editor-form__checkbox-label--disabled")}
-         (get-virkailija-translation :numeric-range)]
+         @(subscribe [:editor/virkailija-translation :numeric-range])]
         [:input.editor-form__range-input
          {:type      "text"
           :id        min-id
@@ -609,7 +609,7 @@
         [:label.editor-form__checkbox-label
          {:for   id
           :class (when @component-locked? "editor-form__checkbox-label--disabled")}
-         (get-virkailija-translation :only-numeric)]]
+         @(subscribe [:editor/virkailija-translation :only-numeric])]]
        (when @checked?
          [decimal-places-selector component-id path])])))
 
@@ -645,7 +645,7 @@
         [:div
          [:div.editor-form__component-row-wrapper
           [:div.editor-form__text-field-wrapper
-           [:header.editor-form__component-item-header (get-virkailija-translation :question)
+           [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :question])
             [copy-link (:id initial-content)]]
            (input-fields-with-lang
             (fn [lang]
@@ -676,7 +676,7 @@
                        btn-name]]))]
            (when text-area?
              [:div.editor-form__max-length-container
-              [:header.editor-form__component-item-header (get-virkailija-translation :max-characters)]
+              [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :max-characters])]
               [:input.editor-form__text-field.editor-form__text-field-auto-width
                {:value     @max-length
                 :disabled  @component-locked?
@@ -692,13 +692,13 @@
 
 (defn text-field [initial-content path]
   [text-component initial-content path
-   :header-label (get-virkailija-translation :text-field)
-   :size-label (get-virkailija-translation :text-field-size)])
+   :header-label @(subscribe [:editor/virkailija-translation :text-field])
+   :size-label @(subscribe [:editor/virkailija-translation :text-field-size])])
 
 (defn text-area [initial-content path]
   [text-component initial-content path
-   :header-label (get-virkailija-translation :text-area)
-   :size-label (get-virkailija-translation :text-area-size)])
+   :header-label @(subscribe [:editor/virkailija-translation :text-area])
+   :size-label @(subscribe [:editor/virkailija-translation :text-area-size])])
 
 (defn- remove-dropdown-option-button [path option-index disabled? parent-key option-value question-group-element?]
   [:div.editor-form__multi-options-remove--cross
@@ -757,7 +757,7 @@
           [:div.editor-form__selection-limit
            [input-field option-path :dont-care #(dispatch [:editor/set-dropdown-option-selection-limit
                                                            (only-numbers (-> % .-target .-value)) option-path :selection-limit])
-            {:placeholder (get-virkailija-translation :selection-limit-input)
+            {:placeholder @(subscribe [:editor/virkailija-translation :selection-limit-input])
              :class       "editor-form__text-field--selection-limit"
              :value-fn    (fn [v] (:selection-limit v))}]])
         (when (not question-group-element?)
@@ -776,7 +776,7 @@
       [:div.editor-form__koodisto-options
        [:label.editor-form__select-koodisto-dropdown-label
         {:for id}
-        (get-virkailija-translation :koodisto)]
+        @(subscribe [:editor/virkailija-translation :koodisto])]
        [:div.editor-form__select-koodisto-dropdown-wrapper
         [:select.editor-form__select-koodisto-dropdown
          {:id        id
@@ -835,12 +835,12 @@
           [:div.editor-form__show-koodisto-values
            [:a
             {:on-click show-koodisto-options}
-            [:i.zmdi.zmdi-chevron-down] (str " " (get-virkailija-translation :show-options))]]
+            [:i.zmdi.zmdi-chevron-down] (str " " @(subscribe [:editor/virkailija-translation :show-options]))]]
           [:div
            [:div.editor-form__show-koodisto-values
             [:a
              {:on-click hide-koodisto-options}
-             [:i.zmdi.zmdi-chevron-up] (str " " (get-virkailija-translation :hide-options))]]
+             [:i.zmdi.zmdi-chevron-up] (str " " @(subscribe [:editor/virkailija-translation :hide-options]))]]
            [custom-answer-options languages (:options value) followups path question-group-element? editable? show-followups parent-key]])))))
 
 (defn dropdown [initial-content followups path]
@@ -860,12 +860,12 @@
         [:div.editor-form__component-wrapper
          (let [header (case field-type
                         "dropdown"       (if (some? @options-koodisto)
-                                           (get-virkailija-translation :dropdown-koodisto)
-                                           (get-virkailija-translation :dropdown))
-                        "singleChoice"   (get-virkailija-translation :single-choice-button)
+                                           @(subscribe [:editor/virkailija-translation :dropdown-koodisto])
+                                           @(subscribe [:editor/virkailija-translation :dropdown]))
+                        "singleChoice"   @(subscribe [:editor/virkailija-translation :single-choice-button])
                         "multipleChoice" (if (some? @options-koodisto)
-                                           (get-virkailija-translation :multiple-choice-koodisto)
-                                           (get-virkailija-translation :multiple-choice)))]
+                                           @(subscribe [:editor/virkailija-translation :multiple-choice-koodisto])
+                                           @(subscribe [:editor/virkailija-translation :multiple-choice])))]
            [text-header (:id initial-content) header path (:metadata initial-content)
             :sub-header (:label @value)])
          [component-content
@@ -874,7 +874,7 @@
            [:div.editor-form__component-row-wrapper
             [:div.editor-form__multi-question-wrapper
              [:div.editor-form__text-field-wrapper
-              [:header.editor-form__component-item-header (get-virkailija-translation :question)
+              [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :question])
                [copy-link (:id initial-content)]]
               (input-fields-with-lang
                (fn [lang]
@@ -897,7 +897,7 @@
                                 (dispatch [:editor/set-ordered-by-user (-> event .-target .-checked) path]))}]
                  [:label.editor-form__checkbox-label
                   {:for koodisto-ordered-id}
-                  (get-virkailija-translation :alphabetically)]])
+                  @(subscribe [:editor/virkailija-translation :alphabetically])]])
               (when (some? @options-koodisto)
                 [:div.editor-form__checkbox-container
                  [:input.editor-form__checkbox
@@ -911,14 +911,14 @@
                                           (not (:allow-invalid? @options-koodisto))])}]
                  [:label.editor-form__checkbox-label
                   {:for allow-invalid-koodis-id}
-                  (get-virkailija-translation :allow-invalid-koodis)]])]
+                  @(subscribe [:editor/virkailija-translation :allow-invalid-koodis])]])]
              [belongs-to-hakukohteet path initial-content]]]
            [info-addon path initial-content]
            [:div.editor-form__component-row-wrapper
             [:div.editor-form__multi-options_wrapper
              (if (some? @options-koodisto)
                [select-koodisto-dropdown path]
-               [:header.editor-form__component-item-header (get-virkailija-translation :options)])
+               [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :options])])
              (if (nil? @options-koodisto)
                [custom-answer-options languages (:options @value) followups path question-group-element? true show-followups (:id initial-content)]
                [koodisto-answer-options (:id @value) followups path question-group-element? (:id initial-content)])
@@ -931,18 +931,18 @@
                                 (reset! show-followups nil)
                                 (dispatch [:editor/add-dropdown-option path])))
                   :class    (when @component-locked? "editor-form__add-dropdown-item--disabled")}
-                 [:i.zmdi.zmdi-plus-square] (str " " (get-virkailija-translation :add))]])]]]]]))))
+                 [:i.zmdi.zmdi-plus-square] (str " " @(subscribe [:editor/virkailija-translation :add]))]])]]]]]))))
 
 (defn component-group [content path children]
   (let [id                (:id content)
         languages         @(subscribe [:editor/languages])
         value             @(subscribe [:editor/get-component-value path])
         group-header-text (case (:fieldClass content)
-                            "wrapperElement" (get-virkailija-translation :wrapper-element)
-                            "questionGroup"  (get-virkailija-translation :question-group))
+                            "wrapperElement" @(subscribe [:editor/virkailija-translation :wrapper-element])
+                            "questionGroup"  @(subscribe [:editor/virkailija-translation :question-group]))
         header-label-text (case (:fieldClass content)
-                            "wrapperElement" (get-virkailija-translation :wrapper-header)
-                            "questionGroup"  (get-virkailija-translation :group-header))]
+                            "wrapperElement" @(subscribe [:editor/virkailija-translation :wrapper-header])
+                            "questionGroup"  @(subscribe [:editor/virkailija-translation :group-header]))]
     [:div.editor-form__component-wrapper
      [text-header id group-header-text path (:metadata content)
       :sub-header (:label value)]
@@ -989,7 +989,7 @@
         :can-remove? false]
        [:div.editor-form__component-content-wrapper
         [:div.editor-form__module-fields
-         (get-virkailija-translation :hakukohde-info)]]])))
+         @(subscribe [:editor/virkailija-translation :hakukohde-info])]]])))
 
 (defn module [content path]
   (let [languages       (subscribe [:editor/languages])
@@ -1017,10 +1017,10 @@
              :value     (or (get values (:id content)) "onr")}
             (doall (for [opt values]
                      [:option {:value opt
-                               :key   opt} (get-virkailija-translation (keyword (str "person-info-module-" opt)))]))]])
+                               :key   opt} @(subscribe [:editor/virkailija-translation (keyword (str "person-info-module-" opt))])]))]])
         [:div.editor-form__module-fields
          [:span.editor-form__module-fields-label
-          (get-virkailija-translation :contains-fields)]
+          @(subscribe [:editor/virkailija-translation :contains-fields])]
          " "
          (clojure.string/join ", " (get-leaf-component-labels @value :fi))]]])))
 
@@ -1033,21 +1033,21 @@
         component-locked?     (subscribe [:editor/component-locked? path])]
     (fn [initial-content path]
       [:div.editor-form__component-wrapper
-       [text-header (:id initial-content) (get-virkailija-translation :info-element) path (:metadata initial-content)
+       [text-header (:id initial-content) @(subscribe [:editor/virkailija-translation :info-element]) path (:metadata initial-content)
         :sub-header @sub-header]
        [component-content
         path ;(:id initial-content)
         [:div
          [:div.editor-form__component-row-wrapper
           [:div.editor-form__text-field-wrapper
-           [:header.editor-form__component-item-header (get-virkailija-translation :title)]
+           [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :title])]
            (input-fields-with-lang
             (fn [lang]
               [input-field path lang #(dispatch-sync [:editor/set-component-value (-> % .-target .-value) path :label lang])])
             @languages
             :header? true)
            [:div.infoelement
-            [:header.editor-form__component-item-header (get-virkailija-translation :text)]
+            [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :text])]
             (->> (input-fields-with-lang
                   (fn [lang]
                     [input-field path lang #(dispatch-sync [:editor/set-component-value (-> % .-target .-value) path :text lang])
@@ -1073,7 +1073,7 @@
               [:label.editor-form__checkbox-label
                {:for   collapsed-id
                 :class (when @component-locked? "editor-form__checkbox-label--disabled")}
-               (get-virkailija-translation :collapse-info-text)]])]
+               @(subscribe [:editor/virkailija-translation :collapse-info-text])]])]
           [belongs-to-hakukohteet path initial-content]]]]])))
 
 (defn pohjakoulutusristiriita
@@ -1106,14 +1106,14 @@
         component-locked? (subscribe [:editor/component-locked? path])]
     (fn [content path children]
       [:div.editor-form__component-wrapper
-       [text-header (:id content) (get-virkailija-translation :adjacent-fieldset) path (:metadata content)
+       [text-header (:id content) @(subscribe [:editor/virkailija-translation :adjacent-fieldset]) path (:metadata content)
         :sub-header @sub-header]
        [component-content
         path ;(:id content)
         [:div
          [:div.editor-form__component-row-wrapper
           [:div.editor-form__text-field-wrapper
-           [:header.editor-form__component-item-header (get-virkailija-translation :title)]
+           [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :title])]
            (input-fields-with-lang
             (fn [lang]
               [input-field path lang #(dispatch-sync [:editor/set-component-value (-> % .-target .-value) path :label lang])])
@@ -1138,7 +1138,7 @@
         numeric? (subscribe [:editor/get-component-value path :params :numeric])]
     (fn [content path]
       [:div.editor-form__component-wrapper
-       [text-header (:id content) (get-virkailija-translation :text-field) path (:metadata content)
+       [text-header (:id content) @(subscribe [:editor/virkailija-translation :text-field]) path (:metadata content)
         :foldable? false
         :can-cut? false
         :can-copy? false
@@ -1146,7 +1146,7 @@
        [:div.editor-form__component-content-wrapper
         [:div.editor-form__component-row-wrapper
          [:div.editor-form__text-field-wrapper
-          [:header.editor-form__component-item-header (get-virkailija-translation :question)
+          [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :question])
            [copy-link (:id content)]]
           (input-fields-with-lang
            (fn [lang]
@@ -1179,7 +1179,7 @@
           [:label
            {:for   id
             :class (when @component-locked? "editor-form__checkbox-label--disabled")}
-           (get-virkailija-translation :mail-attachment-text)]])
+           @(subscribe [:editor/virkailija-translation :mail-attachment-text])]])
        (when-not @mail-attachment?
          (let [id (util/new-uuid)]
            [:div.editor-form__info-addon-checkbox
@@ -1194,7 +1194,7 @@
             [:label
              {:for   id
               :class (when @component-locked? "editor-form__checkbox-label--disabled")}
-             (get-virkailija-translation :attachment-info-text)]]))
+             @(subscribe [:editor/virkailija-translation :attachment-info-text])]]))
        (when @checked?
          (let [id (util/new-uuid)]
            [:div.editor-form__info-addon-checkbox
@@ -1209,7 +1209,7 @@
             [:label
              {:for   id
               :class (when @component-locked? "editor-form__checkbox-label--disabled")}
-             (get-virkailija-translation :collapse-info-text)]]))
+             @(subscribe [:editor/virkailija-translation :collapse-info-text])]]))
        (when @checked?
          [:div.editor-form__info-addon-inputs
           (->> (input-fields-with-lang
@@ -1259,14 +1259,14 @@
                               :else (update-value value nil false))))]
     (fn [content path]
       [:div.editor-form__component-wrapper
-       [text-header (:id content) (get-virkailija-translation :attachment) path (:metadata content)
+       [text-header (:id content) @(subscribe [:editor/virkailija-translation :attachment]) path (:metadata content)
         :sub-header (:label @component)]
        [component-content
         path ;(:id content)
         [:div
          [:div.editor-form__component-row-wrapper
           [:div.editor-form__text-field-wrapper
-           [:header.editor-form__component-item-header (get-virkailija-translation :attachment-name)
+           [:header.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :attachment-name])
             [copy-link (:id content)]]
            (input-fields-with-lang
             (fn attachment-file-name-input [lang]
@@ -1274,7 +1274,7 @@
             @languages
             :header? true)]
           [:div.editor-form__text-field-wrapper
-           [:label.editor-form__component-item-header (get-virkailija-translation :attachment-deadline)]
+           [:label.editor-form__component-item-header @(subscribe [:editor/virkailija-translation :attachment-deadline])]
            [:input.editor-form__attachment-deadline-field
             {:type        "text"
              :class       (when-not @valid "editor-form__text-field--invalid")

--- a/src/cljs/ataru/virkailija/editor/components/drag_n_drop_spacer.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/drag_n_drop_spacer.cljs
@@ -1,6 +1,5 @@
 (ns ataru.virkailija.editor.components.drag-n-drop-spacer
   (:require [re-frame.core :as re-frame]
-            [ataru.cljs-util :as util :refer [get-virkailija-translation]]
             [reagent.core :as r]))
 
 (defn drag-n-drop-spacer [path]
@@ -23,7 +22,7 @@
                 :on-click (fn [_] (when (and @expanded?)
                                     (reset! expanded? false)
                                     (re-frame/dispatch [:editor/paste-component @copy-component path])))}
-               (get-virkailija-translation :paste-element)]
+               @(re-frame/subscribe [:editor/virkailija-translation :paste-element])]
               [:button.editor-form__component-button
                {:disabled true}
-               (get-virkailija-translation :paste-element)])]))])))
+               @(re-frame/subscribe [:editor/virkailija-translation :paste-element])])]))])))

--- a/src/cljs/ataru/virkailija/editor/components/followup_question.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/followup_question.cljs
@@ -43,10 +43,10 @@
                                  (fn [v] (update v option-index not)))}]
     [:div.editor-form__followup-question
      (if (empty? followups)
-       [:a attrs (util/get-virkailija-translation :followups)]
+       [:a attrs @(subscribe [:editor/virkailija-translation :followups])]
        [:a attrs
         (s/format "%s (%d) "
-                  (util/get-virkailija-translation :followups)
+                  @(subscribe [:editor/virkailija-translation :followups])
                   (count followups))
         (if (get @show-followups option-index)
           [:i.zmdi.zmdi-chevron-up.zmdi-hc-lg]

--- a/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
@@ -1,6 +1,5 @@
 (ns ataru.virkailija.editor.components.toolbar
-  (:require [ataru.cljs-util :as util :refer [get-virkailija-translation]]
-            [ataru.component-data.component :as component]
+  (:require [ataru.component-data.component :as component]
             [ataru.component-data.base-education-module :as base-education-module]
             [ataru.component-data.higher-education-base-education-module :as kk-base-education-module]
             [ataru.feature-config :as fc]
@@ -89,7 +88,7 @@
                [:a {:on-click (fn [evt]
                                 (.preventDefault evt)
                                 (generator generate-fn))}
-                (get-virkailija-translation component-name)]])))))
+                @(subscribe [:editor/virkailija-translation component-name])]])))))
 
 
 (defn custom-add-component [toolbar path generator]

--- a/src/cljs/ataru/virkailija/editor/subs.cljs
+++ b/src/cljs/ataru/virkailija/editor/subs.cljs
@@ -4,13 +4,26 @@
             [re-frame.core :as re-frame]
             [ataru.cljs-util :as cu]
             [taoensso.timbre :refer-macros [spy debug]]
-            [markdown.core :as md]))
+            [markdown.core :as md]
+            [ataru.translations.translation-util :as translations]))
 
 (re-frame/reg-sub
   :editor/virkailija-texts
   (fn [db _]
     (or (-> db :editor :virkailija-texts)
         {})))
+
+(re-frame/reg-sub
+  :editor/virkailija-translation
+  (fn []
+    [(re-frame/subscribe [:editor/virkailija-texts])
+     (re-frame/subscribe [:editor/virkailija-lang])])
+  (fn [[virkailija-texts lang] [_ translation-key & params]]
+    (apply translations/get-translation
+           translation-key
+           lang
+           virkailija-texts
+           params)))
 
 (re-frame/reg-sub
   :editor/ui

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -1,6 +1,6 @@
 (ns ataru.virkailija.editor.view
   (:require-macros [reagent.ratom :refer [reaction]])
-  (:require [ataru.cljs-util :refer [wrap-scroll-to get-virkailija-translation]]
+  (:require [ataru.cljs-util :refer [wrap-scroll-to]]
             [ataru.component-data.component :as component]
             [ataru.virkailija.editor.core :as c]
             [ataru.virkailija.editor.subs]
@@ -43,7 +43,7 @@
    {:on-click (fn [evt]
                 (.preventDefault evt)
                 (dispatch [:editor/add-form]))}
-   (get-virkailija-translation :new-form)])
+   @(subscribe [:editor/virkailija-translation :new-form])])
 
 (defn- copy-form []
   (let [form-key    (subscribe [:state-query [:editor :selected-form-key]])
@@ -57,26 +57,26 @@
         :class    (if @disabled?
                     "editor-form__control-button--disabled"
                     "editor-form__control-button--enabled")}
-       (get-virkailija-translation :copy-form)])))
+       @(subscribe [:editor/virkailija-translation :copy-form])])))
 
 (defn- remove-form []
   (case @(subscribe [:editor/remove-form-button-state])
     :active
     [:button.editor-form__control-button--enabled.editor-form__control-button
      {:on-click #(dispatch [:editor/start-remove-form])}
-     (get-virkailija-translation :delete-form)]
+     @(subscribe [:editor/virkailija-translation :delete-form])]
     :confirm
     [:div.editor-form__component-button-group
      [:button.editor-form__control-button--confirm.editor-form__control-button
       {:on-click #(dispatch [:editor/confirm-remove-form])}
-      (get-virkailija-translation :confirm-delete)]
+      @(subscribe [:editor/virkailija-translation :confirm-delete])]
      [:button.editor-form__control-button--enabled.editor-form__control-button
       {:on-click #(dispatch [:editor/unstart-remove-form])}
-      (get-virkailija-translation :cancel-form-delete)]]
+      @(subscribe [:editor/virkailija-translation :cancel-form-delete])]]
     :disabled
     [:button.editor-form__control-button--disabled.editor-form__control-button
      {:disabled true}
-     (get-virkailija-translation :delete-form)]))
+     @(subscribe [:editor/virkailija-translation :delete-form])]))
 
 (defn- form-controls []
   [:div.editor-form__form-controls-container
@@ -86,7 +86,7 @@
 
 (defn- form-header-row []
   [:div.editor-form__form-header-row
-   [:h1.editor-form__form-heading (get-virkailija-translation :forms)]
+   [:h1.editor-form__form-heading @(subscribe [:editor/virkailija-translation :forms])]
    [form-controls]])
 
 (defn- editor-name-input [lang focus?]
@@ -104,7 +104,7 @@
                                {:type        "text"
                                 :value       (get-in @form [:name lang])
                                 :disabled    @form-locked?
-                                :placeholder (get-virkailija-translation :form-name)
+                                :placeholder @(subscribe [:editor/virkailija-translation :form-name])
                                 :on-change   #(do (dispatch [:editor/change-form-name lang (.-value (.-target %))])
                                                   (dispatch [:set-state [:editor :new-form-created?] false]))
                                 :on-blur     #(dispatch [:set-state [:editor :new-form-created?] false])}])})))
@@ -128,7 +128,7 @@
 (defn- get-org-name [org]
   (str (get-in org [:name :fi])
        (if (= "group" (:type org))
-         (str " (" (get-virkailija-translation :group) ")")
+         (str " (" @(subscribe [:editor/virkailija-translation :group]) ")")
          "")))
 
 (defn- get-org-name-for-oid [oid orgs] (get-org-name (first (filter #(= oid (:oid %)) orgs))))
@@ -137,12 +137,12 @@
   [:div
    [:span.editor-form__fold-clickable-text
     {:on-click #(dispatch [:editor/fold-all])}
-    (get-virkailija-translation :close)]
+    @(subscribe [:editor/virkailija-translation :close])]
    [:span.editor-form__fold-description-text " / "]
    [:span.editor-form__fold-clickable-text
     {:on-click #(dispatch [:editor/unfold-all])}
-    (get-virkailija-translation :open)]
-   [:span.editor-form__fold-description-text (str " " (get-virkailija-translation :questions))]])
+    @(subscribe [:editor/virkailija-translation :open])]
+   [:span.editor-form__fold-description-text (str " " @(subscribe [:editor/virkailija-translation :questions]))]])
 
 (defn- preview-link [form-key lang-kwd]
   [:a.editor-form__preview-button-link
@@ -161,7 +161,7 @@
     {:href   (str "/palaute/"
                   "?q=" (str js/config.applicant.service_url path))
      :target "_blank"}
-    (get-virkailija-translation :link-to-feedback)]])
+    @(subscribe [:editor/virkailija-translation :link-to-feedback])]])
 
 (defn- lock-form-editing []
   (let [form-locked-info @(subscribe [:editor/form-locked-info])
@@ -173,7 +173,7 @@
     [:div.editor-form__preview-buttons
      (when (not= lock-state :open)
        [:div.editor-form__form-editing-locked
-        (get-virkailija-translation :form-locked)
+        @(subscribe [:editor/virkailija-translation :form-locked])
         [:i.zmdi.zmdi-lock.editor-form__form-editing-lock-icon]
         [:div.editor-form__form-editing-locked-by
          (str "("
@@ -186,8 +186,8 @@
         {:on-click #(dispatch [:editor/toggle-form-editing-lock])}
         {:disabled true})
       (if (= lock-state :locked)
-        (get-virkailija-translation :remove-lock)
-        (get-virkailija-translation :lock-form))]]))
+        @(subscribe [:editor/virkailija-translation :remove-lock])
+        @(subscribe [:editor/virkailija-translation :lock-form]))]]))
 
 (defn- disable-autosave
   []
@@ -198,8 +198,8 @@
         {:on-click #(dispatch [:editor/toggle-autosave])
          :class    (when-not @autosave-enabled "editor-form__autosave-toggle-link--autosave-off")}
         (if @autosave-enabled
-          (get-virkailija-translation :autosave-enabled)
-          (get-virkailija-translation :autosave-disabled))]])))
+          @(subscribe [:editor/virkailija-translation :autosave-enabled])
+          @(subscribe [:editor/virkailija-translation :autosave-disabled]))]])))
 
 (defn- lang-checkbox [lang-kwd]
   (let [id (str "lang-checkbox-" (name lang-kwd))]
@@ -212,10 +212,10 @@
        :on-change (fn [_] (dispatch [:editor/toggle-language lang-kwd]))}]
      [:label.editor-form__checkbox-label.editor-form__language-checkbox-label
       {:for id}
-      (get-virkailija-translation (case lang-kwd
-                                    :fi :finnish
-                                    :sv :swedish
-                                    :en :english))]]))
+      @(subscribe [:editor/virkailija-translation (case lang-kwd
+                                                    :fi :finnish
+                                                    :sv :swedish
+                                                    :en :english)])]]))
 
 (defn- form-toolbar []
   [:div.editor-form__toolbar
@@ -227,7 +227,7 @@
     [:div.editor-form__preview-buttons
      [:a.editor-form__email-template-editor-link
       {:on-click #(dispatch [:editor/toggle-email-template-editor])}
-      (get-virkailija-translation :edit-email-templates)]]
+      @(subscribe [:editor/virkailija-translation :edit-email-templates])]]
     [lock-form-editing]
     [disable-autosave]]
    [:div.editor-form__toolbar-right
@@ -245,8 +245,8 @@
           [:i.zmdi.zmdi-alert-circle-o]
           (str " "
                (if (empty? (rest (vals form-used-in-hakus)))
-                 (get-virkailija-translation :used-by-haku)
-                 (get-virkailija-translation :used-by-haut)))]
+                 @(subscribe [:editor/virkailija-translation :used-by-haku])
+                 @(subscribe [:editor/virkailija-translation :used-by-haut])))]
          [:ul.editor-form__used-in-haku-list
           (doall
            (for [haku (vals form-used-in-hakus)]
@@ -266,29 +266,29 @@
                               (:haku-oid haku)
                               "?lang=fi")
                  :target "_blank"}
-                (get-virkailija-translation :test-application)]
+                @(subscribe [:editor/virkailija-translation :test-application])]
                [:span " | "]
                [:a
                 {:href   (str js/config.applicant.service_url
                               "/hakemus/haku/" (:haku-oid haku)
                               "?lang=fi")
                  :target "_blank"}
-                (get-virkailija-translation :form)]
+                @(subscribe [:editor/virkailija-translation :form])]
                (when (:superuser? @user-info)
                  (link-to-feedback (str "/hakemus/haku/" (:haku-oid haku))))]]))]]
         [:div.editor-form__form-link-container
          [:h3.editor-form__form-link-heading
           [:i.zmdi.zmdi-alert-circle-o]
-          (str " " (get-virkailija-translation :link-to-form))]
+          (str " " @(subscribe [:editor/virkailija-translation :link-to-form]))]
          [:a.editor-form__form-preview-link
           {:href   (str js/config.applicant.service_url
                         "/hakemus/" (:key form)
                         "?lang=fi")
            :target "_blank"}
-          (get-virkailija-translation :form)]
+          @(subscribe [:editor/virkailija-translation :form])]
          [:span " | "]
          [:a.editor-form__form-admin-preview-link
-          (get-virkailija-translation :test-application)]
+          @(subscribe [:editor/virkailija-translation :test-application])]
          (map (partial preview-link (:key form)) @languages)
          (when (:superuser? @user-info)
            (link-to-feedback (str "/hakemus/" (:key form))))]))))

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -1,6 +1,6 @@
 (ns ataru.virkailija.editor.view
   (:require-macros [reagent.ratom :refer [reaction]])
-  (:require [ataru.cljs-util :refer [wrap-scroll-to get-virkailija-translation get-virkailija-label]]
+  (:require [ataru.cljs-util :refer [wrap-scroll-to get-virkailija-translation]]
             [ataru.component-data.component :as component]
             [ataru.virkailija.editor.core :as c]
             [ataru.virkailija.editor.subs]

--- a/src/cljs/ataru/virkailija/views/banner.cljs
+++ b/src/cljs/ataru/virkailija/views/banner.cljs
@@ -1,7 +1,7 @@
 (ns ataru.virkailija.views.banner
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction]])
-  (:require [ataru.cljs-util :as util :refer [get-virkailija-translation get-virkailija-label]]
+  (:require [ataru.cljs-util :as util :refer [get-virkailija-translation]]
             [ataru.util :as autil]
             [ataru.virkailija.routes :as routes]
             [cljs.core.async :refer [<! timeout]]
@@ -16,11 +16,11 @@
   {:editor      {:text :forms-panel :href "/lomake-editori/editor/"}
    :application {:text :applications-panel :href "/lomake-editori/applications/"}})
 
-(def right-labels {:form-edit         (get-virkailija-label :form-edit-rights-panel)
-                   :view-applications (get-virkailija-label :view-applications-rights-panel)
-                   :edit-applications (get-virkailija-label :edit-applications-rights-panel)
-                   :view-valinta      (get-virkailija-label :view-valinta-rights-panel)
-                   :edit-valinta      (get-virkailija-label :edit-valinta-rights-panel)})
+(def right-labels {:form-edit         :form-edit-rights-panel
+                   :view-applications :view-applications-rights-panel
+                   :edit-applications :edit-applications-rights-panel
+                   :view-valinta      :view-valinta-rights-panel
+                   :edit-valinta      :edit-valinta-rights-panel})
 
 (def active-section-arrow [:i.active-section-arrow.zmdi.zmdi-chevron-down.zmdi-hc-lg])
 
@@ -45,12 +45,12 @@
   [label]
   (some #(-> label %) [:fi :sv :en]))
 
-(defn create-org-labels [organizations lang]
+(defn create-org-labels [organizations]
   (map
     (fn [org]
       (str (get-label (:name org))
            (when (not-empty (:rights org))
-             (str " (" (string/join ", " (map #(get-in right-labels [(keyword %) lang]) (:rights org))) ")"))))
+             (str " (" (string/join ", " (map #(-> right-labels (keyword %) (get-virkailija-translation)) (:rights org))) ")"))))
    organizations))
 
 (defn- org-label
@@ -91,7 +91,6 @@
 (defn profile []
   (let [user-info                 (subscribe [:state-query [:editor :user-info]])
         org-select-visible?       (reagent/atom false)
-        lang                      (subscribe [:editor/virkailija-lang])
         results-page              (subscribe [:state-query [:editor :organizations :results-page]])
         search-results            (subscribe [:state-query [:editor :organizations :matches]])
         selected-organization-sub (subscribe [:state-query [:editor :user-info :selected-organization]])
@@ -122,7 +121,7 @@
                   [:ul.profile__organization-select-user-orgs.zmdi-hc-ul]
                   (map
                     (fn [org] [:li [:i.zmdi.zmdi-hc-li.zmdi-accounts] org])
-                    (create-org-labels (or selected-organization organizations) @lang)))
+                    (create-org-labels (or selected-organization organizations))))
                 (when selected-organization
                   [:div
                    (when (:superuser? @user-info)

--- a/src/cljs/ataru/virkailija/views/hakukohde_and_hakukohderyhma_search.cljs
+++ b/src/cljs/ataru/virkailija/views/hakukohde_and_hakukohderyhma_search.cljs
@@ -1,6 +1,5 @@
 (ns ataru.virkailija.views.hakukohde-and-hakukohderyhma-search
   (:require [ataru.util :as util]
-            [ataru.cljs-util :as cljs-util]
             [re-frame.core :as re-frame]
             [reagent.core :as r]))
 
@@ -131,7 +130,7 @@
           [:li.hakukohde-and-hakukohderyhma-category-list-item.hakukohde-and-hakukohderyhma-category-list-item--show-more
            {:on-click #(swap! show-n + 10)}
            [:span.hakukohde-and-hakukohderyhma-show-more
-            (cljs-util/get-virkailija-translation :show-more)]])]])))
+            @(re-frame/subscribe [:editor/virkailija-translation :show-more])]])]])))
 
 (defn search-input
   [{:keys [id
@@ -150,7 +149,7 @@
                     hakukohde-selected?
                     hakukohderyhma-selected?
                     (.-value (.-target %))])
-    :placeholder (cljs-util/get-virkailija-translation :search-hakukohde-placeholder)}])
+    :placeholder @(re-frame/subscribe [:editor/virkailija-translation :search-hakukohde-placeholder])}])
 
 (defn visibility-checkbox
   [id path]
@@ -163,7 +162,7 @@
      :on-change #(re-frame/dispatch [:editor/toggle-element-visibility-on-form path])}]
    [:label
     {:for id}
-    (cljs-util/get-virkailija-translation :is-hidden?)]])
+    @(re-frame/subscribe [:editor/virkailija-translation :is-hidden?])]])
 
 (defn search-listing
   [{:keys [id
@@ -182,7 +181,7 @@
                              id
                              hakukohderyhmat]))]
        [category-listing
-        (cljs-util/get-virkailija-translation :hakukohderyhmat)
+        @(re-frame/subscribe [:editor/virkailija-translation :hakukohderyhmat])
         hits
         hakukohderyhma-selected?
         on-hakukohderyhma-select

--- a/src/cljs/ataru/virkailija/views/template_editor.cljs
+++ b/src/cljs/ataru/virkailija/views/template_editor.cljs
@@ -1,6 +1,6 @@
 (ns ataru.virkailija.views.template-editor
   (:require [ataru.translations.texts :refer [email-default-texts]]
-            [ataru.cljs-util :refer [get-virkailija-translation get-virkailija-label]]
+            [ataru.cljs-util :refer [get-virkailija-translation]]
             [ataru.virkailija.views.modal :as modal]
             [goog.string :as s]
             [re-frame.core :refer [subscribe dispatch]]
@@ -16,9 +16,9 @@
 (defn- render-template-editor []
   (let [tab-lang (r/atom :fi)]
     (fn []
-      (let [language-names   {:fi (get-virkailija-label :finnish)
-                              :sv (get-virkailija-label :swedish)
-                              :en (get-virkailija-label :english)}
+      (let [language-names   {:fi (get-virkailija-translation :finnish)
+                              :sv (get-virkailija-translation :swedish)
+                              :en (get-virkailija-translation :english)}
             content          @(subscribe [:editor/email-template])
             contents-changed @(subscribe [:editor/email-templates-altered])
             any-changed?     (some true? (vals contents-changed))
@@ -53,7 +53,7 @@
                     {:key   (str "email-preview-lang-radio-label-" (name @tab-lang))
                      :for   (str "email-template-language-selection-" (name button-lang))
                      :class (when (= button-lang @tab-lang) "virkailija-email-preview__tab-label--selected")}
-                    (get-in language-names [button-lang @virkailija-lang])
+                    (get language-names button-lang)
                     (when (get contents-changed (name button-lang))
                       [:span.virkailija-email-preview__tab-edited "*"])]))
                 [:fi :sv :en]))]

--- a/src/cljs/ataru/virkailija/views/template_editor.cljs
+++ b/src/cljs/ataru/virkailija/views/template_editor.cljs
@@ -1,6 +1,5 @@
 (ns ataru.virkailija.views.template-editor
   (:require [ataru.translations.texts :refer [email-default-texts]]
-            [ataru.cljs-util :refer [get-virkailija-translation]]
             [ataru.virkailija.views.modal :as modal]
             [goog.string :as s]
             [re-frame.core :refer [subscribe dispatch]]
@@ -16,9 +15,9 @@
 (defn- render-template-editor []
   (let [tab-lang (r/atom :fi)]
     (fn []
-      (let [language-names   {:fi (get-virkailija-translation :finnish)
-                              :sv (get-virkailija-translation :swedish)
-                              :en (get-virkailija-translation :english)}
+      (let [language-names   {:fi @(subscribe [:editor/virkailija-translation :finnish])
+                              :sv @(subscribe [:editor/virkailija-translation :swedish])
+                              :en @(subscribe [:editor/virkailija-translation :english])}
             content          @(subscribe [:editor/email-template])
             contents-changed @(subscribe [:editor/email-templates-altered])
             any-changed?     (some true? (vals contents-changed))
@@ -28,10 +27,10 @@
         [modal/modal
          #(dispatch [:editor/toggle-email-template-editor])
          [:div.virkailija-email-preview
-          [:h3.virkailija-email-preview__heading (get-virkailija-translation :email-content)]
+          [:h3.virkailija-email-preview__heading @(subscribe [:editor/virkailija-translation :email-content])]
           [:div.virkailija-email-preview__info-text
            (s/format "%s '%s'"
-                     (get-virkailija-translation :applicant-will-receive-following-email)
+                     @(subscribe [:editor/virkailija-translation :applicant-will-receive-following-email])
                      (get lang-content :from))]
           (when (not (nil? content))
             [:div.virkailija-email-preview__tabs
@@ -59,22 +58,22 @@
                 [:fi :sv :en]))]
              [:div.virkailija-email-preview__tab-border]
              [:div.virkailija-email-preview__tab-content
-              [:h4.virkailija-email-preview__sub-heading (get-virkailija-translation :editable-content-title)]
+              [:h4.virkailija-email-preview__sub-heading @(subscribe [:editor/virkailija-translation :editable-content-title])]
               [:input.virkailija-email-preview__input
                {:value     (:subject lang-content)
                 :class     (when (clojure.string/blank? (:subject lang-content)) "virkailija-email-preview__input-field-error")
                 :on-change #(dispatch [:editor/update-email-preview (name @tab-lang) :subject (.-value (.-target %))])}]
-              [:h4.virkailija-email-preview__sub-heading (get-virkailija-translation :editable-content-beginning)]
+              [:h4.virkailija-email-preview__sub-heading @(subscribe [:editor/virkailija-translation :editable-content-beginning])]
               [:textarea.virkailija-email-preview__text-input
                {:value     (:content lang-content)
                 :on-change #(dispatch [:editor/update-email-preview (name @tab-lang) :content (.-value (.-target %))])}]
-              [:h4.virkailija-email-preview__sub-heading (get-virkailija-translation  :application-oid-here)]
-              [:h4.virkailija-email-preview__sub-heading (get-virkailija-translation :editable-content-ending)]
+              [:h4.virkailija-email-preview__sub-heading @(subscribe [:editor/virkailija-translation  :application-oid-here])]
+              [:h4.virkailija-email-preview__sub-heading @(subscribe [:editor/virkailija-translation :editable-content-ending])]
               [:textarea.virkailija-email-preview__text-input
                {:value     (:content-ending lang-content)
                 :on-change #(dispatch [:editor/update-email-preview (name @tab-lang) :content-ending (.-value (.-target %))])}]
               [:div.virkailija-email-preview__preview-container
-               [:h4.virkailija-email-preview__sub-heading (get-virkailija-translation :message-preview)]
+               [:h4.virkailija-email-preview__sub-heading @(subscribe [:editor/virkailija-translation :message-preview])]
                [:iframe.virkailija-email-preview__preview-iframe
                 {:srcDoc (:body lang-content)}]
                [:div.virkailija-email-preview__buttons
@@ -83,7 +82,7 @@
                               "editor-form__control-button--enabled"
                               "editor-form__control-button--disabled")
                   :on-click #(when (and any-changed? (not any-errors?)) (dispatch [:editor/save-email-template]))}
-                 (str (get-virkailija-translation :save-changes)
+                 (str @(subscribe [:editor/virkailija-translation :save-changes])
                       (when any-changed?
                         (str
                          " ("

--- a/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
+++ b/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
@@ -16,7 +16,6 @@
                                                                        copy-link
                                                                        question-group-answer?
                                                                        answers->read-only-format]]
-            [ataru.cljs-util :refer [get-virkailija-translation]]
             [ataru.feature-config :as fc]
             [ataru.component-data.component-util :refer [answer-to-always-include?]]
             [ataru.util :as util]
@@ -103,11 +102,11 @@
                         component-key     (str "attachment-div-" idx)
                         virus-status-elem (case virus-scan-status
                                             "not_started" [:span.application__virkailija-readonly-attachment-virus-status-not-started
-                                                           (s/format "| %s..." (get-virkailija-translation :checking))]
+                                                           (s/format "| %s..." @(subscribe [:editor/virkailija-translation :checking]))]
                                             "failed" [:span.application__virkailija-readonly-attachment-virus-status-virus-found
-                                                      (s/format "| %s" (get-virkailija-translation :virus-found))]
+                                                      (s/format "| %s" @(subscribe [:editor/virkailija-translation :virus-found]))]
                                             "done" nil
-                                            (get-virkailija-translation :error))]
+                                            @(subscribe [:editor/virkailija-translation :error]))]
                     [:div.application__virkailija-readonly-attachment
                      {:key component-key}
                      [attachment-item file-key virus-scan-status virus-status-elem text]]))
@@ -242,8 +241,8 @@
           [:div
            [:p.application__text-field-paragraph
             (if value
-              (str (get-virkailija-translation :unknown-option) " " value)
-              (str (get-virkailija-translation :empty-option)))]]))])]])
+              (str @(subscribe [:editor/virkailija-translation :unknown-option]) " " value)
+              (str @(subscribe [:editor/virkailija-translation :empty-option])))]]))])]])
 
 (defn- haku-row [haku-name haku-oid]
   [:div.application__form-field

--- a/test/cljs/unit/ataru/hakija/banner_test.cljs
+++ b/test/cljs/unit/ataru/hakija/banner_test.cljs
@@ -7,7 +7,7 @@
 
 (deftest correctly-shows-remaining-time
   (defn invoke-and-verify [hours minutes substring]
-    (let [actual (hakuaika-left-text hours minutes)
+    (let [actual (hakuaika-left-text hours minutes :fi)
           text   (second actual)]
       (is (includes? text substring)))
     )
@@ -23,5 +23,5 @@
                (invoke-and-verify 0 59 "Hakuaikaa jäljellä alle tunti")
                (invoke-and-verify 1 00 "Hakuaikaa jäljellä alle vuorokausi")
                (invoke-and-verify 23 59 "Hakuaikaa jäljellä alle vuorokausi")
-               (is (nil? (hakuaika-left-text 24 0)))))
+               (is (nil? (hakuaika-left-text 24 0 :fi)))))
 


### PR DESCRIPTION
Tässä PR:ssä

* Kevytvalinnan tekstit haetaan kielikäännöspalvelusta
* Nykyinen tapa käyttää kielikäännöksiä on muutettu niin, että ainoastaan `ataru.translations.translation-util` -nimiavaruudesta voi hakea käännöksiä suoraan. Muut paikat poistettu.
* Hakijasovellus käyttää em. nimiavaruuden `get-hakija-translation` -funktiota.
* Virkailijasovellus käyttää `:editor/virkailija-translation` -kirjautumista.