### PR TITLE
Oy 4171 huoltajien spostisoite-kenttään virheilmoitus väärän muotoisesta spostista

### DIFF
--- a/cypress/hakijanNakyma.ts
+++ b/cypress/hakijanNakyma.ts
@@ -175,6 +175,12 @@ export const henkilotiedot = {
   },
 }
 
+export const huoltajantiedot = {
+  huoltajanNimi: () => cy.get('[id$=guardian-name-0]'),
+  huoltajanPuhelin: () => cy.get('[id$=guardian-phone-0]'),
+  huoltajanSahkoposti: () => cy.get('[id$=guardian-email-0]'),
+}
+
 export const klikkaa = (elementinTeksti: string) =>
   cy.get(`label:contains(${elementinTeksti})`).click({ multiple: true })
 

--- a/cypress/integration/hakemuksenValidoinnitSpec.ts
+++ b/cypress/integration/hakemuksenValidoinnitSpec.ts
@@ -34,6 +34,9 @@ describe('Hakulomakkeen validoinnit', () => {
             .henkilotunnus()
             .invoke('attr', 'aria-invalid')
             .should('eq', 'true')
+          cy.contains('Henkilötunnus on oltava muodossa PPKKVVXNNNT.', {
+            matchCase: true,
+          }).should('exist')
         })
         it('Näyttää huoltajan yhteystietokentät kun täyttää alaikäisen hetun', () => {
           tekstinSyotto.syotaTeksti(

--- a/cypress/integration/hakemuksenValidoinnitSpec.ts
+++ b/cypress/integration/hakemuksenValidoinnitSpec.ts
@@ -1,0 +1,64 @@
+import kirjautuminenVirkailijanNakymaan from '../testit/kirjautuminenVirkailijanNakymaan'
+import lomakkeenLuonti from '../testit/lomakkeenLuonti'
+import hakijanNakymaanSiirtyminen from '../testit/hakijanNakymaanSiirtyminen'
+import * as lomakkeenMuokkaus from '../lomakkeenMuokkaus'
+import * as hakijanNakyma from '../hakijanNakyma'
+import * as tekstinSyotto from '../tekstinSyotto'
+
+describe('Hakulomakkeen validoinnit', () => {
+  kirjautuminenVirkailijanNakymaan('lomakkeen luomista varten', () => {
+    lomakkeenLuonti((lomakkeenTunnisteet) => {
+      it('Lisää huoltajan yhteystietomoduulin', () => {
+        lomakkeenMuokkaus.henkilotiedot.valitseHenkilotietolomakkeenKentat(
+          'Opiskelijavalinta, perusopetuksen jälkeinen yhteishaku',
+          lomakkeenTunnisteet().lomakkeenId
+        )
+        lomakkeenMuokkaus.komponentinLisays.lisaaElementti(
+          lomakkeenTunnisteet().lomakkeenId,
+          'Huoltajan yhteystiedot'
+        )
+      })
+      hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
+        it('Ei näytä huoltajan yhteystietokenttiä, kun lomakkeen avaa ensimmäistä kertaa', () => {
+          cy.contains('Huoltajan tiedot (jos olet alle 18v)', {
+            matchCase: true,
+          }).should('not.exist')
+        })
+        it('Tuottaa validointivirheen virheellisestä hetusta', () => {
+          hakijanNakyma.henkilotiedot.henkilotunnus().should('exist')
+          tekstinSyotto.syotaTeksti(
+            hakijanNakyma.henkilotiedot.henkilotunnus(),
+            'asd'
+          )
+          hakijanNakyma.henkilotiedot
+            .henkilotunnus()
+            .invoke('attr', 'aria-invalid')
+            .should('eq', 'true')
+        })
+        it('Näyttää huoltajan yhteystietokentät kun täyttää alaikäisen hetun', () => {
+          tekstinSyotto.syotaTeksti(
+            hakijanNakyma.henkilotiedot.henkilotunnus(),
+            '010123A968L' // tämä testihetu pysyy alaikäisenä hyvän aikaa!
+          )
+          cy.contains('Henkilötunnus on oltava muodossa PPKKVVXNNNT.', {
+            matchCase: true,
+          }).should('not.exist') // virheilmoitus poistuu
+          cy.contains('Huoltajan tiedot (jos olet alle 18v)', {
+            matchCase: true,
+          }).should('exist')
+          hakijanNakyma.huoltajantiedot.huoltajanSahkoposti().should('exist')
+        })
+        it('Näyttää virheilmoituksen kun huoltajan sähköposti on virheellinen', () => {
+          tekstinSyotto.syotaTeksti(
+            hakijanNakyma.huoltajantiedot.huoltajanSahkoposti(),
+            'asd'
+          )
+          hakijanNakyma.huoltajantiedot
+            .huoltajanSahkoposti()
+            .invoke('attr', 'aria-invalid')
+            .should('eq', 'true')
+        })
+      })
+    })
+  })
+})

--- a/cypress/integration/hakemuksenValidoinnitSpec.ts
+++ b/cypress/integration/hakemuksenValidoinnitSpec.ts
@@ -60,6 +60,12 @@ describe('Hakulomakkeen validoinnit', () => {
             .huoltajanSahkoposti()
             .invoke('attr', 'aria-invalid')
             .should('eq', 'true')
+          cy.contains(
+            'Sähköpostiosoitteesi on väärässä muodossa. Sähköpostiosoite on oltava muodossa nimi@osoite.fi.',
+            {
+              matchCase: true,
+            }
+          ).should('exist')
         })
       })
     })

--- a/src/cljc/ataru/hakija/application_validators.cljc
+++ b/src/cljc/ataru/hakija/application_validators.cljc
@@ -70,12 +70,12 @@
         modifying?     (some? original-value)]
     (async/go
       (cond (not (ssn/ssn? value))
-            [false [(texts/person-info-validation-error :ssn)]]
+            [false [{:ssn [(texts/person-info-validation-error :ssn)]}]]
             (and (not multiple?)
                  (not (and modifying? (= value original-value)))
                  (async/<! (has-applied haku-oid {:ssn value})))
-            [false [(texts/ssn-applied-error (when (:valid preferred-name)
-                                               (:value preferred-name)))]]
+            [false [{:ssn [(texts/ssn-applied-error (when (:valid preferred-name)
+                                               (:value preferred-name)))]}]]
             :else
             [true []]))))
 

--- a/src/cljc/ataru/hakija/application_validators.cljc
+++ b/src/cljc/ataru/hakija/application_validators.cljc
@@ -336,7 +336,7 @@
   (if-let [pure-validator ((keyword validator) pure-validators)]
     (let [valid? (pure-validator params)]
       (if valid? (async/go [valid? []])
-                 (async/go [valid? [(texts/person-info-validation-error (keyword validator))]])))
+                 (async/go [valid? [{(keyword validator) [(texts/person-info-validation-error (keyword validator))]}]])))
     (if-let [async-validator ((keyword validator) async-validators)]
       (async-validator params)
       (async/go [false []]))))

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -2647,10 +2647,15 @@
                            :en "The preferred name has to be on of your first/given names."}
    :past-date             {:fi "Syntymäajan on oltava muodossa pp.kk.vvvv."
                            :sv "Födelsetiden ska anges i formen dd.mm.åååå."
-                           :en "The date of birth has to be in the format dd.mm.yyyy."}})
+                           :en "The date of birth has to be in the format dd.mm.yyyy."}
+   :email-simple          {:fi "Huoltajan sähköpostiosoite on väärässä muodossa. Sähköpostiosoite on oltava muodossa nimi@osoite.fi."
+                           :sv "XXX e-postadress är i fel form. E-postadressen ska anges i formen namn@adress.fi."
+                           :en "XXX email address is in incorrect format. The email address has to be in the format name@address.com."}
+   })
 
 (defn person-info-validation-error [msg-key]
   (when (some? msg-key)
+    (print "PERSON INFO VALIDATION ERROR for key: " msg-key)
     (if-let [texts (get person-info-module-validation-error-texts msg-key)]
       {:fi [:div.application__person-info-validation-error-dialog {:class msg-key}
             [:p (:fi texts)]]

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -2648,14 +2648,13 @@
    :past-date             {:fi "Syntymäajan on oltava muodossa pp.kk.vvvv."
                            :sv "Födelsetiden ska anges i formen dd.mm.åååå."
                            :en "The date of birth has to be in the format dd.mm.yyyy."}
-   :email-simple          {:fi "Huoltajan sähköpostiosoite on väärässä muodossa. Sähköpostiosoite on oltava muodossa nimi@osoite.fi."
-                           :sv "XXX e-postadress är i fel form. E-postadressen ska anges i formen namn@adress.fi."
-                           :en "XXX email address is in incorrect format. The email address has to be in the format name@address.com."}
+   :email-simple          {:fi "Sähköpostiosoitteesi on väärässä muodossa. Sähköpostiosoite on oltava muodossa nimi@osoite.fi."
+                           :sv "Din e-postadress är i fel form. E-postadressen ska anges i formen namn@adress.fi."
+                           :en "Your email address is in incorrect format. The email address has to be in the format name@address.com."}
    })
 
 (defn person-info-validation-error [msg-key]
   (when (some? msg-key)
-    (print "PERSON INFO VALIDATION ERROR for key: " msg-key)
     (if-let [texts (get person-info-module-validation-error-texts msg-key)]
       {:fi [:div.application__person-info-validation-error-dialog {:class msg-key}
             [:p (:fi texts)]]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -58,6 +58,8 @@
 (defn- validation-error
   [errors]
   (let [languages @(subscribe [:application/default-languages])]
+    (print "ERRORS")
+    (print errors)
     (when (not-empty (filter #(some? %) errors))
       [:div.application__validation-error-dialog-container
        (doall
@@ -704,9 +706,13 @@
 (defn- adjacent-field-input [{:keys [field-descriptor]}]
   (let [id          (keyword (:id field-descriptor))
         local-state (r/atom {:focused? false :value nil})]
+    (print "adjacent field input")
+    (print id)
     (fn [{:keys [field-descriptor labelledby question-group-idx row-idx]}]
       (let [{:keys [value
-                    valid]} @(subscribe [:application/answer id question-group-idx row-idx])
+                    valid
+                    errors]} @(subscribe [:application/answer id question-group-idx row-idx])
+            answer          @(subscribe [:application/answer id question-group-idx row-idx])
             cannot-edit?    @(subscribe [:application/cannot-edit? id])
             show-error?     @(subscribe [:application/show-validation-error-class? id question-group-idx row-idx nil])
             on-blur         (fn [_]
@@ -722,6 +728,8 @@
                                            question-group-idx
                                            row-idx
                                            value])))]
+        (print "ANSWER: " answer)
+        (print "subscribettu errors: " errors)
         [:input.application__form-text-input
          {:class           (if show-error?
                              " application__form-field-error"

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -295,7 +295,7 @@
          [validation-error (some-> errors
                                    first
                                    vals
-                                   first)] ;toistaiseksi tiedetään että on vain yksi virhe per kenttä
+                                   first)] ;tiedetään että toistaiseksi on vain yksi virhe per kenttä
          (when (not (or (string/blank? value)
                         show-error?))
            [text-field-followups-container field-descriptor options value idx])]))))

--- a/src/cljs/ataru/hakija/subs.cljs
+++ b/src/cljs/ataru/hakija/subs.cljs
@@ -733,8 +733,12 @@
      (re-frame/subscribe [:application/validator-processing? id])])
   (fn [[field {:keys [value valid]} validator-processing?] _]
     (and (not valid)
-         (or (afc/is-required-field? field)
-             (-> field :params :numeric))
+         (or (afc/is-required-field? field) ;pakollinen kenttä
+             (-> field :params :numeric) ;numeerisuusvalidointi
+             (contains? #{"email-optional" "email-simple"} ;ei-pakollisen sähköpostikentän validointi
+                        (some-> field
+                                :validators
+                                first)))
          (if (string? value)
            (not (cstr/blank? value))
            (not (empty? value)))


### PR DESCRIPTION
Huoltajien spostisoite-kentissä näkyy nyt virheilmoitus ja väärän muotoisesta osoitteesta, ja kenttä menee punaiseksi.  Korjattu virhetyylin puuttuminen myös ei-pakollisessa hakijan sähköpostikentässä (2. asteen yhteishaun lomake)
Cypress-testipohja hakulomakkeen validoinneille.
 