### PR TITLE
BUG-2128: organization service caching

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -6,7 +6,8 @@
                                            (clojure.core.match/match)
                                            (cljs.core.match/match)
                                            (ataru.db.flyway-migration/defmigration)
-                                           (ataru.virkailija.editor.editor-macros/with-form-key)]}
+                                           (ataru.virkailija.editor.editor-macros/with-form-key)
+                                           (speclj.core/around)]}
            :unused-namespace    {:exclude [cljs.repl]}
            :unused-referred-var {:exclude {cljs.repl [Error->map
                                                       apropos

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ npm-debug.log*
 /cypress/videos
 /cypress/screenshots
 /docker/ataru-cypress-http-proxy/etc/nginx/nginx.conf
-.clj-kondo/cache
+.clj-kondo/cache/

--- a/src/clj/ataru/cache/caches.clj
+++ b/src/clj/ataru/cache/caches.clj
@@ -32,7 +32,7 @@
     (in-memory/map->InMemoryCache
      {:loader (cache/->FunctionCacheLoader
                (fn [key] (organization-client/get-organizations key)))
-      :expires-after [2 TimeUnit/DAYS]
+      :expires-after [3 TimeUnit/DAYS]
       :refresh-after [60 TimeUnit/MINUTES]})]
    [:all-organization-groups-cache
     (in-memory/map->InMemoryCache

--- a/src/clj/ataru/hakija/hakija_system.clj
+++ b/src/clj/ataru/hakija/hakija_system.clj
@@ -38,7 +38,8 @@
 
     :organization-service (component/using
                            (organization-service/new-organization-service)
-                           [:all-organization-groups-cache])
+                           [:organizations-hierarchy-cache
+                            :all-organization-groups-cache])
 
     :tarjonta-service (component/using
                        (tarjonta-service/new-tarjonta-service)

--- a/src/clj/ataru/organization_service/organization_client.clj
+++ b/src/clj/ataru/organization_service/organization_client.clj
@@ -1,9 +1,8 @@
 (ns ataru.organization-service.organization-client
-  (:require [ataru.cas.client :as cas-client]
-            [ataru.config.core :refer [config]]
-            [ataru.config.url-helper :refer [resolve-url]]
+  (:require [ataru.config.url-helper :refer [resolve-url]]
             [ataru.util.http-util :as http-util]
             [cheshire.core :as json]
+            [clojure.string :as s]
             [taoensso.timbre :as log]))
 
 (def oph-organization "1.2.246.562.10.00000000001")
@@ -60,7 +59,7 @@
   "Returns a sequence of {:name <org-name> :oid <org-oid>} maps containing all suborganizations
    The root organization is the first element"
   [root-organization-oid]
-  (let [url      (if (or (clojure.string/blank? root-organization-oid) (= root-organization-oid oph-organization))
+  (let [url      (if (or (s/blank? root-organization-oid) (= root-organization-oid oph-organization))
                    (resolve-url :organisaatio-service.root-hierarchy)
                    (resolve-url :organisaatio-service.plain-hierarchy root-organization-oid))
         response (http-util/do-get url)]
@@ -83,7 +82,7 @@
   "Get organization by oid or number."
   [oid-or-number]
   (let [url (resolve-url :organisaatio-service.get-by-oid oid-or-number)
-        {:keys [status headers body error] :as resp} (http-util/do-get url)]
+        {:keys [status body]} (http-util/do-get url)]
     (if (= 200 status)
       (json/parse-string body true)
       (log/error (str "Couldn't fetch organization by number from url: " url)))))

--- a/src/clj/ataru/organization_service/organization_service.clj
+++ b/src/clj/ataru/organization_service/organization_service.clj
@@ -19,10 +19,7 @@
 (defn get-organization-hierarchies
   [organizations-hierarchy-cache direct-oids]
   (mapcat (fn [org-oid]
-            (cache/get-from organizations-hierarchy-cache
-                            (if (s/blank? org-oid)
-                              "all-organizations"
-                              org-oid)))
+            (cache/get-from organizations-hierarchy-cache org-oid))
           direct-oids))
 
 (defn group-oid? [oid] (clojure.string/starts-with? oid group-oid-prefix))

--- a/src/clj/ataru/organization_service/organization_service.clj
+++ b/src/clj/ataru/organization_service/organization_service.clj
@@ -1,14 +1,10 @@
 (ns ataru.organization-service.organization-service
-  (:require
-   [clojure.string :refer [join]]
-   [com.stuartsierra.component :as component]
-   [ataru.cache.cache-service :as cache]
-   [ataru.config.core :refer [config]]
-   [clojure.core.cache :as ccache]
-   [medley.core :refer [map-kv]]
-   [ataru.organization-service.organization-client :as org-client]))
+  (:require [clojure.string :as s]
+            [com.stuartsierra.component :as component]
+            [ataru.cache.cache-service :as cache]
+            [ataru.config.core :refer [config]]
+            [ataru.organization-service.organization-client :as org-client]))
 
-(def all-orgs-cache-time-to-live (* 2 60 1000))
 (def group-oid-prefix "1.2.246.562.28")
 
 (defn unknown-group [oid] {:oid oid :name {:fi "Tuntematon ryhmä"} :type :group})
@@ -20,21 +16,14 @@
     "Gets all hakukohde groups")
   (get-organizations-for-oids [this organization-oids]))
 
-(defn get-from-cache-or-real-source [cache-instance cache-key get-from-source-fn]
-  (let [item (delay (get-from-source-fn))]
-    (ccache/lookup (swap! cache-instance
-                          #(if (ccache/has? % cache-key)
-                             (ccache/hit % cache-key)
-                             (ccache/miss % cache-key @item)))
-                   cache-key)))
-
-(defn get-orgs-from-cache-or-client [all-orgs-cache direct-oids]
-  (let [oids-key  (join "-" direct-oids)
-        cache-key (if (clojure.string/blank? oids-key) "all-orgs" oids-key)]
-    (get-from-cache-or-real-source
-      all-orgs-cache
-      cache-key
-      #(mapcat org-client/get-organizations direct-oids))))
+(defn get-organization-hierarchies
+  [organizations-hierarchy-cache direct-oids]
+  (mapcat (fn [org-oid]
+            (cache/get-from organizations-hierarchy-cache
+                            (if (s/blank? org-oid)
+                              "all-organizations"
+                              org-oid)))
+          direct-oids))
 
 (defn group-oid? [oid] (clojure.string/starts-with? oid group-oid-prefix))
 
@@ -43,7 +32,7 @@
     (map #(select-keys % [:oid :name :hakukohderyhma? :active?]) hakukohde-groups)))
 
 ;; The real implementation for Organization service
-(defrecord IntegratedOrganizationService [all-organization-groups-cache]
+(defrecord IntegratedOrganizationService [organizations-hierarchy-cache all-organization-groups-cache]
   component/Lifecycle
   OrganizationService
 
@@ -55,8 +44,8 @@
   (get-all-organizations [this direct-organizations]
     (let [[groups orgs]       ((juxt filter remove) #(group-oid? (:oid %)) direct-organizations)
           ;; Only fetch hierarchy for actual orgs, not groups:
-          flattened-hierarchy (get-orgs-from-cache-or-client
-                               (:all-orgs-cache this)
+          flattened-hierarchy (get-organization-hierarchies
+                               organizations-hierarchy-cache
                                (map :oid orgs))]
       ;; Include groups as-is in the result:
       (concat groups flattened-hierarchy)))
@@ -68,12 +57,9 @@
           groups      (map #(get all-groups % (unknown-group %)) group-oids)]
       (concat normal-orgs groups)))
 
-  (start [this]
-    (-> this
-        (assoc :all-orgs-cache (atom (ccache/ttl-cache-factory {} :ttl all-orgs-cache-time-to-live)))))
+  (start [this] this)
 
-  (stop [this]
-    (assoc this :all-orgs-cache nil)))
+  (stop [this] this))
 
 (def fake-org-by-oid
   {"1.2.246.562.10.11"          {:name {:fi "Lasikoulu"}, :oid "1.2.246.562.10.11", :type :organization}
@@ -111,4 +97,4 @@
 (defn new-organization-service []
   (if (-> config :dev :fake-dependencies) ;; Ui automated test mode
     (->FakeOrganizationService)
-    (->IntegratedOrganizationService nil)))
+    (->IntegratedOrganizationService nil nil)))

--- a/src/clj/ataru/tarjonta_service/tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_service.clj
@@ -1,17 +1,10 @@
 (ns ataru.tarjonta-service.tarjonta-service
-  (:require
-   [ataru.tarjonta-service.tarjonta-client :as client]
-   [ataru.organization-service.organization-service :as organization-service]
-   [ataru.organization-service.organization-client :refer [oph-organization]]
-   [com.stuartsierra.component :as component]
-   [ataru.config.core :refer [config]]
-   [ataru.cache.cache-service :as cache]
-   [ataru.tarjonta-service.tarjonta-protocol :refer [TarjontaService get-haku get-hakukohde]]
-   [ataru.tarjonta-service.mock-tarjonta-service :refer [->MockTarjontaService]]))
-
-(defn- parse-search-result
-  [search-result]
-  (mapcat :tulokset (:tulokset search-result)))
+  (:require [ataru.organization-service.organization-service :as organization-service]
+            [ataru.organization-service.organization-client :refer [oph-organization]]
+            [ataru.config.core :refer [config]]
+            [ataru.cache.cache-service :as cache]
+            [ataru.tarjonta-service.tarjonta-protocol :refer [TarjontaService get-haku get-hakukohde]]
+            [ataru.tarjonta-service.mock-tarjonta-service :refer [->MockTarjontaService]]))
 
 (defn fetch-or-cached-hakukohde-search
   [hakukohde-search-cache haku-oid organization-oid]

--- a/src/clj/ataru/virkailija/virkailija_system.clj
+++ b/src/clj/ataru/virkailija/virkailija_system.clj
@@ -46,7 +46,8 @@
 
     :organization-service (component/using
                            (organization-service/new-organization-service)
-                           [:all-organization-groups-cache])
+                           [:organizations-hierarchy-cache
+                            :all-organization-groups-cache])
 
     :tarjonta-service (component/using
                        (tarjonta-service/new-tarjonta-service)


### PR DESCRIPTION
Refaktorointi, joka poistaa clojure.cachen ja korvaa sen Caffeinella (eli koodinsisäisesti in-memory cachella) organisaatiohierarkiahauissa.