### PR TITLE
HLE-1098: kielten oppiaineiden muuttuminen hakijan äidinkielen mukaan

### DIFF
--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -20,6 +20,7 @@
     "@typescript-eslint/no-unused-vars": [
       "error"
     ],
+    "chai-friendly/no-unused-expressions": "off",
     "import/extensions": "off",
     "import/no-extraneous-dependencies": "off",
     "import/prefer-default-export": "off",

--- a/cypress/dropdown.ts
+++ b/cypress/dropdown.ts
@@ -7,3 +7,8 @@ export const setDropdownValue = (dataTestIdPrefix: string, value: string) =>
         .get(`[data-test-id=${dataTestIdPrefix}-option-${value}]`)
         .click({ force: true })
     )
+
+export const asetaHakijanNakymanPudotusvalikonArvo = (
+  dataTestIdPrefix: string,
+  value: string
+) => cy.get(`[data-test-id=${dataTestIdPrefix}-input]`).select(value)

--- a/cypress/dropdown.ts
+++ b/cypress/dropdown.ts
@@ -9,6 +9,6 @@ export const setDropdownValue = (dataTestIdPrefix: string, value: string) =>
     )
 
 export const asetaHakijanNakymanPudotusvalikonArvo = (
-  dataTestIdPrefix: string,
+  dataTestId: string,
   value: string
-) => cy.get(`[data-test-id=${dataTestIdPrefix}-input]`).select(value)
+) => cy.get(`[data-test-id=${dataTestId}]`).select(value)

--- a/cypress/hakijanNakyma.ts
+++ b/cypress/hakijanNakyma.ts
@@ -55,6 +55,9 @@ export const arvosanat = {
     arvosanat
       .haeValinnaisaineLinkki({ oppiaine, index: 0, poisKaytosta: false })
       .click(),
+
+  haeOppiaineenArvosanaRivi: ({ oppiaine }: { oppiaine: string }) =>
+    cy.get(`[data-test-id=oppiaineen-arvosana-${oppiaine}]`),
 }
 
 const syota = <T>(

--- a/cypress/integration/peruskoulunArvosanatSpec.ts
+++ b/cypress/integration/peruskoulunArvosanatSpec.ts
@@ -4,6 +4,7 @@ import peruskoulunArvosanatOsionPoistaminen from '../testit/arvosanat/peruskoulu
 import peruskoulunArvosanatOsionTayttaminenHakijana from '../testit/arvosanat/peruskoulunArvosanatOsionTayttaminenHakijana'
 import peruskoulunArvosanatOsionLisays from '../testit/arvosanat/peruskoulunArvosanatOsionLisays'
 import hakijanNakymaanSiirtyminen from '../testit/hakijanNakymaanSiirtyminen'
+import peruskoulunArvosanatOsionAidinkielenVaihtaminen from '../testit/arvosanat/peruskoulunArvosanatOsionAidinkielenVaihtaminen'
 
 describe('Peruskoulun arvosanat -osio', () => {
   kirjautuminenVirkailijanNakymaan(() => {
@@ -11,6 +12,7 @@ describe('Peruskoulun arvosanat -osio', () => {
       peruskoulunArvosanatOsionLisays(lomakkeenTunnisteet, () => {
         peruskoulunArvosanatOsionPoistaminen(lomakkeenTunnisteet)
         hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
+          peruskoulunArvosanatOsionAidinkielenVaihtaminen()
           peruskoulunArvosanatOsionTayttaminenHakijana()
         })
       })

--- a/cypress/integration/peruskoulunArvosanatSpec.ts
+++ b/cypress/integration/peruskoulunArvosanatSpec.ts
@@ -6,6 +6,7 @@ import peruskoulunArvosanatOsionLisays from '../testit/arvosanat/peruskoulunArvo
 import hakijanNakymaanSiirtyminen from '../testit/hakijanNakymaanSiirtyminen'
 import peruskoulunArvosanatOsionAidinkielenVaihtaminen from '../testit/arvosanat/peruskoulunArvosanatOsionAidinkielenVaihtaminen'
 import henkilotietoModuulinTayttaminen from '../testit/henkilotietoModuulinTayttaminen'
+import hakemuksenLahettaminen from '../testit/hakemuksenLahettaminen'
 
 describe('Peruskoulun arvosanat -osio', () => {
   kirjautuminenVirkailijanNakymaan(() => {
@@ -16,6 +17,7 @@ describe('Peruskoulun arvosanat -osio', () => {
           henkilotietoModuulinTayttaminen(() => {
             peruskoulunArvosanatOsionAidinkielenVaihtaminen()
             peruskoulunArvosanatOsionTayttaminenHakijana()
+            hakemuksenLahettaminen()
           })
         })
       })

--- a/cypress/integration/peruskoulunArvosanatSpec.ts
+++ b/cypress/integration/peruskoulunArvosanatSpec.ts
@@ -5,6 +5,7 @@ import peruskoulunArvosanatOsionTayttaminenHakijana from '../testit/arvosanat/pe
 import peruskoulunArvosanatOsionLisays from '../testit/arvosanat/peruskoulunArvosanatOsionLisays'
 import hakijanNakymaanSiirtyminen from '../testit/hakijanNakymaanSiirtyminen'
 import peruskoulunArvosanatOsionAidinkielenVaihtaminen from '../testit/arvosanat/peruskoulunArvosanatOsionAidinkielenVaihtaminen'
+import henkilotietoModuulinTayttaminen from '../testit/henkilotietoModuulinTayttaminen'
 
 describe('Peruskoulun arvosanat -osio', () => {
   kirjautuminenVirkailijanNakymaan(() => {
@@ -12,8 +13,10 @@ describe('Peruskoulun arvosanat -osio', () => {
       peruskoulunArvosanatOsionLisays(lomakkeenTunnisteet, () => {
         peruskoulunArvosanatOsionPoistaminen(lomakkeenTunnisteet)
         hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
-          peruskoulunArvosanatOsionAidinkielenVaihtaminen()
-          peruskoulunArvosanatOsionTayttaminenHakijana()
+          henkilotietoModuulinTayttaminen(() => {
+            peruskoulunArvosanatOsionAidinkielenVaihtaminen()
+            peruskoulunArvosanatOsionTayttaminenHakijana()
+          })
         })
       })
     })

--- a/cypress/lomakkeenMuokkaus.ts
+++ b/cypress/lomakkeenMuokkaus.ts
@@ -68,7 +68,7 @@ export const naytaVastausvaihtoehdot = () =>
 export const vastausvaihtoehdot = () =>
   cy
     .get('[data-test-id=editor-form__multi-options-container')
-    .find('[data-test-id=editor-form__koodisto-field]')
+    .find('[data-test-id=editor-form__koodisto-field]:visible')
 
 export const hakukohteet = {
   haeOtsikko: () => cy.get('[data-test-id=hakukohteet-header-label]:visible'),

--- a/cypress/testit/arvosanat/peruskoulunArvosanatOsionAidinkielenVaihtaminen.ts
+++ b/cypress/testit/arvosanat/peruskoulunArvosanatOsionAidinkielenVaihtaminen.ts
@@ -1,0 +1,25 @@
+import * as hakijanNakyma from '../../hakijanNakyma'
+import * as dropdown from '../../dropdown'
+
+export default () => {
+  describe('Peruskoulun arvosanat -osion äidinkielen vaihtaminen ruotsiksi', () => {
+    before(() => {
+      dropdown.asetaHakijanNakymanPudotusvalikonArvo('language-input', 'SV')
+    })
+
+    after(() => {
+      dropdown.asetaHakijanNakymanPudotusvalikonArvo('language-input', 'FI')
+    })
+
+    it('Näyttää peruskoulun arvosanat -osiossa ruotsin kielen edellyttämät oppiaineet', () => {
+      hakijanNakyma.arvosanat
+        .haeOppiaineenArvosanaRivi({ oppiaine: 'A2' })
+        .should('exist')
+        .should('be.visible')
+        .then(() =>
+          hakijanNakyma.arvosanat.haeOppiaineenArvosanaRivi({ oppiaine: 'B1' })
+        )
+        .should('not.exist')
+    })
+  })
+}

--- a/cypress/testit/arvosanat/peruskoulunArvosanatOsionTayttaminenHakijana.ts
+++ b/cypress/testit/arvosanat/peruskoulunArvosanatOsionTayttaminenHakijana.ts
@@ -38,7 +38,7 @@ export default () => {
         .then(() =>
           hakijanNakyma.arvosanat.asetaOppiaineenArvosanat({
             oppiaine: 'A',
-            arvosana: 'hyvaksytty',
+            arvosana: 'hyvaksytty-suoritettu',
             oppimaara: 'ruotsi-viittomakielisille',
             index: 3,
           })

--- a/cypress/testit/hakemuksenLahettaminen.ts
+++ b/cypress/testit/hakemuksenLahettaminen.ts
@@ -1,6 +1,6 @@
 import * as hakijanNakyma from '../hakijanNakyma'
 
-export default (testit: () => void) => {
+export default (testit?: () => void) => {
   describe('Hakemuksen lähettäminen', () => {
     before(() => {
       hakijanNakyma
@@ -13,6 +13,6 @@ export default (testit: () => void) => {
       hakijanNakyma.haeLomakkeenNimi().should('have.text', 'Testilomake')
     })
 
-    testit()
+    testit?.()
   })
 }

--- a/resources/less/arvosanat-hakija.less
+++ b/resources/less/arvosanat-hakija.less
@@ -98,6 +98,10 @@
       border-bottom: 1px solid @component-light-gray-1;
     }
   }
+
+  .arvosanat-taulukko__solu--span-2 {
+    grid-column-end: span 2;
+  }
 }
 
 @media only screen and (max-width: @mobile-width) {

--- a/resources/less/arvosanat-hakija.less
+++ b/resources/less/arvosanat-hakija.less
@@ -42,6 +42,10 @@
     width: 100%;
   }
 
+  .arvosanat-taulukko__rivi:not(:last-child) {
+    border-bottom: 1px solid @component-light-gray-1;
+  }
+
   .arvosana__oppiaine {
     .flex-row-left-center();
 
@@ -93,10 +97,6 @@
 
     &:not(:last-of-type) {
       padding-right: 10px;
-    }
-
-    &:not(.arvosanat-taulukko__otsikko) {
-      border-bottom: 1px solid @component-light-gray-1;
     }
   }
 

--- a/resources/less/arvosanat-hakija.less
+++ b/resources/less/arvosanat-hakija.less
@@ -83,6 +83,7 @@
   }
 
   .arvosanat-taulukko__solu {
+    grid-row-start: 1;
     padding-bottom: 10px;
     padding-top: 10px;
 

--- a/src/cljc/ataru/component_data/arvosanat_module.cljc
+++ b/src/cljc/ataru/component_data/arvosanat_module.cljc
@@ -116,8 +116,8 @@
                                                                    :en arvosana}
                                                   :value          (str "arvosana-" oppiaineen-koodi "-" arvosana)}))))
                                   (arvosana-option
-                                    {:arvosana-label (:hyvaksytty texts/translation-mapping)
-                                     :value          (str "arvosana-" oppiaineen-koodi "-hyvaksytty")})
+                                    {:arvosana-label (:hyvaksytty-suoritettu texts/translation-mapping)
+                                     :value          (str "arvosana-" oppiaineen-koodi "-hyvaksytty-suoritettu")})
                                   (arvosana-option
                                     {:arvosana-label (:ei-arvosanaa texts/translation-mapping)
                                      :value          (str "arvosana-" oppiaineen-koodi "-ei-arvosanaa")}))

--- a/src/cljc/ataru/component_data/arvosanat_module.cljc
+++ b/src/cljc/ataru/component_data/arvosanat_module.cljc
@@ -40,14 +40,15 @@
    (s/optional-key :children) [s/Any]})
 
 (s/defschema ArvosanatTaulukko
-  {:id         s/Str
-   :fieldClass (s/eq "wrapperElement")
-   :fieldType  (s/eq "fieldset")
-   :children   [OppiaineenArvosana]
-   :metadata   element-metadata-schema/ElementMetadata
-   :label      localized-schema/LocalizedString
-   :version    ArvosanatVersio
-   :params     {}})
+  {:id              s/Str
+   :fieldClass      (s/eq "wrapperElement")
+   :fieldType       (s/eq "fieldset")
+   :children        [OppiaineenArvosana]
+   :child-validator (s/eq :oppiaine-a1-or-a2-component)
+   :metadata        element-metadata-schema/ElementMetadata
+   :label           localized-schema/LocalizedString
+   :version         ArvosanatVersio
+   :params          {}})
 
 (s/defn concat-labels
   [separator :- s/Str
@@ -287,9 +288,10 @@
            children]} :- {:metadata element-metadata-schema/ElementMetadata
                           :children [OppiaineenArvosana]}]
   (merge (component/form-section metadata)
-         {:id       "arvosanat-taulukko"
-          :version  "oppiaineen-arvosanat"
-          :children children}))
+         {:id              "arvosanat-taulukko"
+          :version         "oppiaineen-arvosanat"
+          :children        children
+          :child-validator :oppiaine-a1-or-a2-component}))
 
 (s/defn arvosanat
   [{:keys [type]} :- {:type (s/enum :peruskoulu)}

--- a/src/cljc/ataru/component_data/arvosanat_module.cljc
+++ b/src/cljc/ataru/component_data/arvosanat_module.cljc
@@ -12,6 +12,7 @@
 (s/defschema OppiaineenKoodi
   (s/enum "A"
           "A1"
+          "A2"
           "B1"
           "MA"
           "BI"
@@ -185,6 +186,12 @@
      :label            (:arvosana-a1-kieli texts/virkailija-texts)
      :metadata         metadata}))
 
+(defn- arvosana-a2-kieli [{:keys [metadata]}]
+  (oppiaineen-arvosana
+    {:oppiaineen-koodi "A2"
+     :label            (:arvosana-a2-kieli texts/virkailija-texts)
+     :metadata         metadata}))
+
 (defn- arvosana-b1-kieli [{:keys [metadata]}]
   (oppiaineen-arvosana
     {:oppiaineen-koodi "B1"
@@ -302,6 +309,7 @@
                          {:metadata metadata
                           :children [(arvosana-aidinkieli-ja-kirjallisuus {:metadata metadata})
                                      (arvosana-a1-kieli {:metadata metadata})
+                                     (arvosana-a2-kieli {:metadata metadata})
                                      (arvosana-b1-kieli {:metadata metadata})
                                      (arvosana-matematiikka {:metadata metadata})
                                      (arvosana-biologia {:metadata metadata})

--- a/src/cljc/ataru/component_data/person_info_module.cljc
+++ b/src/cljc/ataru/component_data/person_info_module.cljc
@@ -222,7 +222,8 @@
       (merge {:label (:language person-info-module-texts)
               :validators [:required]
               :id :language
-              :koodisto-source {:uri "kieli" :version 1 :default-option "suomi"}})))
+              :koodisto-source {:uri "kieli" :version 1 :default-option "suomi"}
+              :rules {:toggle-arvosanat-module-aidinkieli-ja-kirjallisuus-oppiaineet nil}})))
 
 (defn onr-person-info-module [metadata]
   [(first-name-section metadata)

--- a/src/cljc/ataru/schema/child_validator_schema.cljc
+++ b/src/cljc/ataru/schema/child_validator_schema.cljc
@@ -1,4 +1,7 @@
 (ns ataru.schema.child-validator-schema
   (:require [schema.core :as s]))
 
-(s/defschema ChildValidator (s/enum :one-of :birthdate-and-gender-component :ssn-or-birthdate-component))
+(s/defschema ChildValidator (s/enum :one-of
+                                    :birthdate-and-gender-component
+                                    :ssn-or-birthdate-component
+                                    :oppiaine-a1-or-a2-component))

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -2,7 +2,10 @@
   (:require [clojure.string :as string]))
 
 (def translation-mapping
-  {:add                                         {:fi "Lisää"
+  {:hyvaksytty-suoritettu                       {:fi "Hyväksytty / suoritettu"
+                                                 :sv "Hyväksytty / suoritettu"
+                                                 :en "Hyväksytty / suoritettu"}
+   :add                                         {:fi "Lisää"
                                                  :sv "Lägg till"
                                                  :en "Add"}
    :add-application-option                      {:fi "Lisää hakukohde"

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -424,6 +424,9 @@
    :oppiaine-a1 {:fi "A1-kieli"
                  :sv "A1-kieli"
                  :en "A1-kieli"}
+   :oppiaine-a2 {:fi "A2-kieli"
+                 :sv "A2-kieli"
+                 :en "A2-kieli"}
    :oppiaine-b1 {:fi "B1-kieli"
                  :sv "B1-kieli"
                  :en "B1-kieli"}
@@ -838,6 +841,9 @@
    :arvosana-a1-kieli                               {:fi "A1-kieli"
                                                      :sv "A1-kieli"
                                                      :en "A1-kieli"}
+   :arvosana-a2-kieli                               {:fi "A2-kieli"
+                                                     :sv "A2-kieli"
+                                                     :en "A2-kieli"}
    :arvosana-b1-kieli                               {:fi "B1-kieli"
                                                      :sv "B1-kieli"
                                                      :en "B1-kieli"}

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -21,7 +21,7 @@
             [ataru.hakija.components.question-hakukohde-names-component :as hakukohde-names-component]
             [ataru.hakija.components.info-text-component :as info-text-component]
             [ataru.hakija.components.dropdown-component :as dropdown-component]
-            [ataru.hakija.arvosanat.render-arvosanat :as arvosanat]
+            [ataru.hakija.arvosanat.arvosanat-render :as arvosanat]
             [ataru.hakija.render-generic-component :as generic-component]))
 
 (defonce autocomplete-off "new-password")

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -914,16 +914,15 @@
          {:fieldClass "infoElement"} [info-element field-descriptor idx]
          {:fieldClass "wrapperElement" :fieldType "adjacentfieldset"} [adjacent-text-fields field-descriptor idx]))
 
-(defn render-field
-  [field-descriptor idx]
+(defn render-field [field-descriptor idx]
   (let [render-fn (case (:version field-descriptor)
                     "generic" generic-component/render-generic-component
                     "oppiaineen-arvosanat" arvosanat/render-arvosanat-component
                     render-component)]
-    (render-fn
-      {:field-descriptor field-descriptor
-       :idx              idx
-       :render-field     render-field})))
+    [render-fn
+     {:field-descriptor field-descriptor
+      :idx              idx
+      :render-field     render-field}]))
 
 (defn editable-fields [_]
   (r/create-class

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -918,11 +918,13 @@
   (let [render-fn (case (:version field-descriptor)
                     "generic" generic-component/render-generic-component
                     "oppiaineen-arvosanat" arvosanat/render-arvosanat-component
-                    render-component)]
-    [render-fn
-     {:field-descriptor field-descriptor
-      :idx              idx
-      :render-field     render-field}]))
+                    render-component)
+        visible?  @(subscribe [:application/visible? (keyword (:id field-descriptor))])]
+    (when visible?
+      [render-fn
+       {:field-descriptor field-descriptor
+        :idx              idx
+        :render-field     render-field}])))
 
 (defn editable-fields [_]
   (r/create-class

--- a/src/cljs/ataru/hakija/arvosanat/arvosanat_components.cljs
+++ b/src/cljs/ataru/hakija/arvosanat/arvosanat_components.cljs
@@ -25,11 +25,15 @@
                     "arvosanat-taulukko__rivi--pakollinen-oppiaine")
     :data-test-id data-test-id}
    [:div.arvosanat-taulukko__solu.arvosana__oppiaine
+    {:class (when-not oppimaara-dropdown
+              "arvosanat-taulukko__solu--span-2")}
     label]
-   [:div.arvosanat-taulukko__solu.arvosana__oppimaara
-    oppimaara-dropdown]
-   [:div.arvosanat-taulukko__solu.arvosana__arvosana
-    arvosana-dropdown]
+   (when oppimaara-dropdown
+     [:div.arvosanat-taulukko__solu.arvosana__oppimaara
+      oppimaara-dropdown])
+   (when arvosana-dropdown
+     [:div.arvosanat-taulukko__solu.arvosana__arvosana
+      arvosana-dropdown])
    [:div.arvosanat-taulukko__solu.arvosana__lisaa-valinnaisaine.arvosana__lisaa-valinnaisaine--solu
     lisaa-valinnaisaine-linkki]])
 

--- a/src/cljs/ataru/hakija/arvosanat/arvosanat_components.cljs
+++ b/src/cljs/ataru/hakija/arvosanat/arvosanat_components.cljs
@@ -13,14 +13,17 @@
            oppimaara-dropdown
            arvosana-dropdown
            lisaa-valinnaisaine-linkki
-           pakollinen-oppiaine?]} :- {:label                                       s/Any
-                                      (s/optional-key :oppimaara-dropdown)         s/Any
-                                      (s/optional-key :arvosana-dropdown)          s/Any
-                                      (s/optional-key :lisaa-valinnaisaine-linkki) s/Any
-                                      :pakollinen-oppiaine?                        s/Bool}]
+           pakollinen-oppiaine?
+           data-test-id]} :- {:label                                       s/Any
+                              (s/optional-key :oppimaara-dropdown)         s/Any
+                              (s/optional-key :arvosana-dropdown)          s/Any
+                              (s/optional-key :lisaa-valinnaisaine-linkki) s/Any
+                              :pakollinen-oppiaine?                        s/Bool
+                              (s/optional-key :data-test-id)               s/Str}]
   [:div.arvosanat-taulukko__rivi
-   {:class (when pakollinen-oppiaine?
-             "arvosanat-taulukko__rivi--pakollinen-oppiaine")}
+   {:class        (when pakollinen-oppiaine?
+                    "arvosanat-taulukko__rivi--pakollinen-oppiaine")
+    :data-test-id data-test-id}
    [:div.arvosanat-taulukko__solu.arvosana__oppiaine
     label]
    [:div.arvosanat-taulukko__solu.arvosana__oppimaara
@@ -82,20 +85,22 @@
 (s/defn oppiaineen-arvosana
   [{:keys [field-descriptor
            render-field]} :- render-field-schema/RenderFieldArgs]
-  (let [lang                @(re-frame/subscribe [:application/form-language])
-        row-count           @(re-frame/subscribe [:application/question-group-row-count (:id field-descriptor)])
-        children            (:children field-descriptor)
-        arvosana-dropdown   (last children)
-        oppimaara-dropdown  (when (= (count children) 2)
-                              (first children))
-        data-test-id-prefix (str "oppiaineen-arvosana-" (:id field-descriptor))]
+  (let [lang               @(re-frame/subscribe [:application/form-language])
+        row-count          @(re-frame/subscribe [:application/question-group-row-count (:id field-descriptor)])
+        children           (:children field-descriptor)
+        arvosana-dropdown  (last children)
+        oppimaara-dropdown (when (= (count children) 2)
+                             (first children))
+        data-test-id       (str "oppiaineen-arvosana-" (:id field-descriptor))]
     (->> (range row-count)
          (mapv (fn ->oppiaineen-arvosana-rivi [arvosana-idx]
                  (let [key                 (str "oppiaineen-arvosana-rivi-" (:id field-descriptor) "-" arvosana-idx)
                        valinnaisaine-rivi? (> arvosana-idx 0)]
                    ^{:key key}
                    [oppiaineen-arvosana-rivi
-                    {:pakollinen-oppiaine?
+                    {:data-test-id
+                     data-test-id
+                     :pakollinen-oppiaine?
                      (not valinnaisaine-rivi?)
                      :label
                      (let [label (cond->> (-> field-descriptor :label lang)
@@ -109,13 +114,13 @@
                      :oppimaara-dropdown
                      (when oppimaara-dropdown
                        [render-field
-                        (assoc oppimaara-dropdown :data-test-id (str data-test-id-prefix "-oppimaara-" arvosana-idx))
+                        (assoc oppimaara-dropdown :data-test-id (str data-test-id "-oppimaara-" arvosana-idx))
                         arvosana-idx])
 
                      :arvosana-dropdown
                      (when arvosana-dropdown
                        [render-field
-                        (assoc arvosana-dropdown :data-test-id (str data-test-id-prefix "-arvosana-" arvosana-idx))
+                        (assoc arvosana-dropdown :data-test-id (str data-test-id "-arvosana-" arvosana-idx))
                         arvosana-idx])
 
                      :lisaa-valinnaisaine-linkki
@@ -127,7 +132,7 @@
                        :arvosana-idx        arvosana-idx
                        :field-descriptor    field-descriptor
                        :row-count           row-count
-                       :data-test-id        (str data-test-id-prefix "-lisaa-valinnaisaine-linkki-" arvosana-idx "-" (if valinnaisaine-rivi? "poista" "lisaa"))}]}])))
+                       :data-test-id        (str data-test-id "-lisaa-valinnaisaine-linkki-" arvosana-idx "-" (if valinnaisaine-rivi? "poista" "lisaa"))}]}])))
          (into [:<>]))))
 
 (s/defn arvosanat-taulukko-otsikkorivi

--- a/src/cljs/ataru/hakija/arvosanat/arvosanat_render.cljs
+++ b/src/cljs/ataru/hakija/arvosanat/arvosanat_render.cljs
@@ -1,4 +1,4 @@
-(ns ataru.hakija.arvosanat.render-arvosanat
+(ns ataru.hakija.arvosanat.arvosanat-render
   (:require [ataru.hakija.arvosanat.arvosanat-components :as arvosanat]
             [ataru.hakija.schema.render-field-schema :as render-field-schema]
             [ataru.schema.lang-schema :as lang-schema]

--- a/src/cljs/ataru/hakija/components/dropdown_component.cljs
+++ b/src/cljs/ataru/hakija/components/dropdown_component.cljs
@@ -26,7 +26,8 @@
                        first
                        :followups
                        (filter #(deref (re-frame/subscribe [:application/visible? (keyword (:id %))]))))
-        data-test-id (when (some #{id} [:home-town])
+        data-test-id (when (some #{id} [:home-town
+                                        :language])
                        (-> id
                            name
                            (str "-input")))]

--- a/src/cljs/ataru/hakija/hakija_readonly.cljs
+++ b/src/cljs/ataru/hakija/hakija_readonly.cljs
@@ -17,7 +17,7 @@
                                                                        replace-with-option-label
                                                                        predefined-value-answer?
                                                                        scroll-to-anchor]]
-            [ataru.hakija.arvosanat.render-arvosanat :as arvosanat]))
+            [ataru.hakija.arvosanat.arvosanat-render :as arvosanat]))
 
 (defn- from-multi-lang [text lang]
   (util/non-blank-val text [lang :fi :sv :en]))

--- a/src/cljs/ataru/hakija/rules.cljs
+++ b/src/cljs/ataru/hakija/rules.cljs
@@ -5,13 +5,24 @@
             [ataru.koodisto.koodisto-codes :refer [finland-country-code]]
             clojure.string))
 
+(defn- update-value [current-value update-fn]
+  (if (vector? current-value)
+    [(update-value (first current-value) update-fn)]
+    (update-fn current-value)))
+
+(defn- blank-value? [value]
+  (or (and (string? value)
+           (clojure.string/blank? value))
+      (and (vector? value)
+           (-> value first blank-value?))))
+
 (defn- set-empty-validity
   [a cannot-view? valid?]
-  (if (and (clojure.string/blank? (:value a))
+  (if (and (blank-value? (:value a))
            (not cannot-view?))
     (-> a
         (assoc :valid valid?)
-        (assoc-in [:values :valid] valid?))
+        (update :values update-value #(assoc % :valid valid?)))
     a))
 
 (defn- hide-field
@@ -20,12 +31,16 @@
   ([db id value]
    (if-let [_ (some #(when (= id (keyword (:id %))) %)
                     (:flat-form-content db))]
-     (-> db
-         (update-in [:application :answers id] merge {:valid true
-                                                      :value value})
-         (update-in [:application :answers id :values] merge {:valid true
-                                                              :value value})
-         (assoc-in [:application :ui id :visible?] false))
+     (as-> db db'
+           (assoc-in db' [:application :ui id :visible?] false)
+           (cond-> db'
+                   (-> db' :application :answers id)
+                   (update-in [:application :answers id]
+                              (fn [answer]
+                                (-> answer
+                                    (assoc :valid true)
+                                    (update :value update-value (constantly value))
+                                    (update :values update-value (constantly {:value value :valid true})))))))
      db)))
 
 (defn- show-field
@@ -34,11 +49,13 @@
   ([db id valid?]
    (if-let [field (some #(when (= id (keyword (:id %))) %)
                         (:flat-form-content db))]
-     (let [cannot-view? (and (get-in db [:application :editing?])
-                             (:cannot-view field))]
-       (-> db
-           (update-in [:application :answers id] set-empty-validity cannot-view? valid?)
-           (assoc-in [:application :ui id :visible?] true)))
+     (as-> db db'
+           (assoc-in db' [:application :ui id :visible?] true)
+           (let [cannot-view? (and (get-in db [:application :editing?])
+                                   (:cannot-view field))]
+             (cond-> db'
+                     (-> db' :application :answers id)
+                     (update-in [:application :answers id] set-empty-validity cannot-view? valid?))))
      db)))
 
 (defn- have-finnish-ssn

--- a/src/cljs/ataru/hakija/schema.cljs
+++ b/src/cljs/ataru/hakija/schema.cljs
@@ -38,7 +38,10 @@
 
 (s/defschema Values
   (s/conditional is-question-group-answer?
-                 [(s/maybe [ValuesValue])]
+                 [(s/conditional is-question-group-answer?
+                                 [(s/maybe [ValuesValue])]
+                                 :else
+                                 (s/maybe [ValuesValue]))]
                  vector?
                  [ValuesValue]
                  :else

--- a/src/cljs/ataru/hakija/schema.cljs
+++ b/src/cljs/ataru/hakija/schema.cljs
@@ -38,10 +38,7 @@
 
 (s/defschema Values
   (s/conditional is-question-group-answer?
-                 [(s/conditional is-question-group-answer?
-                                 [(s/maybe [ValuesValue])]
-                                 :else
-                                 (s/maybe [ValuesValue]))]
+                 [(s/maybe [ValuesValue])]
                  vector?
                  [ValuesValue]
                  :else


### PR DESCRIPTION
Kun hakija valitsee henkilötietomoduulista äidinkielekseen ruotsin, näytetään A1- ja A2 -kielet, muussa tapauksessa A1- ja B1 -kielet.