### PR TITLE
Varmempi tekstinsyotto Cypressilla

### DIFF
--- a/cypress/asetukset.ts
+++ b/cypress/asetukset.ts
@@ -1,1 +1,4 @@
+/**
+ * Cypressin (4.8.0) oletusviive on 10 ms.
+ */
 export const tekstikentanSyotonViive = 0

--- a/cypress/asetukset.ts
+++ b/cypress/asetukset.ts
@@ -1,1 +1,1 @@
-export const tekstikentanSyotonViive = 40
+export const tekstikentanSyotonViive = 0

--- a/cypress/hakijanNakyma.ts
+++ b/cypress/hakijanNakyma.ts
@@ -63,6 +63,12 @@ export const arvosanat = {
 const syota = <T>(
   elementti: Chainable<T>,
   teksti: string
+): (() => Chainable<T>) => () =>
+  tekstikentta.syotaTekstiTarkistamatta(elementti, teksti)
+
+const syotaTurv = <T>(
+  elementti: Chainable<T>,
+  teksti: string
 ): (() => Chainable<T>) => () => tekstikentta.syotaTeksti(elementti, teksti)
 
 export const henkilotiedot = {
@@ -79,11 +85,14 @@ export const henkilotiedot = {
 
   taytaTiedot: () => {
     return tekstikentta
-      .syotaTeksti(henkilotiedot.haeEtunimiKentta(), 'Frank Zacharias')
+      .syotaTekstiTarkistamatta(
+        henkilotiedot.haeEtunimiKentta(),
+        'Frank Zacharias'
+      )
       .then(syota(henkilotiedot.haeSukunimiKentta(), 'Testerberg'))
       .then(syota(henkilotiedot.haeHenkilotunnusKentta(), '160600A999C'))
-      .then(syota(henkilotiedot.haeSahkopostiKentta(), 'f.t@example.com'))
-      .then(syota(henkilotiedot.haeSahkostinVarmistus(), 'f.t@example.com'))
+      .then(syotaTurv(henkilotiedot.haeSahkopostiKentta(), 'f.t@example.com'))
+      .then(syotaTurv(henkilotiedot.haeSahkostinVarmistus(), 'f.t@example.com'))
       .then(syota(henkilotiedot.haeMatkapuhelinKentta(), '0401234567'))
       .then(syota(henkilotiedot.haeKatuosoiteKentta(), 'Yliopistonkatu 4'))
       .then(syota(henkilotiedot.haePostinumeroKentta(), '00100'))

--- a/cypress/hakijanNakyma.ts
+++ b/cypress/hakijanNakyma.ts
@@ -66,37 +66,34 @@ const syota = <T>(
 ): (() => Chainable<T>) => () =>
   tekstikentta.syotaTekstiTarkistamatta(elementti, teksti)
 
-const syotaTurv = <T>(
+const syotaTurvallisesti = <T>(
   elementti: Chainable<T>,
   teksti: string
 ): (() => Chainable<T>) => () => tekstikentta.syotaTeksti(elementti, teksti)
 
 export const henkilotiedot = {
-  haeEtunimiKentta: () => cy.get('[data-test-id=first-name-input]'),
-  haeSukunimiKentta: () => cy.get('[data-test-id=last-name-input]'),
-  haeHenkilotunnusKentta: () => cy.get('[data-test-id=ssn-input]'),
-  haeSahkopostiKentta: () => cy.get('[data-test-id=email-input]'),
-  haeSahkostinVarmistus: () => cy.get('[data-test-id=verify-email-input]'),
-  haeMatkapuhelinKentta: () => cy.get('[data-test-id=phone-input]'),
-  haeKatuosoiteKentta: () => cy.get('[data-test-id=address-input]'),
-  haePostinumeroKentta: () => cy.get('[data-test-id=postal-code-input]'),
-  haePostitoimipaikkaKentta: () => cy.get('[data-test-id=postal-office-input]'),
-  haeKotikuntaKentta: () => cy.get('[data-test-id=home-town-input]'),
+  etunimi: () => cy.get('[data-test-id=first-name-input]'),
+  sukunimi: () => cy.get('[data-test-id=last-name-input]'),
+  henkilotunnus: () => cy.get('[data-test-id=ssn-input]'),
+  sahkoposti: () => cy.get('[data-test-id=email-input]'),
+  sahkopostitoisto: () => cy.get('[data-test-id=verify-email-input]'),
+  matkapuhelin: () => cy.get('[data-test-id=phone-input]'),
+  katusoite: () => cy.get('[data-test-id=address-input]'),
+  postinumero: () => cy.get('[data-test-id=postal-code-input]'),
+  postitoimipaikka: () => cy.get('[data-test-id=postal-office-input]'),
+  kotikunta: () => cy.get('[data-test-id=home-town-input]'),
 
   taytaTiedot: () => {
     return tekstikentta
-      .syotaTekstiTarkistamatta(
-        henkilotiedot.haeEtunimiKentta(),
-        'Frank Zacharias'
-      )
-      .then(syota(henkilotiedot.haeSukunimiKentta(), 'Testerberg'))
-      .then(syota(henkilotiedot.haeHenkilotunnusKentta(), '160600A999C'))
-      .then(syotaTurv(henkilotiedot.haeSahkopostiKentta(), 'f.t@example.com'))
-      .then(syotaTurv(henkilotiedot.haeSahkostinVarmistus(), 'f.t@example.com'))
-      .then(syota(henkilotiedot.haeMatkapuhelinKentta(), '0401234567'))
-      .then(syota(henkilotiedot.haeKatuosoiteKentta(), 'Yliopistonkatu 4'))
-      .then(syota(henkilotiedot.haePostinumeroKentta(), '00100'))
-      .then(() => henkilotiedot.haeKotikuntaKentta().select('Forssa'))
+      .syotaTekstiTarkistamatta(henkilotiedot.etunimi(), 'Frank Zacharias')
+      .then(syota(henkilotiedot.sukunimi(), 'Testerberg'))
+      .then(syota(henkilotiedot.henkilotunnus(), '160600A999C'))
+      .then(syotaTurvallisesti(henkilotiedot.sahkoposti(), 'f.t@ex.com'))
+      .then(syotaTurvallisesti(henkilotiedot.sahkopostitoisto(), 'f.t@ex.com'))
+      .then(syota(henkilotiedot.matkapuhelin(), '0401234567'))
+      .then(syota(henkilotiedot.katusoite(), 'Yliopistonkatu 4'))
+      .then(syota(henkilotiedot.postinumero(), '00100'))
+      .then(() => henkilotiedot.kotikunta().select('Forssa'))
   },
 }
 

--- a/cypress/lomakkeenMuokkaus.ts
+++ b/cypress/lomakkeenMuokkaus.ts
@@ -1,8 +1,8 @@
 import * as httpPaluusanomat from './httpPaluusanomat'
 import * as reitit from './reitit'
-import * as asetukset from './asetukset'
 import * as odota from './odota'
 import * as tekstikentta from './tekstikentta'
+import { syotaTeksti } from './tekstikentta'
 
 import Chainable = Cypress.Chainable
 import WaitXHR = Cypress.WaitXHR
@@ -46,9 +46,7 @@ export function teeJaodotaLomakkeenTallennusta<T>(
 
 export const asetaLomakkeenNimi = (name: string, lomakkeenId: number) =>
   teeJaodotaLomakkeenTallennusta(lomakkeenId, () =>
-    haeLomakkeenNimenSyote()
-      .clear()
-      .type(name, { delay: asetukset.tekstikentanSyotonViive })
+    syotaTeksti(haeLomakkeenNimenSyote(), name)
   )
 
 const koodistonValitsin = () =>

--- a/cypress/tekstikentta.ts
+++ b/cypress/tekstikentta.ts
@@ -1,4 +1,15 @@
+import * as asetukset from './asetukset'
+
 import Chainable = Cypress.Chainable
+
+export const syotaTekstiTarkistamatta = <T>(
+  elementti: Chainable<T>,
+  teksti: string
+): Chainable<T> => {
+  return elementti
+    .clear()
+    .type(teksti, { delay: asetukset.tekstikentanSyotonViive })
+}
 
 export const syotaTeksti = <T>(
   elementti: Chainable<T>,

--- a/cypress/tekstikentta.ts
+++ b/cypress/tekstikentta.ts
@@ -2,6 +2,10 @@ import * as asetukset from './asetukset'
 
 import Chainable = Cypress.Chainable
 
+/**
+ * Tämä tapa on nopeampi joten sitä kannattaa käyttää, jos ei ole riskiä siitä,
+ * että Reactin hallinta hävittäisi syötettyjä merkkejä.
+ */
 export const syotaTekstiTarkistamatta = <T>(
   elementti: Chainable<T>,
   teksti: string
@@ -11,6 +15,11 @@ export const syotaTekstiTarkistamatta = <T>(
     .type(teksti, { delay: asetukset.tekstikentanSyotonViive })
 }
 
+/**
+ * Tämä on turvallinen tapa täyttää tekstikenttä, koska se tarkistaa jokaisen
+ * merkin syöttämisen jälkeen, että syötetty merkki ehtii renderöityä kenttään
+ * ennen kuin seuraava merkki syötetään.
+ */
 export const syotaTeksti = <T>(
   elementti: Chainable<T>,
   teksti: string

--- a/cypress/tekstikentta.ts
+++ b/cypress/tekstikentta.ts
@@ -1,9 +1,21 @@
-import * as asetukset from './asetukset'
-
 import Chainable = Cypress.Chainable
 
 export const syotaTeksti = <T>(
   elementti: Chainable<T>,
   teksti: string
-): Chainable<T> =>
-  elementti.clear().type(teksti, { delay: asetukset.tekstikentanSyotonViive })
+): Chainable<T> => {
+  return elementti.clear().then((tyhjennettyElementti) => {
+    const merkit = [...teksti]
+    return Cypress.Promise.all(
+      merkit.map((m, i) => {
+        elementti
+          .type(m, {
+            delay: 0,
+          })
+          .then(() => {
+            elementti.should('have.value', teksti.substring(0, i + 1))
+          })
+      })
+    ).then(() => tyhjennettyElementti)
+  })
+}

--- a/cypress/testit/henkilotietoModuulinTayttaminen.ts
+++ b/cypress/testit/henkilotietoModuulinTayttaminen.ts
@@ -8,7 +8,7 @@ export default (testit: () => void) => {
 
     it('Näyttää täytetyn henkilötietomoduulin', () => {
       hakijanNakyma.henkilotiedot
-        .haePostitoimipaikkaKentta()
+        .postitoimipaikka()
         .should('have.value', 'HELSINKI')
     })
 


### PR DESCRIPTION
Tämä toivottavasti korjaa esim rikkinäisen "Testilomake"-tekstin ongelman Cypress-testeistä.