### PR TITLE
Käsittele puuttuvat vanhat tyhjät vastaukset

### DIFF
--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -81,10 +81,10 @@
          util/flatten-form-fields
          (keep (fn [{:keys [id cannot-edit]}]
                  (when (and cannot-edit
-                            (not= (if (sequential? (:value (new-answers id)))
-                                    (seq (:value (new-answers id)))
-                                    (:value (new-answers id)))
-                                  (:value (old-answers id))))
+                            (if (contains? old-answers id)
+                              (not= (:value (new-answers id))
+                                    (:value (old-answers id)))
+                              (not-empty (:value (new-answers id)))))
                    id))))))
 
 (defn- flatten-attachment-keys [application]


### PR DESCRIPTION
Ennen HLE-1180 muutoksia sellaisia vastauksia joiden value oli not-empty ei
tallennut tietokantaan ollenkaan. Tämän takia edited-cannot-edit-questions
joutuu käsittelemään erikseen tilanteen jossa vastaus löytyy kaikkien
vastauksien joukosta, ja tilanteen jossa sitä ei löydy.