### PR TITLE
BUG-2100: Redirect user to generic error page on technical login failure

### DIFF
--- a/resources/ataru-oph.properties
+++ b/resources/ataru-oph.properties
@@ -13,6 +13,7 @@ ataru.hakemus-edit = ${url-hakija}/hakemus?modify=$1
 
 cas.login = ${url-virkailija}/cas/login?service=${ataru.login-success}
 cas.logout = ${url-virkailija}/cas/logout?service=${ataru.login-success}
+cas.failure = ${url-editor}/virhe
 
 kayttooikeus-service.kayttooikeus.kayttaja = ${url-virkailija}/kayttooikeus-service/kayttooikeus/kayttaja
 

--- a/src/clj/ataru/virkailija/authentication/auth_routes.clj
+++ b/src/clj/ataru/virkailija/authentication/auth_routes.clj
@@ -17,8 +17,6 @@
     url-from-session
     (string/replace url-from-session #"^http://" "https://")))
 
-
-
 (defn- fake-login-provider [ticket]
   (fn []
       (let [username      (if (= ticket "USER-WITH-HAKUKOHDE-ORGANIZATION")

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -142,9 +142,10 @@
 
 (api/defroutes app-routes
   (api/undocumented
-    (api/GET "/" [] (render-virkailija-page))
-    (api/GET client-routes [] (render-virkailija-page))
-    (api/GET client-sub-routes [] (render-virkailija-page))))
+   (api/GET "/" [] (render-virkailija-page))
+   (api/GET client-routes [] (render-virkailija-page))
+    (api/GET client-sub-routes [] (render-virkailija-page))
+    (api/GET "/virhe" [] (render-virkailija-page))))
 
 (defn- render-file-in-dev
   [filename js-config]

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1605,7 +1605,11 @@
                                                      :en "Selection"}
    :julkaisu                                        {:fi "Julkaisu"}
    :vastaanotto                                     {:fi "Vastaanotto"}
-   :ilmoittautuminen                                {:fi "Ilmoittautuminen"}})
+   :ilmoittautuminen                                {:fi "Ilmoittautuminen"}
+   :odottamaton-virhe-otsikko                       {:fi "Tapahtui odottamaton virhe"
+                                                     :sv "Ett oväntat fel uppstod"}
+   :odottamaton-virhe-aputeksti                     {:fi "Yritä uudelleen tai ota yhteyttä ylläpitoon."
+                                                     :sv "Försök igen, om problemet kvarstår, kontakta registratorn."}})
 
 (def state-translations
   {:active                 {:fi "Aktiivinen"

--- a/src/cljs/ataru/virkailija/error/view.cljs
+++ b/src/cljs/ataru/virkailija/error/view.cljs
@@ -1,0 +1,10 @@
+(ns ataru.virkailija.error.view
+  (:require [re-frame.core :refer [subscribe]]))
+
+(defn error []
+  [:div
+   [:div.editor-form__container.panel-content
+    [:div.editor-form__form-header-row
+     [:h1.editor-form__form-heading @(subscribe [:editor/virkailija-translation :odottamaton-virhe-otsikko])]
+     ]
+    [:div @(subscribe [:editor/virkailija-translation :odottamaton-virhe-aputeksti])]]])

--- a/src/cljs/ataru/virkailija/routes.cljs
+++ b/src/cljs/ataru/virkailija/routes.cljs
@@ -125,4 +125,10 @@
     (dispatch [:application/set-filters-from-query])
     (dispatch [:application/select-form key]))
 
+  (defroute #"^/lomake-editori/virhe?"
+    []
+    (common-actions)
+    (dispatch [:set-active-panel :error])
+    (dispatch [:application/stop-loading-applications]))
+
   (accountant/dispatch-current!))

--- a/src/cljs/ataru/virkailija/views.cljs
+++ b/src/cljs/ataru/virkailija/views.cljs
@@ -1,16 +1,16 @@
 (ns ataru.virkailija.views
     (:require [re-frame.core :as re-frame]
-              [reagent.core :as r]
               [ataru.virkailija.views.banner :refer [snackbar top-banner]]
               [ataru.virkailija.application.view :refer [application application-version-changes]]
               [ataru.virkailija.application.attachments.virkailija-attachment-view :as attachments]
               [ataru.virkailija.views.template-editor :refer [email-template-editor]]
-              [ataru.virkailija.dev.lomake :as l]
               [ataru.virkailija.editor.view :refer [editor]]
-              [taoensso.timbre :refer-macros [spy]]))
+              [ataru.virkailija.error.view :refer [error]]))
 
 (def panel-components
-  {:editor editor :application application})
+  {:editor      editor
+   :application application
+   :error       error})
 
 (defn no-privileges []
   [:div.privilege-info-outer [:div.privilege-info-inner "Ei oikeuksia"]])
@@ -30,6 +30,8 @@
   [privileged-panel :application #{:view-applications :edit-applications}])
 (defmethod panels :editor []
   [privileged-panel :editor #{:form-edit}])
+(defmethod panels :error []
+  [(get panel-components :error)])
 (defmethod panels :default [])
 
 (defn main-panel []


### PR DESCRIPTION
The login failure in this context means erroneous CAS ticket handling or other such technical issues, not "wrong password" kind of login issues.

---

Tässä on vielä epäselvyytenä mihin kohtiin tämä pitäisi laittaa näkymään ja missä kohdin olemassaoleva uudelleenohjaus kirjautumiseen on OK. Itse virhehän näyttää tältä:

![Screenshot 2020-03-17 at 16 54 24](https://user-images.githubusercontent.com/1393900/77062469-99ae0500-69e4-11ea-98f9-8f1e89c08e26.png)
