### PR TITLE
OY-352: improve logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -89,7 +89,10 @@
                  [com.github.ben-manes.caffeine/caffeine "2.8.0"]
                  [clj-http "3.10.0"]
                  [org.clojure/data.xml "0.0.8"]
-                 [com.jcraft/jsch "0.1.55"]]
+                 [com.jcraft/jsch "0.1.55"]
+                 ; these two deps are for routing all other logging frameworks' output to timbre by first piping them to SLF4J and then timbre
+                 [com.fzakaria/slf4j-timbre "0.3.19"]
+                 [org.slf4j/log4j-over-slf4j "1.7.30"]]
 
   :min-lein-version "2.5.3"
 

--- a/spec/ataru/form_store_spec.clj
+++ b/spec/ataru/form_store_spec.clj
@@ -2,8 +2,7 @@
   (:require [speclj.core :refer :all]
             [clj-time.core :as t]
             [ataru.fixtures.person-info-form :refer [form]]
-            [ataru.forms.form-store :as store]
-            [taoensso.timbre :refer [spy debug]])
+            [ataru.forms.form-store :as store])
   (:import
    (clojure.lang ExceptionInfo)))
 

--- a/spec/ataru/hakija/validator_spec.clj
+++ b/spec/ataru/hakija/validator_spec.clj
@@ -6,8 +6,7 @@
             [speclj.core :refer :all]
             [ataru.util :as util]
             [ataru.fixtures.answer :refer [answer]]
-            [ataru.fixtures.person-info-form :refer [form]]
-            [taoensso.timbre :refer [spy debug]]))
+            [ataru.fixtures.person-info-form :refer [form]]))
 
 (def f form)
 (def a answer)

--- a/spec/ataru/virkailija/virkailija_routes_spec.clj
+++ b/spec/ataru/virkailija/virkailija_routes_spec.clj
@@ -5,8 +5,7 @@
             [ataru.fixtures.form :as fixtures]
             [speclj.core :refer :all]
             [cheshire.core :as json]
-            [ataru.virkailija.editor.form-diff :as form-diff]
-            [taoensso.timbre :refer [spy debug]]))
+            [ataru.virkailija.editor.form-diff :as form-diff]))
 
 (defmacro with-static-resource
   [name path]

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -25,7 +25,7 @@
     [ataru.virkailija.editor.form-utils :refer [visible?]]
     [ataru.virkailija.authentication.virkailija-edit :as virkailija-edit]
     [medley.core :refer [find-first filter-vals]]
-    [taoensso.timbre :refer [spy debug] :as log]
+    [taoensso.timbre :as log]
     [ataru.application.review-states :as review-states]
     [ataru.application.application-states :as application-states]
     [ataru.schema.form-schema :as ataru-schema]

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -15,10 +15,8 @@
             [clojure.string :as string :refer [trim]]
             [clojure.core.match :refer [match]]
             [clojure.java.io :refer [input-stream]]
-            [taoensso.timbre :refer [spy debug]]
             [ataru.application.review-states :as review-states]
-            [ataru.application.application-states :as application-states]
-            [taoensso.timbre :as log]))
+            [ataru.application.application-states :as application-states]))
 
 
 (def max-value-length 5000)

--- a/src/clj/ataru/applications/permission_check.clj
+++ b/src/clj/ataru/applications/permission_check.clj
@@ -1,5 +1,5 @@
 (ns ataru.applications.permission-check
-  (:require [taoensso.timbre :refer [error]]
+  (:require [taoensso.timbre :as log]
             [ataru.applications.application-access-control :as aac]
             [ataru.applications.application-store :as application-store]))
 
@@ -16,6 +16,6 @@
             boolean)})
     (catch Exception e
       (let [msg "Error while checking permission"]
-        (error e msg)
+        (log/error e msg)
         {:accessAllowed false
          :errorMessage  msg}))))

--- a/src/clj/ataru/config/core.clj
+++ b/src/clj/ataru/config/core.clj
@@ -13,7 +13,7 @@
   (try
     (slurp path)
     (catch Exception e
-      (log/warn (str "Could not read configuration from '" path "'"))
+      (log/warn e (str "Could not read configuration from '" path "'"))
       "{}")))
 
 (defonce secrets

--- a/src/clj/ataru/forms/form_access_control.clj
+++ b/src/clj/ataru/forms/form_access_control.clj
@@ -8,8 +8,7 @@
    [ataru.tarjonta-service.tarjonta-service :as tarjonta-service]
    [ataru.organization-service.session-organizations :as session-orgs]
    [ataru.organization-service.organization-client :refer [oph-organization]]
-   [ataru.middleware.user-feedback :refer [user-feedback-exception]]
-   [taoensso.timbre :refer [warn]]))
+   [ataru.middleware.user-feedback :refer [user-feedback-exception]]))
 
 (defn- form-allowed-by-id?
   [authorized-organization-oids form-id]

--- a/src/clj/ataru/forms/form_store.clj
+++ b/src/clj/ataru/forms/form_store.clj
@@ -6,7 +6,7 @@
             [clojure.java.jdbc :as jdbc :refer [with-db-transaction]]
             [ataru.db.db :refer [exec get-datasource]]
             [yesql.core :refer [defqueries]]
-            [taoensso.timbre :refer [warn]])
+            [taoensso.timbre :as log])
   (:import [java.util UUID]))
 
 (defqueries "sql/form-queries.sql")
@@ -115,12 +115,12 @@
       (when-let [latest-version (not-empty (and id (fetch-latest-version-and-lock-for-update id conn)))]
         (if (not (latest-version-same? form latest-version))
           (do
-            (warn (str "Form with id "
-                       (:id latest-version)
-                       " created-time "
-                       (:created-time latest-version)
-                       " already exists. Supplied form id was "
-                       (:id form)
+            (log/warn (str "Form with id "
+                           (:id latest-version)
+                           " created-time "
+                           (:created-time latest-version)
+                           " already exists. Supplied form id was "
+                           (:id form)
                        " created-time "
                        (:created-time form)))
             (throw (user-feedback-exception "Lomakkeen sisältö on muuttunut. Lataa sivu uudelleen.")))

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -26,7 +26,6 @@
             [ring.util.http-response :as response]
             [schema.core :as s]
             [selmer.parser :as selmer]
-            [taoensso.timbre :refer [info warn error]]
             [cheshire.core :as json]
             [ataru.config.core :refer [config]]
             [ataru.flowdock.flowdock-client :as flowdock-client]

--- a/src/clj/ataru/hakija/validator.clj
+++ b/src/clj/ataru/hakija/validator.clj
@@ -6,7 +6,7 @@
             [clojure.set :refer [difference]]
             [clojure.core.match :refer [match]]
             [clojure.core.async :as async]
-            [taoensso.timbre :refer [spy debug warn info]]
+            [taoensso.timbre :as log]
             [ataru.koodisto.koodisto :as koodisto]))
 
 (defn allowed-values [options]
@@ -230,7 +230,7 @@
                                                               (belongs-to-existing-hakukohde-or-hakukohderyma? field hakukohteet hakukohderyhmat))
                                                         (passes-all? has-applied form validators answers answers-by-key field virkailija?)
                                                         (every? nil? answers))}})
-                                :else (when (some? field) (warn "Invalid field clause, not validated:" field)))]
+                                :else (when (some? field) (log/warn "Invalid field clause, not validated:" field)))]
               (build-results koodisto-cache has-applied answers-by-key ret form rest-form-fields hakukohderyhmat virkailija?)
               results)))))
 
@@ -267,11 +267,11 @@
                              (build-failed-results answers-by-key))
         failed-meta-fields (validate-meta-fields application)]
     (when (not (empty? extra-answers))
-      (warn "Extra answers in application" (apply str extra-answers)))
+      (log/warn "Extra answers in application" (apply str extra-answers)))
     (when (not (empty? failed-results))
-      (warn "Validation failed in application fields" failed-results))
+      (log/warn "Validation failed in application fields" failed-results))
     (when (not (empty? failed-meta-fields))
-      (warn "Validation failed in application meta fields " (str failed-meta-fields)))
+      (log/warn "Validation failed in application meta fields " (str failed-meta-fields)))
     {:passed?
      (and
        (empty? extra-answers)

--- a/src/clj/ataru/http/server.clj
+++ b/src/clj/ataru/http/server.clj
@@ -1,5 +1,5 @@
 (ns ataru.http.server
-  (:require [taoensso.timbre :refer [info report]]
+  (:require [taoensso.timbre :as log]
             [clojure.core.async :as a]
             [environ.core :refer [env]]
             [ring.middleware.reload :refer [wrap-reload]]
@@ -18,7 +18,7 @@
   (when (and (:dev? env) (compare-and-set! repl-started false true))
     (do
       (nrepl/start-server :port repl-port)
-      (report "nREPL started on port" repl-port))))
+      (log/report "nREPL started on port" repl-port))))
 
 (defrecord Server []
   component/Lifecycle
@@ -33,13 +33,13 @@
           server       (http/start-server handler {:port port
                                                    :executor executor})]
       (start-repl! repl-port)
-      (report (str "Started server on port " port))
+      (log/report (str "Started server on port " port))
       (assoc this :server server)))
 
   (stop [this]
-    (report "Stopping server")
+    (log/report "Stopping server")
     (try (.close (:server this)) (catch Exception e))
-    (report "Stopped server")
+    (log/report "Stopped server")
     (assoc this :server nil)))
 
 (defn new-server

--- a/src/clj/ataru/tarjonta_service/tarjonta_client.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_client.clj
@@ -5,8 +5,7 @@
    [ataru.util.http-util :as http-util]
    [cheshire.core :as json]
    [clojure.string :as string]
-   [schema.core :as s]
-   [taoensso.timbre :refer [warn info]])
+   [schema.core :as s])
   (:import [org.joda.time DateTime DateTimeZone]))
 
 (def koulutus-checker (s/checker schema/Koulutus))

--- a/src/clj/ataru/timbre_config.clj
+++ b/src/clj/ataru/timbre_config.clj
@@ -8,20 +8,25 @@
   (:import [java.util TimeZone]))
 
 (defn configure-logging! [app-id]
-  (timbre/merge-config!
-   {:appenders
-    {:println
-     (println-appender {:stream :std-out})
-     :file-appender
-     (rolling-appender
-      {:path    (str (case (app-utils/get-app-id)
-                       :virkailija (-> config :log :virkailija-base-path)
-                       :hakija     (-> config :log :hakija-base-path))
-                     "/app_" (case (app-utils/get-app-id)
-                               :virkailija "ataru-editori"
-                               :hakija     "ataru-hakija")
-                     (when (:hostname env) (str "_" (:hostname env))))
-       :pattern :daily})}
-    :timestamp-opts {:pattern  "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
-                     :timezone (TimeZone/getTimeZone "Europe/Helsinki")}
-    :output-fn      (partial timbre/default-output-fn {:stacktrace-fonts {}})}))
+  (let [system-defaults {:min-level (if (:dev? env) :debug :info)}]
+    (timbre/merge-config!
+     {:appenders
+      {:println
+       (merge
+        (println-appender {:stream :std-out})
+        system-defaults)
+       :file-appender
+       (merge
+        (rolling-appender
+        {:path    (str (case (app-utils/get-app-id)
+                         :virkailija (-> config :log :virkailija-base-path)
+                         :hakija     (-> config :log :hakija-base-path))
+                       "/app_" (case (app-utils/get-app-id)
+                                 :virkailija "ataru-editori"
+                                 :hakija     "ataru-hakija")
+                       (when (:hostname env) (str "_" (:hostname env))))
+         :pattern :daily})
+        system-defaults)}
+      :timestamp-opts {:pattern  "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+                       :timezone (TimeZone/getTimeZone "Europe/Helsinki")}
+      :output-fn      (partial timbre/default-output-fn {:stacktrace-fonts {}})})))

--- a/src/clj/ataru/util/client_error.clj
+++ b/src/clj/ataru/util/client_error.clj
@@ -1,5 +1,5 @@
 (ns ataru.util.client-error
-  (:require [taoensso.timbre :refer [error]]
+  (:require [taoensso.timbre :as log]
             [schema.core :as s]))
 
 (s/defschema ClientError {:error-message s/Str
@@ -11,9 +11,9 @@
 
 
 (defn log-client-error [error-details]
-  (error (str "Error from client browser:\n"
-              (:error-message error-details) "\n"
-              (:url error-details) "\n"
-              "line: " (:line error-details) " column: " (:col error-details) "\n"
-              "user-agent: " (:user-agent error-details) "\n"
-              "stack trace: " (:stack error-details))))
+  (log/error (str "Error from client browser:\n"
+                  (:error-message error-details) "\n"
+                  (:url error-details) "\n"
+                  "line: " (:line error-details) " column: " (:col error-details) "\n"
+                  "user-agent: " (:user-agent error-details) "\n"
+                  "stack trace: " (:stack error-details))))

--- a/src/clj/ataru/virkailija/authentication/auth_routes.clj
+++ b/src/clj/ataru/virkailija/authentication/auth_routes.clj
@@ -1,12 +1,9 @@
 (ns ataru.virkailija.authentication.auth-routes
   (:require [ataru.virkailija.authentication.auth :refer [login cas-login logout cas-initiated-logout]]
-            [ataru.config.url-helper :refer [resolve-url]]
             [ataru.middleware.session-client :as session-client]
             [ataru.config.core :refer [config]]
             [compojure.api.sweet :as api]
             [environ.core :refer [env]]
-            [taoensso.timbre :refer [spy debug info]]
-            [clojure.core.match :refer [match]]
             [clojure.string :as string]))
 
 (defn- rewrite-url-for-environment

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -71,7 +71,7 @@
             [ring.util.response :refer [redirect header] :as ring-util]
             [schema.core :as s]
             [selmer.parser :as selmer]
-            [taoensso.timbre :refer [spy debug error warn info]]
+            [taoensso.timbre :as log]
             [ataru.user-rights :as user-rights]
             [ataru.util :as util])
   (:import java.util.Locale
@@ -619,7 +619,7 @@
         :summary "Generate Excel sheet for applications given by ids (and which the user has rights to view)"
         (let [size-limit 40000
               application-keys (json/parse-string application-keys)]
-          (info "Yritetään" (count application-keys) "hakemuksen excelin luontia")
+          (log/info "Yritetään" (count application-keys) "hakemuksen excelin luontia")
           (if (< size-limit (count application-keys))
             (response/request-entity-too-large
              {:error (str "Cannot create excel for more than " size-limit " applications")})
@@ -1201,7 +1201,7 @@
             {:yksiloimattomat yksiloimattomat
              :applications    applications}
             (if (get-in config [:yksiloimattomat :allow] false)
-              (do (warn "Yksilöimättömiä hakijoita")
+              (do (log/warn "Yksilöimättömiä hakijoita")
                   (response/ok applications))
               (response/conflict
                {:error      "Yksilöimättömiä hakijoita"
@@ -1230,7 +1230,7 @@
             {:yksiloimattomat yksiloimattomat
              :applications    applications}
             (if (get-in config [:yksiloimattomat :allow] false)
-              (do (warn "Yksilöimättömiä hakijoita")
+              (do (log/warn "Yksilöimättömiä hakijoita")
                   (response/ok applications))
               (response/conflict
                {:error      "Yksilöimättömiä hakijoita"

--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -2,8 +2,6 @@
   (:require #?(:cljs [ataru.cljs-util :as util])
             #?(:clj  [clojure.core.match :refer [match]]
                :cljs [cljs.core.match :refer-macros [match]])
-            #?(:clj  [taoensso.timbre :refer [spy debug]]
-               :cljs [taoensso.timbre :refer-macros [spy debug]])
             #?(:cljs [goog.string :as gstring])
             #?(:clj  [clj-time.core :as time]
                :cljs [cljs-time.core :as time])

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -6,7 +6,6 @@
             [cljs-uuid-utils.core :as uuid]
             [re-frame.core :refer [dispatch subscribe]]
             [reagent.core :as r]
-            [taoensso.timbre :refer-macros [spy debug]]
             [cemerick.url :as url]
             [camel-snake-kebab.core :refer [->kebab-case-keyword]]
             [camel-snake-kebab.extras :refer [transform-keys]]

--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -2,7 +2,6 @@
   "Pure functions handling application data"
   (:require [ataru.util :as util]
             [medley.core :refer [remove-vals filter-vals remove-keys]]
-            [taoensso.timbre :refer-macros [spy debug]]
             [ataru.application-common.application-field-common :refer [required-validators]]
             [clojure.core.match :refer [match]]
             [cljs-time.core :as time]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -16,7 +16,6 @@
             [ataru.hakija.pohjakoulutusristiriita :as pohjakoulutusristiriita]
             [ataru.util :as util]
             [reagent.core :as r]
-            [taoensso.timbre :refer-macros [spy debug]]
             [ataru.feature-config :as fc]
             [clojure.string :as string]
             [ataru.hakija.person-info-fields :refer [editing-forbidden-person-info-field-ids]]

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -14,7 +14,6 @@
                                               create-application-to-submit
                                               extract-wrapper-sections
                                               db->valid-status]]
-            [taoensso.timbre :refer-macros [spy debug]]
             [clojure.data :as d]
             [ataru.component-data.value-transformers :as value-transformers]
             [cljs-time.core :as c]

--- a/src/cljs/ataru/hakija/core.cljs
+++ b/src/cljs/ataru/hakija/core.cljs
@@ -2,7 +2,6 @@
   (:require [reagent.core :as reagent]
             [re-frame.core :as re-frame]
             [re-frisk.core :as re-frisk]
-            [taoensso.timbre :refer-macros [spy info]]
             [ataru.cljs-util :as cljs-util]
             [ataru.hakija.hakija-ajax :as ajax]
             [ataru.hakija.application-view :refer [form-view]]

--- a/src/cljs/ataru/hakija/hakija_readonly.cljs
+++ b/src/cljs/ataru/hakija/hakija_readonly.cljs
@@ -18,8 +18,7 @@
                                                                        predefined-value-answer?
                                                                        scroll-to-anchor
                                                                        question-group-answer?
-                                                                       answers->read-only-format]]
-            [taoensso.timbre :refer-macros [spy debug]]))
+                                                                       answers->read-only-format]]))
 
 (defn- from-multi-lang [text lang]
   (util/non-blank-val text [lang :fi :sv :en]))

--- a/src/cljs/ataru/virkailija/application/handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/handlers.cljs
@@ -9,7 +9,6 @@
             [ataru.cljs-util :as cljs-util]
             [ataru.virkailija.temporal :as temporal]
             [reagent.core :as r]
-            [taoensso.timbre :refer-macros [spy debug]]
             [ataru.feature-config :as fc]
             [ataru.url :as url]
             [camel-snake-kebab.core :as c]

--- a/src/cljs/ataru/virkailija/application/view.cljs
+++ b/src/cljs/ataru/virkailija/application/view.cljs
@@ -34,8 +34,7 @@
             [medley.core :refer [find-first]]
             [re-frame.core :refer [subscribe dispatch dispatch-sync]]
             [reagent.core :as r]
-            [reagent.ratom :refer-macros [reaction]]
-            [taoensso.timbre :refer-macros [spy debug]]))
+            [reagent.ratom :refer-macros [reaction]]))
 
 (defn- icon-check []
   [:span.application-handling__review-state-selected-icon.zmdi-hc-stack.zmdi-hc-lg

--- a/src/cljs/ataru/virkailija/autosave.cljs
+++ b/src/cljs/ataru/virkailija/autosave.cljs
@@ -4,7 +4,7 @@
             [ataru.cljs-util :refer [debounce]]
             [cljs.core.match :refer-macros [match]]
             [cljs.core.async :as a :refer [chan <! >! close! alts! timeout sliding-buffer]]
-            [taoensso.timbre :refer-macros [spy info debug]]))
+            [taoensso.timbre :as log]))
 
 (defn stop-autosave! [stop-fn]
   (when stop-fn
@@ -46,7 +46,7 @@
         (if (and @value-to-watch
                  (not @stop?))
           (recur)
-          (info "Stopping autosave at" subscribe-path)))
+          (log/info "Stopping autosave at" subscribe-path)))
 
       (go-loop []
         (when-let [[prev current] (<! change)]

--- a/src/cljs/ataru/virkailija/core.cljs
+++ b/src/cljs/ataru/virkailija/core.cljs
@@ -12,7 +12,6 @@
             [ataru.virkailija.routes :as routes]
             [ataru.virkailija.views :as views]
             [ataru.virkailija.editor.handlers]
-            [taoensso.timbre :refer-macros [spy info]]
             [ataru.application-common.fx :refer [http]] ; ataru.application-common.fx must be required to have common fx handlers enabled
             [ataru.virkailija.views.banner :as banner]
             [ataru.virkailija.application.view :as app-handling-view]))

--- a/src/cljs/ataru/virkailija/editor/component.cljs
+++ b/src/cljs/ataru/virkailija/editor/component.cljs
@@ -19,8 +19,7 @@
    [cljs-time.core :as t]
    [re-frame.core :refer [subscribe dispatch dispatch-sync]]
    [reagent.core :as r]
-   [reagent.ratom :refer-macros [reaction]]
-   [taoensso.timbre :refer-macros [spy debug]]))
+   [reagent.ratom :refer-macros [reaction]]))
 
 (defn- required-disabled [initial-content]
   (contains? (-> initial-content :validators set) "required-hakija"))

--- a/src/cljs/ataru/virkailija/editor/components/followup_question.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/followup_question.cljs
@@ -9,7 +9,6 @@
    [re-frame.core :refer [subscribe dispatch reg-sub reg-event-db reg-fx reg-event-fx]]
    [reagent.core :as r]
    [reagent.ratom :refer-macros [reaction]]
-   [taoensso.timbre :refer-macros [spy debug]]
    [ataru.virkailija.temporal :as temporal]))
 
 (reg-event-db

--- a/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
@@ -4,8 +4,7 @@
             [ataru.component-data.higher-education-base-education-module :as kk-base-education-module]
             [ataru.feature-config :as fc]
             [re-frame.core :refer [dispatch subscribe]]
-            [reagent.core :as r]
-            [taoensso.timbre :refer-macros [spy debug]]))
+            [reagent.core :as r]))
 
 (def ^:private toolbar-elements
   [[:form-section component/form-section]

--- a/src/cljs/ataru/virkailija/editor/core.cljs
+++ b/src/cljs/ataru/virkailija/editor/core.cljs
@@ -11,7 +11,7 @@
             [reagent.core :as r]
             [cljs.core.match :refer-macros [match]]
             [cljs-uuid-utils.core :as uuid]
-            [taoensso.timbre :refer-macros [spy debug error]]))
+            [taoensso.timbre :as log]))
 
 (defn soresu->reagent [content path & args]
   (fn [content path & args]
@@ -86,7 +86,7 @@
                    [ec/hakukohteet-module content path]
 
                    :else (do
-                           (error content)
+                           (log/error content)
                            (throw (new js/Error (str "Unknown component type " content)))))]
         [:div
          [dnd/drag-n-drop-spacer path]

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -19,7 +19,6 @@
             [ataru.util :as util :refer [collect-ids assoc?]]
             [ataru.user-rights :as user-rights]
             [ataru.cljs-util :as cu]
-            [taoensso.timbre :refer-macros [spy debug]]
             [ataru.virkailija.temporal :as temporal]
             [ataru.virkailija.editor.form-diff :as form-diff]
             [cljs-time.core :as t])

--- a/src/cljs/ataru/virkailija/editor/subs.cljs
+++ b/src/cljs/ataru/virkailija/editor/subs.cljs
@@ -3,7 +3,6 @@
   (:require [ataru.util :as util :refer [collect-ids]]
             [re-frame.core :as re-frame]
             [ataru.cljs-util :as cu]
-            [taoensso.timbre :refer-macros [spy debug]]
             [markdown.core :as md]
             [ataru.translations.translation-util :as translations]))
 

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -8,8 +8,7 @@
             [ataru.virkailija.routes :as routes]
             [ataru.virkailija.temporal :as temporal]
             [re-frame.core :refer [subscribe dispatch dispatch-sync]]
-            [reagent.core :as r]
-            [taoensso.timbre :refer-macros [spy debug]]))
+            [reagent.core :as r]))
 
 (defn form-row [key selected?]
   [:a.editor-form__row

--- a/src/cljs/ataru/virkailija/handlers.cljs
+++ b/src/cljs/ataru/virkailija/handlers.cljs
@@ -2,8 +2,7 @@
     (:require [re-frame.core :refer [reg-event-db reg-event-fx dispatch]]
               [ataru.virkailija.autosave :as autosave]
               [ataru.virkailija.editor.handlers :refer [clear-copy-component]]
-              [ataru.virkailija.db :as db]
-              [taoensso.timbre :refer-macros [spy debug]]))
+              [ataru.virkailija.db :as db]))
 
 (reg-event-db
  :initialize-db

--- a/src/cljs/ataru/virkailija/temporal.cljs
+++ b/src/cljs/ataru/virkailija/temporal.cljs
@@ -5,8 +5,7 @@
             [clojure.walk :refer [postwalk]]
             [cljs-time.core :refer [to-default-time-zone now after?]]
             [cljs-time.format :refer [unparse unparse-local formatter]]
-            [cljs-time.coerce :refer [from-long]]
-            [taoensso.timbre :refer-macros [spy warn]]))
+            [cljs-time.coerce :refer [from-long]]))
 
 (def ^:private time-formatter-leading-zeros (f/formatter "dd.MM.yyyy HH:mm" "Europe/Helsinki"))
 

--- a/src/cljs/ataru/virkailija/views/banner.cljs
+++ b/src/cljs/ataru/virkailija/views/banner.cljs
@@ -8,8 +8,7 @@
             [clojure.string :as string]
             [goog.string :as s]
             [re-frame.core :refer [subscribe dispatch]]
-            [reagent.core :as reagent]
-            [taoensso.timbre :refer-macros [spy debug]]))
+            [reagent.core :as reagent]))
 
 (def panels
   {:editor      {:text :forms-panel :href "/lomake-editori/editor/"}

--- a/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
+++ b/src/cljs/ataru/virkailija/views/virkailija_readonly.cljs
@@ -24,7 +24,6 @@
             [clojure.string :refer [trim]]
             [goog.string :as s]
             [re-frame.core :refer [subscribe]]
-            [taoensso.timbre :refer-macros [spy debug]]
             [reagent.core :as r]))
 
 (def exclude-always-included #(not (answer-to-always-include? %)))

--- a/src/cljs/ataru/virkailija/virkailija_ajax.cljs
+++ b/src/cljs/ataru/virkailija/virkailija_ajax.cljs
@@ -3,8 +3,7 @@
             [cljs.core.match :refer-macros [match]]
             [ataru.cljs-util :as util]
             [ataru.virkailija.temporal :as temporal]
-            [ajax.core :refer [GET POST PUT DELETE PATCH] :as ajax]
-            [taoensso.timbre :refer-macros [spy debug]]))
+            [ajax.core :refer [GET POST PUT DELETE PATCH] :as ajax]))
 
 (defn dispatch-flasher-error-msg
   [method response]

--- a/test/cljs/unit/ataru/hakija/rules_test.cljs
+++ b/test/cljs/unit/ataru/hakija/rules_test.cljs
@@ -1,8 +1,7 @@
 (ns ataru.hakija.rules-test
   (:require [cljs.test :refer-macros [deftest are is]]
             [ataru.util :as util]
-            [ataru.hakija.rules :as rules]
-            [taoensso.timbre :refer-macros [spy debug]]))
+            [ataru.hakija.rules :as rules]))
 
 
 (deftest rule-runner


### PR DESCRIPTION
Aluksi epäiltiin isompaakin remonttia, mutta paljastui, että konfiguraatiopuutteen vuoksi ataru on jättänyt lokittamatta jotain 80..99% välillä kaikista logiviesteistä, mitä kirjastoista yms. syntyy. Mennään siis tällä, ja katsotaan sitten jatkotoimenpiteet.

Mukana myös lokituksen yleisiä siivoamisia nippu.