### PR TITLE
OY-4083 Remove attachment data properly

### DIFF
--- a/spec/ataru/hakija/application_validators_spec.clj
+++ b/spec/ataru/hakija/application_validators_spec.clj
@@ -8,12 +8,12 @@
             [ataru.fixtures.hakukohde :as hakukohde]
             [ataru.fixtures.numeric-input :refer [numbers integers value-between]]
             [ataru.hakija.application-validators :as validator]
-            [speclj.core :refer :all]
+            [speclj.core :refer [describe tags it should should-not should=]]
             [clojure.core.async :as async]))
 
 (defn- validate!
   ([validator value answers-by-key field-descriptor]
-   (validate! (fn [haku-oid identifier] (async/go false))
+   (validate! (fn [_ _] (async/go false))
               validator
               value
               answers-by-key
@@ -36,6 +36,18 @@
 
   (it "should not allow string with only whitespace"
     (should-not (validate! :required " " {} nil)))
+
+  (it "should not allow empty vector"
+    (should-not (validate! :required [] {} nil)))
+
+  (it "should not allow vector with empty string"
+    (should-not (validate! :required [""] {} nil)))
+
+  (it "should not allow vector with empty strings"
+    (should-not (validate! :required ["" ""] {} nil)))
+
+  (it "should allow vector with at least one non-empty string"
+    (should (validate! :required ["" "f"] {} nil)))
 
   (it "should allow string with at least one character"
     (should (validate! :required "a" {} nil))))

--- a/src/cljc/ataru/hakija/application_validators.cljc
+++ b/src/cljc/ataru/hakija/application_validators.cljc
@@ -18,7 +18,8 @@
   [{:keys [value]}]
   (if (string? value)
     (not (clojure.string/blank? value))
-    (not (empty? value))))
+    (not (or (empty? value)
+             (every? clojure.string/blank? value)))))
 
 (defn- required-valinnainen-oppimaara
   [params]

--- a/test/cljs/unit/ataru/hakija/application_validators_test.cljs
+++ b/test/cljs/unit/ataru/hakija/application_validators_test.cljs
@@ -12,6 +12,19 @@
 
 (defn- has-never-applied [_ _] (asyncm/go false))
 
+(deftest required-validation
+  (async done
+         (asyncm/go
+           (doseq [input ["" " " [] [""] ["" ""]]]
+             (is (false? (first (async/<! (validator/validate {:has-applied    has-never-applied
+                                                               :validator      "required"
+                                                               :value          input}))))))
+           (doseq [input ["f" ["f"] ["" "f"]]]
+             (is (true? (first (async/<! (validator/validate {:has-applied    has-never-applied
+                                                              :validator      "required"
+                                                              :value          input}))))))
+           (done))))
+
 (deftest ssn-validation
   (async done
          (asyncm/go


### PR DESCRIPTION
https://jira.eduuni.fi/browse/OY-4083

- Varmistutaan, että liite poistuu oikeasti values-taulukosta kun se poistetaan kälissä
- Corner case: liitteen poistaminen virhetilanteissa saattaa jättää kentän valueksi vektorin jossa on yksi tai useampi tyhjä stringi. Validaattori nappasi aiemmin vain tyhjät vektorit ja tyhjät stringit, nyt myös vektorin jossa sisällä vain tyhjiä stringejä
