### PR TITLE
BUG-2222 Concat first and last names with a space in between

### DIFF
--- a/resources/sql/application-list-query.sql
+++ b/resources/sql/application-list-query.sql
@@ -174,7 +174,7 @@ WHERE la.id IS NULL
   AND a.person_oid = :person-oid
 /*~ ) ~*/
 /*~ (when (contains? params :name) */
-  AND to_tsvector('unaccent_simple', a.preferred_name || a.last_name) @@ to_tsquery('unaccent_simple', :name)
+  AND to_tsvector('unaccent_simple', concat(a.preferred_name, ' ', a.last_name)) @@ to_tsquery('unaccent_simple', :name)
 /*~ ) ~*/
 /*~ (when (contains? params :email) */
   AND lower(a.email) = lower(:email)


### PR DESCRIPTION
This is to prevent the first part of a two-part last name
getting combined with the first name when constructing the
search tokens, which was effectively breaking the search.