### PR TITLE
BUG-2136 Pass optional error params to translation function to ensure correct formatting

### DIFF
--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -862,10 +862,10 @@
       [attachment-filename component-id question-group-idx attachment-idx true]]
      [:div.application__form-attachment-list-item-sub-container.application__form-attachment-error-container
       (doall
-       (map-indexed (fn [i [error]]
+       (map-indexed (fn [i [error params]]
                       ^{:key (str "attachment-error-" i)}
                       [:span.application__form-attachment-error
-                       (tu/get-hakija-translation error lang)])
+                       (tu/get-hakija-translation error lang params)])
                     (:errors attachment)))]
      [:div.application__form-attachment-list-item-sub-container
       [attachment-remove-button field-descriptor question-group-idx attachment-idx]]]))


### PR DESCRIPTION
Ei siitä sen kummmempaa, varmaan refaktoroinnin vauhtihuumassa vain unohtunut alunperin. Tällä toimii:

![Screenshot 2020-03-11 at 14 02 09](https://user-images.githubusercontent.com/1393900/76416481-d86c0b80-63a3-11ea-8d64-fc513a2ba5a0.png)
