### PR TITLE
Korjaa cljs käännosvirheet

### DIFF
--- a/src/cljc/ataru/collections.cljc
+++ b/src/cljc/ataru/collections.cljc
@@ -1,7 +1,9 @@
-(ns ataru.collections)
+(ns ataru.collections
+  (:require [ataru.number :as number]))
 
-(defn before? [a b coll]
+(defn before?
   "Testaa onko a ennen b:tä annetussa coll:ssa iteroimatta turhia"
+  [a b coll]
   (true? (and a
               b
               (not= a b)
@@ -23,8 +25,9 @@
                               conj)
                    (first)))))
 
-(defn generate-missing-values [coll]
+(defn generate-missing-values
   "Iterate through coll and to generate :value field, if it does not exist"
+  [coll]
   (:options
     (reduce (fn [{:keys [next-value options]} option]
             (if (:value option)
@@ -34,7 +37,7 @@
                :options    (conj options (assoc option :value (str next-value)))}))
           {:next-value (if (seq coll)
                          (->> coll
-                              (map #(ataru.number/->int (:value %)))
+                              (map #(number/->int (:value %)))
                               (map #(if (nil? %) -1 %))
                               (apply max)
                               inc)

--- a/src/cljc/ataru/component_data/component.cljc
+++ b/src/cljc/ataru/component_data/component.cljc
@@ -46,6 +46,7 @@
    :params     {}})
 
 (defn dropdown-option
+  ([] (dropdown-option nil))
   ([value]
    {:value value
     :label {:fi "" :sv ""}}))

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -67,7 +67,7 @@
   :editor/add-dropdown-option
   (fn [db [_ & path]]
     (let [dropdown-path (current-form-content-path db [path :options])
-          component     (ataru.component-data.component/dropdown-option nil)]
+          component     (component/dropdown-option nil)]
       (-> db
           (update-in dropdown-path into [component])
           (update-in (drop-last dropdown-path) set-non-koodisto-option-values)))))
@@ -83,7 +83,7 @@
   :editor/add-text-field-option
   (fn [db [_ path]]
     (let [text-field-path (current-form-content-path db [path :options])
-          component       (ataru.component-data.component/text-field-option)]
+          component       (component/text-field-option)]
       (-> db
           (update-in text-field-path into [component])
           (update-in (drop-last text-field-path) set-non-koodisto-option-values)))))


### PR DESCRIPTION
Pari käännösvirhettä poistettu. Tuplasti esiintyvä määrittely ja dropdown-option alustus arvosanat-modulissa. Tämä liittyy dropdown-muutokseen #1047.