### PR TITLE
BUG-2143 dropdown values will be set only when they are not already given

### DIFF
--- a/src/cljc/ataru/collections.cljc
+++ b/src/cljc/ataru/collections.cljc
@@ -22,3 +22,7 @@
                                     (filter (comp not nil?)))
                               conj)
                    (first)))))
+
+(defn generate-missing-values [coll f]
+  "Iterate through coll and invoke f to generate :value field, if it does not exist"
+  (map #(assoc % :value (or (:value %) (f))) coll))

--- a/src/cljc/ataru/collections.cljc
+++ b/src/cljc/ataru/collections.cljc
@@ -23,6 +23,17 @@
                               conj)
                    (first)))))
 
-(defn generate-missing-values [coll f]
-  "Iterate through coll and invoke f to generate :value field, if it does not exist"
-  (map #(assoc % :value (or (:value %) (f))) coll))
+(defn generate-missing-values [coll]
+  "Iterate through coll and to generate :value field, if it does not exist"
+  (let [min-start-value 0
+        to-number       (fn [value]
+                          (let [result (ataru.number/->int value)]
+                            (if (ataru.number/isNaN result) (dec min-start-value) result)))
+        values          (map #(to-number (:value %)) coll)
+        max-value       (apply max values)
+        current         (atom (inc max-value))
+        get-current (fn []
+                      (let [previous-value @current]
+                        (swap! current inc)
+                        (str previous-value)))]
+    (map #(assoc % :value (or (:value %) (get-current))) coll)))

--- a/src/cljc/ataru/component_data/component.cljc
+++ b/src/cljc/ataru/component_data/component.cljc
@@ -39,7 +39,6 @@
    :params     {}})
 
 (defn dropdown-option
-  ([] (dropdown-option "0"))
   ([value]
    {:value value
     :label {:fi "" :sv ""}}))

--- a/src/cljc/ataru/component_data/person_info_module.cljc
+++ b/src/cljc/ataru/component_data/person_info_module.cljc
@@ -47,7 +47,7 @@
 
 (defn ^:private dropdown-option
   [value labels & {:keys [default-value] :or {default-value false}}]
-  (-> (component/dropdown-option)
+  (-> (component/dropdown-option "0")
       (merge {:value value :label labels}
              (when default-value
                {:default-value default-value}))))

--- a/src/cljc/ataru/number.cljc
+++ b/src/cljc/ataru/number.cljc
@@ -7,9 +7,13 @@
 (defn- plus? [sign]
   (not (minus? sign)))
 
-(defn- ->int [thestr]
-  #?(:clj  (Integer/parseInt thestr)
+(defn ->int [thestr]
+  #?(:clj  (try (Integer/parseInt thestr) (catch Exception e Double/NaN))
      :cljs (js/parseInt thestr 10)))
+
+(defn isNaN [thenumber]
+  #?(:clj  (Double/isNaN thenumber)
+     :cljs (js/isNaN thenumber)))
 
 (defn- greater-than-or-equal [[value-int value-dec min-int min-dec]]
   (or (> value-int min-int)

--- a/src/cljc/ataru/number.cljc
+++ b/src/cljc/ataru/number.cljc
@@ -8,12 +8,9 @@
   (not (minus? sign)))
 
 (defn ->int [thestr]
-  #?(:clj  (try (Integer/parseInt thestr) (catch Exception e Double/NaN))
-     :cljs (js/parseInt thestr 10)))
-
-(defn isNaN [thenumber]
-  #?(:clj  (Double/isNaN thenumber)
-     :cljs (js/isNaN thenumber)))
+  #?(:clj  (try (Integer/parseInt thestr) (catch Exception e nil))
+     :cljs (let [v (js/parseInt thestr 10)]
+             (if (js/isNaN v) nil v))))
 
 (defn- greater-than-or-equal [[value-int value-dec min-int min-dec]]
   (or (> value-int min-int)

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -53,7 +53,7 @@
   [field-descriptor]
   (if (nil? (:koodisto-source field-descriptor))
     (update field-descriptor :options
-            #(vec (collections/generate-missing-values % cu/new-uuid)))
+            #(vec (collections/generate-missing-values %)))
     field-descriptor))
 
 (reg-event-db

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -68,7 +68,7 @@
   :editor/add-dropdown-option
   (fn [db [_ & path]]
     (let [dropdown-path (current-form-content-path db [path :options])
-          component     (ataru.component-data.component/dropdown-option)]
+          component     (ataru.component-data.component/dropdown-option nil)]
       (-> db
           (update-in dropdown-path into [component])
           (update-in (drop-last dropdown-path) set-non-koodisto-option-values)))))

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -61,8 +61,7 @@
   (fn [db [_ & path]]
     (let [option-path (current-form-content-path db [path])]
       (-> db
-          (update-in (drop-last option-path) util/remove-nth (last option-path))
-          (update-in (drop-last 2 option-path) set-non-koodisto-option-values)))))
+          (update-in (drop-last option-path) util/remove-nth (last option-path))))))
 
 (reg-event-db
   :editor/add-dropdown-option
@@ -118,8 +117,7 @@
       db
       (let [options-path (current-form-content-path db [path :options])]
         (-> db
-            (update-in options-path swap-vector index (dec index))
-            (update-in (drop-last options-path) set-non-koodisto-option-values))))))
+            (update-in options-path swap-vector index (dec index)))))))
 
 (reg-event-db
   :editor/move-option-down
@@ -130,8 +128,7 @@
       (if is-last-option?
         db
         (-> db
-            (update-in options-path swap-vector index (inc index))
-            (update-in (drop-last options-path) set-non-koodisto-option-values))))))
+            (update-in options-path swap-vector index (inc index)))))))
 
 (reg-event-fx
   :editor/select-koodisto-options

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -6,6 +6,7 @@
             [cljs.core.async :as async]
             [ataru.number :refer [numeric-matcher gte]]
             [cljs.core.match :refer-macros [match]]
+            [ataru.collections :as collections]
             [ataru.component-data.value-transformers :refer [update-options-while-keeping-existing-followups]]
             [ataru.virkailija.autosave :as autosave]
             [ataru.component-data.component :as component]
@@ -52,9 +53,7 @@
   [field-descriptor]
   (if (nil? (:koodisto-source field-descriptor))
     (update field-descriptor :options
-            #(vec (map-indexed (fn [i option]
-                                 (assoc option :value (str i)))
-                               %)))
+            #(vec (collections/generate-missing-values % cu/new-uuid)))
     field-descriptor))
 
 (reg-event-db

--- a/test/cljs/unit/ataru/collections_test.cljs
+++ b/test/cljs/unit/ataru/collections_test.cljs
@@ -36,9 +36,19 @@
 
 (deftest generates-missing-values-do-nothing-if-no-missing-values
   (let [fully-populated [{:value "5"} {:value "3"}]]
-    (is (= fully-populated (c/generate-missing-values fully-populated (constantly "generated"))))))
+    (is (= fully-populated (c/generate-missing-values fully-populated)))))
 
 (deftest generates-missing-values-when-values-are-missing
   (let [partially-populated [{:a 4} {:value "5"} {:b 234} {:value "3"}]
-        expected-value [{:a 4 :value "generated"} {:value "5"} {:b 234 :value "generated"} {:value "3"}]]
-    (is (= expected-value (c/generate-missing-values partially-populated (constantly "generated"))))))
+        expected-value [{:a 4 :value "6"} {:value "5"} {:b 234 :value "7"} {:value "3"}]]
+    (is (= expected-value (c/generate-missing-values partially-populated)))))
+
+(deftest generates-missing-values-when-only-zero-is-there
+  (let [partially-populated [{:a 4} {:value "0"} {:b 234}]
+        expected-value [{:a 4 :value "1"} {:value "0"} {:b 234 :value "2"}]]
+    (is (= expected-value (c/generate-missing-values partially-populated)))))
+
+(deftest generates-missing-values-starts-from-zero-if-there-are-no-values-at-all
+  (let [partially-populated [{:a 4 :value nil} {:b 234} {:value nil}]
+        expected-value [{:a 4 :value "0"} {:b 234 :value "1"} {:value "2"}]]
+    (is (= expected-value (c/generate-missing-values partially-populated)))))

--- a/test/cljs/unit/ataru/collections_test.cljs
+++ b/test/cljs/unit/ataru/collections_test.cljs
@@ -33,3 +33,12 @@
 
 (deftest returns-false-when-a-equals-b
   (is (false? (c/before? :a :a [:a :b :c :d]))))
+
+(deftest generates-missing-values-do-nothing-if-no-missing-values
+  (let [fully-populated [{:value "5"} {:value "3"}]]
+    (is (= fully-populated (c/generate-missing-values fully-populated (constantly "generated"))))))
+
+(deftest generates-missing-values-when-values-are-missing
+  (let [partially-populated [{:a 4} {:value "5"} {:b 234} {:value "3"}]
+        expected-value [{:a 4 :value "generated"} {:value "5"} {:b 234 :value "generated"} {:value "3"}]]
+    (is (= expected-value (c/generate-missing-values partially-populated (constantly "generated"))))))


### PR DESCRIPTION
This means that editing and reorganizing the dropdown will not affect the existing values. Whiile new elements will get new, unique values. When creating new dropdown in editor, the values will start from 0, which is like old behaviour.  