### PR TITLE
OY-372 Optimize yesql-suoritusrekisteri-applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ npm-debug.log*
 /cypress/videos
 /cypress/screenshots
 /docker/ataru-cypress-http-proxy/etc/nginx/nginx.conf
-.clj-kondo/cache/
+.clj-kondo/.cache


### PR DESCRIPTION
When no other query parameters are given, it takes a lot of effort to find out whether applications were modified after given date/time, because it unnecessary uses UNION operator. The solution is to use the more efficient EXISTS clauses. 