### PR TITLE
HLE-1319/lomakeosion piilottaminen tekstikentän ehdolla

### DIFF
--- a/cypress/integration/lomakeosionNayttaminenTekstikentanArvonPerusteellaSpec.ts
+++ b/cypress/integration/lomakeosionNayttaminenTekstikentanArvonPerusteellaSpec.ts
@@ -11,6 +11,7 @@ const typeValueAndAssertVisibility = (value: string, isVisible: boolean) => {
       cy.get('[data-test-id=tekstikenttä-input]'),
       value
     )
+    .blur()
     .then(() => {
       hakijanNakyma.henkilotiedot
         .etunimi()
@@ -38,6 +39,7 @@ describe('Lomakeosion näkyvyys tekstikentän arvon perusteella', () => {
             it('Piilottaa lomakeosion, kun tekstikenttä on tyhjä', () => {
               cy.get('[data-test-id=tekstikenttä-input]')
                 .clear()
+                .blur()
                 .then(() => {
                   hakijanNakyma.henkilotiedot.etunimi().should('not.exist')
                 })

--- a/cypress/integration/lomakeosionNayttaminenTekstikentanArvonPerusteellaSpec.ts
+++ b/cypress/integration/lomakeosionNayttaminenTekstikentanArvonPerusteellaSpec.ts
@@ -8,7 +8,7 @@ import * as tekstinSyotto from '../tekstinSyotto'
 const typeValueAndAssertVisibility = (value: string, isVisible: boolean) => {
   tekstinSyotto
     .syotaTekstiTarkistamatta(
-      cy.get('[data-test-id=tekstikenttä-input]'),
+      cy.get('[data-test-id=tekstikenttä-input]').last(),
       value
     )
     .blur()
@@ -38,6 +38,7 @@ describe('Lomakeosion näkyvyys tekstikentän arvon perusteella', () => {
             })
             it('Piilottaa lomakeosion, kun tekstikenttä on tyhjä', () => {
               cy.get('[data-test-id=tekstikenttä-input]')
+                .last()
                 .clear()
                 .blur()
                 .then(() => {

--- a/cypress/integration/lomakeosionNayttaminenTekstikentanArvonPerusteellaSpec.ts
+++ b/cypress/integration/lomakeosionNayttaminenTekstikentanArvonPerusteellaSpec.ts
@@ -1,0 +1,50 @@
+import kirjautuminenVirkailijanNakymaan from '../testit/kirjautuminenVirkailijanNakymaan'
+import lomakkeenLuonti from '../testit/lomakkeenLuonti'
+import hakijanNakymaanSiirtyminen from '../testit/hakijanNakymaanSiirtyminen'
+import * as hakijanNakyma from '../hakijanNakyma'
+import lomakeosionNayttaminenTekstikentanArvonPerusteellaLisays from '../testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/lomakeosionNayttaminenTekstikentanArvonPerusteellaLisays'
+import * as tekstinSyotto from '../tekstinSyotto'
+
+const typeValueAndAssertVisibility = (value: string, isVisible: boolean) => {
+  tekstinSyotto
+    .syotaTekstiTarkistamatta(
+      cy.get('[data-test-id=tekstikenttä-input]'),
+      value
+    )
+    .then(() => {
+      hakijanNakyma.henkilotiedot
+        .etunimi()
+        .should(isVisible ? 'exist' : 'not.exist')
+    })
+}
+
+describe('Lomakeosion näkyvyys tekstikentän arvon perusteella', () => {
+  kirjautuminenVirkailijanNakymaan('lomakkeiden käsittelyä varten', () => {
+    lomakkeenLuonti((lomakkeenTunnisteet) => {
+      lomakeosionNayttaminenTekstikentanArvonPerusteellaLisays(
+        lomakkeenTunnisteet,
+        () => {
+          hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
+            it('Ei näytä valittua lomakeosiota kun lomakkeen avaa ensimmäistä kertaa', () => {
+              hakijanNakyma.henkilotiedot.etunimi().should('not.exist')
+            })
+            it('Piilottaa lomakeosion, kun tekstikentän ehto täyttyy', () => {
+              typeValueAndAssertVisibility('-1', false)
+            })
+            it('Näyttää lomakeosion, kun tekstikentän ehto ei täyty', () => {
+              typeValueAndAssertVisibility('0', true)
+              typeValueAndAssertVisibility('10', true)
+            })
+            it('Piilottaa lomakeosion, kun tekstikenttä on tyhjä', () => {
+              cy.get('[data-test-id=tekstikenttä-input]')
+                .clear()
+                .then(() => {
+                  hakijanNakyma.henkilotiedot.etunimi().should('not.exist')
+                })
+            })
+          })
+        }
+      )
+    })
+  })
+})

--- a/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/lomakeosio.ts
+++ b/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/lomakeosio.ts
@@ -1,0 +1,11 @@
+import * as lomakkeenMuokkaus from '../../../../../lomakkeenMuokkaus'
+
+export const lomakeosio = {
+  haeLisaaLinkki: () => cy.get('[data-test-id=component-toolbar-lomakeosio]'),
+
+  lisaaLomakeosio: (formId: number) =>
+    lomakkeenMuokkaus.teeJaodotaLomakkeenTallennusta(formId, () => {
+      lomakkeenMuokkaus.komponentinLisays.avaaValikko()
+      return lomakeosio.haeLisaaLinkki().click()
+    }),
+}

--- a/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/lomakeosionNayttaminenArvonPerusteella.ts
+++ b/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/lomakeosionNayttaminenArvonPerusteella.ts
@@ -1,0 +1,52 @@
+export const lomakeosionNayttaminenArvonPerusteella = {
+  lomakeosionNayttaminenArvonPerusteellaValinta: () =>
+    cy.get(
+      '[data-test-id=tekstikenttä-valinta-lomakeosion-nayttaminen-arvon-perusteella]'
+    ),
+
+  valitseLomakeosionNayttaminenArvonPerusteella: () => {
+    return lomakeosionNayttaminenArvonPerusteella
+      .lomakeosionNayttaminenArvonPerusteellaValinta()
+      .click()
+  },
+
+  lomakeosionNayttamissaanto: () =>
+    cy.get('[data-test-id=tekstikenttä-lomakeosion-näyttämissääntö]'),
+
+  lomakeosionNayttamissaantoEhtoOperaattori: () =>
+    lomakeosionNayttaminenArvonPerusteella
+      .lomakeosionNayttamissaanto()
+      .find(
+        '[data-test-id=tekstikenttä-lisäkysymys-arvon-perusteella-ehto-operaattori]'
+      ),
+
+  lomakeosionNayttamissaantoEhtoVertailuarvo: () =>
+    lomakeosionNayttaminenArvonPerusteella
+      .lomakeosionNayttamissaanto()
+      .find(
+        '[data-test-id=tekstikenttä-lisäkysymys-arvon-perusteella-ehto-vertailuarvo]'
+      ),
+
+  lomakeosionNayttamissaantoLomakeOsionTeksti: () =>
+    lomakeosionNayttaminenArvonPerusteella
+      .lomakeosionNayttamissaanto()
+      .find(
+        '[data-test-id=tekstikenttä-arvon-perusteella-piilotettavan-osion-nimi]'
+      ),
+
+  haePiilotettavanLomakeosionTeksti: () => {
+    return lomakeosionNayttaminenArvonPerusteella.lomakeosionNayttamissaantoLomakeOsionTeksti()
+  },
+
+  asetaLomakeosionNayttaminenArvonPerusteellaEhto: (
+    operaattori: string,
+    vertailuarvo: number
+  ) => {
+    lomakeosionNayttaminenArvonPerusteella
+      .lomakeosionNayttamissaantoEhtoOperaattori()
+      .select(operaattori)
+    lomakeosionNayttaminenArvonPerusteella
+      .lomakeosionNayttamissaantoEhtoVertailuarvo()
+      .type(`${vertailuarvo}`)
+  },
+}

--- a/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/lomakeosionNayttaminenTekstikentanArvonPerusteellaLisays.ts
+++ b/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/lomakeosionNayttaminenTekstikentanArvonPerusteellaLisays.ts
@@ -1,0 +1,38 @@
+import LomakkeenTunnisteet from '../../../../../LomakkeenTunnisteet'
+import { tekstikentta } from './tekstikentta'
+import { lomakeosionNayttaminenArvonPerusteella } from './lomakeosionNayttaminenArvonPerusteella'
+import { lomakeosio } from './lomakeosio'
+
+export default (
+  lomakkeenTunnisteet: () => LomakkeenTunnisteet,
+  testit: () => void
+) => {
+  describe('Lomakeosion näyttäminen tekstikentän arvon perusteella lisäys', () => {
+    before(() => {
+      tekstikentta
+        .lisaaTekstikentta(lomakkeenTunnisteet().lomakkeenId)
+        .then(() => tekstikentta.asetaKysymys('Kysymys'))
+        .then(() => tekstikentta.valitseKenttäänVainNumeroita())
+        .then(() =>
+          lomakeosionNayttaminenArvonPerusteella.valitseLomakeosionNayttaminenArvonPerusteella()
+        )
+        .then(() =>
+          lomakeosionNayttaminenArvonPerusteella.asetaLomakeosionNayttaminenArvonPerusteellaEhto(
+            '<',
+            0
+          )
+        )
+        .then(() =>
+          lomakeosio.lisaaLomakeosio(lomakkeenTunnisteet().lomakkeenId)
+        )
+    })
+
+    it('Näyttää piilottettavan osion nimen', () => {
+      lomakeosionNayttaminenArvonPerusteella
+        .haePiilotettavanLomakeosionTeksti()
+        .should('have.value', 'onr')
+    })
+
+    testit()
+  })
+}

--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -708,6 +708,17 @@
   margin-left: 10px;
 }
 
+.editor-form__text-field-hideable-section-selector {
+  align-items: center;
+  display: flex;
+  flex-flow: row wrap;
+  margin-left: 10px;
+}
+
+.editor-form__text-field-hideable-section-selector--instruction {
+  margin-right: 10px;
+}
+
 .editor-form__text-field-option-condition-label {
 }
 

--- a/src/cljc/ataru/application/option_visibility.cljc
+++ b/src/cljc/ataru/application/option_visibility.cljc
@@ -4,7 +4,7 @@
 
 (declare answer-values)
 
-(defn- non-blank-answer-satisfies-condition? [value option]
+(defn non-blank-answer-satisfies-condition? [value option]
   (and (not (string/blank? value))
        (if-let [condition (:condition option)]
          (let [operator (case (:comparison-operator condition)

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -70,6 +70,8 @@
                                                                           (s/optional-key :default-option) s/Any
                                                                           (s/optional-key :title)          s/Str
                                                                           (s/optional-key :allow-invalid?) s/Bool}
+                        (s/optional-key :section-visibility-conditions)  [{:section-name s/Str
+                                                                           :condition OptionCondition}]
                         (s/optional-key :options)                        [{:value                            s/Str
                                                                            (s/optional-key :label)           localized-schema/LocalizedStringOptional
                                                                            (s/optional-key :description)     localized-schema/LocalizedStringOptional

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1903,6 +1903,12 @@
    :lisakysymys-arvon-perusteella-lisaa-ehto        {:fi "Lisää ehto"
                                                      :sv "Lisää ehto"
                                                      :en "EN: Lisää ehto"}
+   :lomakeosion-piilottaminen-arvon-perusteella     {:fi "Toisen lomakeosion piilottaminen arvon perusteella"
+                                                     :sv "SV: Toisen lomakeosion piilottaminen arvon perusteella"
+                                                     :en "EN: Toisen lomakeosion piilottaminen arvon perusteella"}
+   :lomakeosion-piilottaminen-arvon-perusteella-valitse-osio {:fi "Valitse piilotettava osio tästä"
+                                                              :sv "SV: Valitse piilotettava osio tästä"
+                                                              :en "EN: Valitse piilotettava osio tästä"}
    :filter-by-question-answer                       {:fi "Rajaa vastauksen mukaan"
                                                      :sv "Avgränsa enligt svar"
                                                      :en "EN: Rajaa vastauksen mukaan"}

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -278,7 +278,7 @@
    :no-hakukohde-search-hits                    {:fi "Ei hakutuloksia"
                                                  :en "No search results found"
                                                  :sv "Inga sökresultat"}
-   :not-applicable-for-hakukohteet              {:fi "Huomaathan, että pohjakoulutuksesi perusteella et ole halukelpoinen seuraaviin hakukohteisiin. Tarkista hakukelpoisuusvaatimukset hakukohteen valintaperusteista."
+   :not-applicable-for-hakukohteet              {:fi "Huomaathan, että pohjakoulutuksesi perusteella et ole hakukelpoinen seuraaviin hakukohteisiin. Tarkista hakukelpoisuusvaatimukset hakukohteen valintaperusteista."
                                                  :sv "Märk, att du på basis av din grundutbildning inte är behörig att söka till detta ansökningsmål. Kontrollera behörighetskraven för ansökan i ansökningsmålets antagningsgrunder."
                                                  :en "Please note that the education you have given does not provide eligibility for these study programmes. Please check the required eligibility from the study programme’s admission criteria."}
    :not-editable-application-period-ended       {:fi "Tämä hakutoive ei ole muokattavissa koska sen hakuaika on päättynyt."

--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -313,3 +313,10 @@
 
 (defn non-blank-option-label [option langs]
   (non-blank-val (:label option) langs))
+
+(defn set-nested-visibility [db id visible?]
+  (->> id
+       (find-field (get-in db [:form :content]))
+       (collect-ids [])
+       (reduce (fn [acc-db cur-id]
+                 (assoc-in acc-db [:application :ui (keyword cur-id) :visible?] visible?)) db)))

--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -6,7 +6,8 @@
             #?(:clj  [clj-time.core :as time]
                :cljs [cljs-time.core :as time])
             #?(:clj  [clj-time.coerce :refer [from-long]]
-               :cljs [cljs-time.coerce :refer [from-long]]))
+               :cljs [cljs-time.coerce :refer [from-long]])
+            [clojure.string :as string])
   (:import #?(:clj [java.util UUID])))
 
 (defn is-question-group-answer? [value]
@@ -89,6 +90,14 @@
        :content
        flatten-form-fields
        (group-by-first (comp keyword :id))))
+
+(defn- form-sections-by-id [form]
+  (->> form
+       :content
+       (filter #(= "wrapperElement" (:fieldClass %)))
+       (group-by-first (comp keyword :id))))
+
+(def form-sections-by-id-memo (memoize form-sections-by-id))
 
 (defn form-attachment-fields [form]
   (->> form
@@ -197,7 +206,7 @@
   (some #(= item %) vec))
 
 (defn not-blank? [s]
-  (not (clojure.string/blank? s)))
+  (not (string/blank? s)))
 
 (defn not-blank [s]
   (when (not-blank? s) s))

--- a/src/cljc/ataru/util.cljc
+++ b/src/cljc/ataru/util.cljc
@@ -320,3 +320,8 @@
        (collect-ids [])
        (reduce (fn [acc-db cur-id]
                  (assoc-in acc-db [:application :ui (keyword cur-id) :visible?] visible?)) db)))
+
+(defn visibility-conditions [content]
+  (->> content
+       (keep :section-visibility-conditions)
+       flatten))

--- a/src/cljs/ataru/hakija/application/field_visibility.cljs
+++ b/src/cljs/ataru/hakija/application/field_visibility.cljs
@@ -31,13 +31,13 @@
 
 (defn- set-followup-visibility [db field-descriptor show-followups? show-conditional-followups-fn ylioppilastutkinto? hakukohteet-and-ryhmat]
   (let [field-id (-> field-descriptor :id keyword)
-        fields-by-id (u/form-fields-by-id (:form db))
+        value (get-in db [:application :answers field-id :value])
+        fields-by-id (u/form-sections-by-id-memo (:form db))
         remove-fn (fn [condition]
                     (when show-followups?
-                      (let [value (get-in db [:application :answers field-id :value])]
-                        (or
-                          (string/blank? value)
-                          (option-visibility/non-blank-answer-satisfies-condition? value condition)))))
+                      (or
+                        (string/blank? value)
+                        (option-visibility/non-blank-answer-satisfies-condition? value condition))))
         conditional-sections (->> (:section-visibility-conditions field-descriptor)
                                   (remove remove-fn)
                                   (map (comp keyword :section-name))

--- a/src/cljs/ataru/hakija/application/field_visibility.cljs
+++ b/src/cljs/ataru/hakija/application/field_visibility.cljs
@@ -29,7 +29,7 @@
 
 (declare set-field-visibility)
 
-(defn- set-followup-visibility [db field-descriptor show-followups? ylioppilastutkinto? hakukohteet-and-ryhmat]
+(defn- set-followup-visibility [db field-descriptor show-followups? show-conditional-followups-fn ylioppilastutkinto? hakukohteet-and-ryhmat]
   (let [field-id (-> field-descriptor :id keyword)
         fields-by-id (u/form-fields-by-id (:form db))
         remove-fn (fn [condition]
@@ -41,17 +41,17 @@
         conditional-sections (->> (:section-visibility-conditions field-descriptor)
                                   (remove remove-fn)
                                   (map (comp keyword :section-name))
-                                  (keep (partial get fields-by-id)))
-        fields (conj conditional-sections field-descriptor)]
-    (reduce
-      #(set-field-visibility %1 %2 show-followups? ylioppilastutkinto? hakukohteet-and-ryhmat)
-      db
-      fields)))
+                                  (keep (partial get fields-by-id)))]
+    (as-> db db'
+          (set-field-visibility db' field-descriptor show-followups? ylioppilastutkinto? hakukohteet-and-ryhmat)
+          (reduce #(u/set-nested-visibility %1 (:id %2) (show-conditional-followups-fn show-followups? %2))
+                  db'
+                  conditional-sections))))
 
-(defn- set-visibility-for-option-followups [db options show-option-followups? ylioppilastutkinto? hakukohteet-and-ryhmat]
+(defn- set-visibility-for-option-followups [db options show-followups-fn show-conditional-followups-fn ylioppilastutkinto? hakukohteet-and-ryhmat]
   (reduce (fn [db option]
-            (let [show-followups? (show-option-followups? option)]
-              (reduce #(set-followup-visibility %1 %2 show-followups? ylioppilastutkinto? hakukohteet-and-ryhmat)
+            (let [show-followups? (show-followups-fn option)]
+              (reduce #(set-followup-visibility %1 %2 show-followups? show-conditional-followups-fn ylioppilastutkinto? hakukohteet-and-ryhmat)
                       db
                       (:followups option))))
           db
@@ -59,13 +59,20 @@
 
 (defn- set-followups-visibility
   [db field-descriptor visible? ylioppilastutkinto? hakukohteet-and-ryhmat]
-  (let [answer-value       (get-in db [:application :answers (keyword (:id field-descriptor)) :value])
+  (let [component-visibility (atom {})
+        answer-value (get-in db [:application :answers (keyword (:id field-descriptor)) :value])
         visibility-checker (option-visibility/visibility-checker field-descriptor answer-value)
-        show-followups?    #(and visible?
-                                 (visibility-checker %))]
+        show-followups-fn #(and visible?
+                                (visibility-checker %))
+        show-conditional-followups-fn (fn [show? field-descriptor]
+                                        (let [id (:id field-descriptor)
+                                              should-show? (or show? (get @component-visibility id false))]
+                                          (swap! component-visibility assoc id should-show?)
+                                          should-show?))]
     (set-visibility-for-option-followups db
                                          (:options field-descriptor)
-                                         show-followups?
+                                         show-followups-fn
+                                         show-conditional-followups-fn
                                          ylioppilastutkinto?
                                          hakukohteet-and-ryhmat)))
 

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -40,6 +40,9 @@
 (defn- email-verify-field-change [field-descriptor value verify-value]
   (dispatch [:application/set-email-verify-field field-descriptor value verify-value]))
 
+(defn- text-field-change [field-descriptor value]
+  (dispatch [:application/set-application-text-field field-descriptor value]))
+
 (defn- textual-field-change [field-descriptor value]
   (dispatch [:application/set-repeatable-application-field field-descriptor nil nil value]))
 
@@ -215,7 +218,7 @@
             show-error?      @(subscribe [:application/show-validation-error-class? id idx nil])
             on-change        (if idx
                                (partial multi-value-field-change field-descriptor idx)
-                               (partial textual-field-change field-descriptor))
+                               (partial text-field-change field-descriptor))
             on-blur          (fn [_] (textual-field-blur field-descriptor))
             form-field-id    (application-field/form-field-id field-descriptor idx)
             data-test-id     (if (some #{id} [:first-name

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -40,8 +40,8 @@
 (defn- email-verify-field-change [field-descriptor value verify-value]
   (dispatch [:application/set-email-verify-field field-descriptor value verify-value]))
 
-(defn- text-field-change [field-descriptor value]
-  (dispatch [:application/set-application-text-field field-descriptor value]))
+(defn- handle-section-visibility-on-blur [field-descriptor value]
+  (dispatch [:application/handle-section-visibility-conditions field-descriptor value]))
 
 (defn- textual-field-change [field-descriptor value]
   (dispatch [:application/set-repeatable-application-field field-descriptor nil nil value]))
@@ -221,7 +221,8 @@
                                (partial textual-field-change field-descriptor))
             on-blur          (fn [_]
                                (textual-field-blur field-descriptor)
-                               (text-field-change field-descriptor (get @local-state :value)))
+                               (when (seq (:section-visibility-conditions field-descriptor))
+                                 (handle-section-visibility-on-blur field-descriptor (get @local-state :value))))
             form-field-id    (application-field/form-field-id field-descriptor idx)
             data-test-id     (if (some #{id} [:first-name
                                               :preferred-name

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -218,8 +218,10 @@
             show-error?      @(subscribe [:application/show-validation-error-class? id idx nil])
             on-change        (if idx
                                (partial multi-value-field-change field-descriptor idx)
-                               (partial text-field-change field-descriptor))
-            on-blur          (fn [_] (textual-field-blur field-descriptor))
+                               (partial textual-field-change field-descriptor))
+            on-blur          (fn [_]
+                               (textual-field-blur field-descriptor)
+                               (text-field-change field-descriptor (get @local-state :value)))
             form-field-id    (application-field/form-field-id field-descriptor idx)
             data-test-id     (if (some #{id} [:first-name
                                               :preferred-name

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -760,12 +760,11 @@
 (reg-event-db
   :application/hide-form-sections-with-text-component-visibility-rules
   (fn [db _]
-    (let [form-content (get-in db [:form :content])
+    (let [form-content (:flat-form-content db)
           section-ids-with-visibility-rules (->> form-content
                                                  (keep :section-visibility-conditions)
                                                  flatten
-                                                 (map :section-name)
-                                                 set)]
+                                                 (map :section-name))]
       (reduce
         (fn [acc-db section-id]
           (assoc-in acc-db [:application :ui (keyword section-id) :visible?] false))

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -790,14 +790,13 @@
       db
       distinct-form-sections)))
 
-(reg-event-fx
-  :application/set-application-text-field
-  (fn [{db :db} [_ field-descriptor value]]
+(reg-event-db
+  :application/handle-section-visibility-conditions
+  (fn [db [_ field-descriptor value]]
     (let [visibility-conditions (:section-visibility-conditions field-descriptor)]
-      {:db       (if (seq visibility-conditions)
-                   (hide-sections-based-on-conditions db value visibility-conditions)
-                   db)
-       :dispatch [:application/set-repeatable-application-field field-descriptor nil nil value]})))
+      (if (seq visibility-conditions)
+        (hide-sections-based-on-conditions db value visibility-conditions)
+        db))))
 
 (reg-event-fx
   :application/set-repeatable-application-field

--- a/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
@@ -2,7 +2,6 @@
   (:require [ataru.component-data.component :as component]
             [ataru.component-data.base-education-module :as base-education-module]
             [ataru.component-data.higher-education-base-education-module :as kk-base-education-module]
-            [ataru.feature-config :as fc]
             [re-frame.core :refer [dispatch subscribe]]
             [reagent.core :as r]
             [ataru.component-data.arvosanat-module :as arvosanat]))
@@ -117,8 +116,7 @@
 
 (defn add-component [path root-level-add-component?]
   (let [elements (cond-> (toolbar-elements)
-                         (and root-level-add-component?
-                              (fc/feature-enabled? :arvosanat))
+                         root-level-add-component?
                          (conj [:arvosanat-peruskoulu arvosanat/arvosanat-peruskoulu {:data-test-id "component-toolbar-arvosanat"}]
                                [:arvosanat-lukio arvosanat/arvosanat-lukio]))]
     [custom-add-component elements path

--- a/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
@@ -8,7 +8,7 @@
             [ataru.component-data.arvosanat-module :as arvosanat]))
 
 (defn- toolbar-elements []
-  [[:form-section component/form-section]
+  [[:form-section component/form-section {:data-test-id "component-toolbar-lomakeosio"}]
    [:single-choice-button component/single-choice-button]
    [:single-choice-button-koodisto (fn [metadata]
                                      (assoc (component/single-choice-button metadata)

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -104,10 +104,33 @@
           (update-in text-field-path into [component])
           (update-in (drop-last text-field-path) set-non-koodisto-option-values)))))
 
+(defn text-field-section-visibility-condition [section-name]
+  {:section-name section-name
+   :condition {:comparison-operator "<"}})
+
+(reg-event-db
+  :editor/lisää-tekstikentän-arvon-perusteella-osion-piilottamis-ehto
+  (fn [db [_ path]]
+    (let [text-field-path (current-form-content-path db [path :section-visibility-conditions])
+          hideable-form-sections @(subscribe [:editor/current-lomakeosiot])
+          default-hidden-section-name (-> hideable-form-sections first :id)
+          section-visibility (text-field-section-visibility-condition default-hidden-section-name)]
+      (-> db
+          (update-in text-field-path (fnil #(conj %1 %2) []) section-visibility)
+          (update-in (drop-last text-field-path) set-non-koodisto-option-values)))))
+
+(reg-event-db
+  :editor/lisää-tekstikentän-arvon-perusteella-piilotettavan-osion-nimi
+  (fn [db [_ path option-index value]]
+    (let [section-name-path (current-form-content-path db [path option-index :section-name])]
+      (assoc-in db
+                 section-name-path
+                 value))))
+
 (reg-event-db
   :editor/aseta-lisäkysymys-arvon-perusteella-operaattori
   (fn [db [_ path option-index value]]
-    (let [condition-path (current-form-content-path db [path :options option-index :condition])]
+    (let [condition-path (current-form-content-path db [path option-index :condition])]
       (update-in db
                  condition-path
                  (fn [condition]
@@ -116,7 +139,7 @@
 (reg-event-db
   :editor/aseta-lisäkysymys-arvon-perusteella-vertailuarvo
   (fn [db [_ path option-index value]]
-    (let [condition-path (current-form-content-path db [path :options option-index :condition])]
+    (let [condition-path (current-form-content-path db [path option-index :condition])]
       (update-in db
                  condition-path
                  (fn [condition]

--- a/src/cljs/ataru/virkailija/editor/subs.cljs
+++ b/src/cljs/ataru/virkailija/editor/subs.cljs
@@ -427,6 +427,12 @@
         :content)))
 
 (re-frame/reg-sub
+  :editor/current-lomakeosiot
+  (fn [db _]
+    (let [content (get-selected-form-content db)]
+      (filter #(= "wrapperElement" (:fieldClass %)) content))))
+
+(re-frame/reg-sub
   :editor/base-education-module-exists?
   (fn [db _]
     (let [content (get-selected-form-content db)]


### PR DESCRIPTION
https://jira.eduuni.fi/browse/HLE-1319

Hakulomakkeelle tullut tarve voida näyttää/piilottaa kokonainen osio jonkin tekstikentän ehdon mukaan. (Spesifi tapaus: arvosanaosiota ei tule näyttää jos suoritusvuosi-tekstikentän vastaus on yli 2018). 

Osion piilottaminen muistuttaa loogisesti `lisäkysymys tekstikentän arvon perusteella` -logiikkaa. Virkailija voi määritellä tekstikentälle "piilottamissääntöjä", jotka koskaevat lomakeosiota. Tekstikomponenttiin määrittyy ehdot uuteen tietorakenteen `:section-visibility-conditions [{:section-name str :condition {:comparison-operator '<|>|=' :answer-compared-to int}}]`, jossa section-name on piilotettavan osion id. Lomaketta täyttäessä, jos jokin ehdoista täyttyy, piilotetaan ehtoa vastaava lomakeosio näkyvistä. Jos tekstikenttä on tyhjänä, kaikki lomakeosiot, joille siihen on määritelty sääntöjä ovat oletuksena piilossa.

Ehto määritellään:
<img width="1014" alt="Screenshot 2021-06-15 at 10 47 04" src="https://user-images.githubusercontent.com/12379561/122013792-310c2e80-cdc7-11eb-96a5-5df9f43133a7.png">

Osio näkyy kun ehto ei täyty:
<img width="557" alt="Screenshot 2021-06-15 at 10 47 34" src="https://user-images.githubusercontent.com/12379561/122013810-35d0e280-cdc7-11eb-8669-049791dd5585.png">

Osio piilotetaan, kun ehto täyttyy:
<img width="663" alt="Screenshot 2021-06-15 at 10 47 46" src="https://user-images.githubusercontent.com/12379561/122013822-38333c80-cdc7-11eb-81ad-b53e75a2beaa.png">
