### PR TITLE
OY-4123 Allow navigating and selecting grades with keyboard

### DIFF
--- a/resources/less/button-component.less
+++ b/resources/less/button-component.less
@@ -14,6 +14,9 @@
   padding: 0;
   user-select: none;
   white-space: nowrap;
+  &:focus-visible {
+    outline: auto;
+  }
 }
 
 .a-button > * {

--- a/resources/less/dropdown-component.less
+++ b/resources/less/dropdown-component.less
@@ -65,6 +65,10 @@
   position: relative;
   user-select: none;
   white-space: nowrap;
+
+  &:focus-visible {
+    outline: auto;
+  }
 }
 
 .a-dropdown-list-option__checked {

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -23,6 +23,9 @@ body {
         outline: initial;
         box-shadow: none;
       }
+      &:focus-visible {
+        outline: auto;
+      }
     }
   }
 }

--- a/src/cljs/ataru/application_common/components/dropdown_component.cljs
+++ b/src/cljs/ataru/application_common/components/dropdown_component.cljs
@@ -85,10 +85,16 @@
      {:id            option-id
       :on-click      (fn dropdown-list-option-on-click []
                        (on-click value))
+      :on-key-down   (fn [e]
+                       (when (or (= " " (.-key e))
+                                 (= "Enter" (.-key e)))
+                         (.preventDefault e)
+                         (on-click value)))
       :role          "option"
       :aria-selected (when selected?
                        true)
-      :data-test-id  data-test-id}
+      :data-test-id  data-test-id
+      :tab-index     "0"}
      (when selected?
        [:i.zmdi.zmdi-check.a-dropdown-list-option__checked])
      [:span label]]))
@@ -184,11 +190,12 @@
                                     {:aria-labelledby label-id
                                      :aria-expanded   expanded?}
                                     button-label]
-                                   (seq unselected-label-icon)
-                                   (conj [:<> unselected-label-icon]))
+                            (seq unselected-label-icon)
+                            (conj [:<> unselected-label-icon]))
             :on-click     on-dropdown-button-click
             :data-test-id (str data-test-id "-button")
-            :aria-attrs   {:aria-haspopup "listbox"}}]
+            :aria-attrs   {:aria-haspopup "listbox"}
+            :tab-index    "0"}]
           (when-not (seq unselected-label-icon)
             [dropdown-chevron
              {:expanded? expanded?}])]


### PR DESCRIPTION
Previously the user wasn't able to fill in the grade sheet only by using keyboard navigation. With this PR it's possible via tabbing + enter/space (including a focus indicator everywhere)