### PR TITLE
OY-4034 lisätty kontrastia 

### DIFF
--- a/resources/less/arvosanat-hakija.less
+++ b/resources/less/arvosanat-hakija.less
@@ -1,6 +1,7 @@
 @import "component-colors";
 @import "component-fonts";
 @import "component-layout";
+@import "vars";
 
 .arvosanat-taulukko {
   .default-font();
@@ -11,11 +12,11 @@
 }
 
 .arvosana__oppimaara:not(.arvosanat-taulukko__otsikko) {
-  color: @component-gray;
+  color: @gray_text_contrast;
 }
 
 .arvosana__arvosana:not(.arvosanat-taulukko__otsikko) {
-  color: @component-gray;
+  color: @gray_text_contrast;
 }
 
 .arvosana__lisaa-valinnaisaine--solu {
@@ -23,7 +24,7 @@
 }
 
 .arvosana__lisaa-valinnaisaine--ei-kaytossa {
-  color: @component-gray;
+  color: @gray_text_contrast;
 }
 
 .arvosana__lisaa-valinnaisaine--ikoni {
@@ -78,7 +79,7 @@
   }
 
   .oppiaineen-arvosana-rivi__oppiaine--valinnaisaine {
-    color: @component-gray;
+    color: @gray_text_contrast;
   }
 
   .arvosana__arvosana {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -438,11 +438,11 @@ body {
 
 .application__sub-header-dates {
   font-size: 16px;
-  color: @gray-of-the-beast;
+  color: @gray_text_contrast;
 }
 .application__sub-header-modifying-prevented {
   font-size: 14px;
-  color: @gray-of-the-beast;
+  color: @gray_text_contrast;
 }
 .application__header {
   font-size: 24px;
@@ -1634,7 +1634,7 @@ th.application__readonly-adjacent--header {
 }
 
 .application__hakukohde-max-selected {
-  color: @gray-of-the-beast;
+  color: @gray_text_contrast;
   font-style: italic;
 }
 
@@ -1965,7 +1965,7 @@ th.application__readonly-adjacent--header {
 }
 
 .application__question_hakukohde_names_container {
-  color: @grey;
+  color: @gray_text_contrast;
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 1;

--- a/resources/less/vars.less
+++ b/resources/less/vars.less
@@ -16,6 +16,7 @@
 @control-button-hover-blue: #00B5EF;
 @gray: @grey;
 @gray-of-the-beast: @grey;
+@gray_text_contrast: #595959;
 @very-light-gray: #FCFCFC;
 @warning-brownish-yellow: #F5A623;
 @section-gray-border: #CCCCCC;


### PR DESCRIPTION
Tyylimuutos, lisätty kontrastia saavutettavuusspeksien mukaiseksi arvosanataulukkoon sekä muutamaan muuhun tiketin kuvankaappauksissa näkyvään kohtaan missä on harmaata tekstiä valkoisella taustalla.