### PR TITLE
BUG-2128: remove special case for oph-organization check

### DIFF
--- a/src/clj/ataru/organization_service/organization_client.clj
+++ b/src/clj/ataru/organization_service/organization_client.clj
@@ -59,7 +59,7 @@
   "Returns a sequence of {:name <org-name> :oid <org-oid>} maps containing all suborganizations
    The root organization is the first element"
   [root-organization-oid]
-  (let [url      (if (or (s/blank? root-organization-oid) (= root-organization-oid oph-organization))
+  (let [url      (if (s/blank? root-organization-oid)
                    (resolve-url :organisaatio-service.root-hierarchy)
                    (resolve-url :organisaatio-service.plain-hierarchy root-organization-oid))
         response (http-util/do-get url)]


### PR DESCRIPTION
This is a revert of https://github.com/Opetushallitus/ataru/commit/0f8e32709b0b2c6378e7d53d8168914b39a199ce https://github.com/Opetushallitus/ataru/commit/2466b51222dca43029e3584f78523ce1d32b63ab