### PR TITLE
OY-4179 Fix Voiceover focus / reading order after submitting application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.log*
 .clj-kondo/.cache
 .java
 .java-version
+.lsp/

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -2105,6 +2105,7 @@ th.application__readonly-adjacent--header {
 .application__submitted-submit-notification-inner {
   display: flex;
   justify-content: center;
+  padding: 25px;
 }
 
 .application__submitted-submit-payment-inner {

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -11,7 +11,8 @@
             [goog.string :as gstring]
             [reagent.ratom :refer [reaction]]
             [reagent.core :as r]
-            [ataru.util :as util]))
+            [ataru.util :as util]
+            [clojure.string :as string]))
 
 (def ^:private language-names
   {:fi "Suomeksi"
@@ -137,22 +138,32 @@
 (defn- submit-notification
   [hidden? demo?]
   (fn []
-    (let [lang @(subscribe [:application/form-language])]
+    (let [lang @(subscribe [:application/form-language])
+          answers @(subscribe [:state-query [:application :answers]])]
       [:div.application__submitted-submit-notification
        {:role "alertdialog"
-        :aria-modal "true"}
+        :aria-modal "true"
+        :aria-labelledby "submitted-submit-notification-heading submitted-submit-notification-confirmation"}
        [:div.application__submitted-submit-notification-inner
-         {:role "alert"
-          :aria-live "assertive"}
         [:h1.application__submitted-submit-notification-heading
+         {:id "submitted-submit-notification-heading"}
          (translations/get-hakija-translation
-           (if @demo? :application-submitted-demo :application-submitted)
-           lang)]]
+          (if @demo? :application-submitted-demo :application-submitted)
+          lang)]]
+       (when (-> answers
+                 (get-in [:email :value])
+                 (string/blank?)
+                 not)
+         [:div.application__submitted-submit-notification-heading
+          {:id "submitted-submit-notification-confirmation"
+           :role "text"}
+          (translations/get-hakija-translation :application-confirmation lang)])
        [:div.application__submitted-submit-notification-inner
         [:button.application__overlay-button.application__overlay-button--enabled
          {:tab-index    "1"
           :on-click     #(reset! hidden? true)
-          :data-test-id "send-feedback-button"}
+          :data-test-id "send-feedback-button"
+          :autofocus ""}
          (translations/get-hakija-translation :application-submitted-ok lang)]]])))
 
 (defn- submit-notification-payment
@@ -161,7 +172,7 @@
     (let [lang @(subscribe [:application/form-language])]
       [:div.application__submitted-submit-payment
        [:div.application__submitted-submit-payment-inner
-        {:role "alertdialog"
+        {:role "dialog"
          :aria-modal "true"}
         [:div.application__submitted-submit-payment-icon
           [icons/icon-check]]
@@ -195,17 +206,21 @@
             submitted? (= :feedback-submitted @rating-status)]
         (when (and @show-feedback? (nil? @virkailija-secret))
           [:div.application-feedback-form
-           {:role "alertdialog"
-            :aria-modal "true"}
+           {:role "dialog"
+            :aria-modal "true"
+            :aria-labelledby "application-feedback-form__header"}
            [:button.a-button.application-feedback-form__close-button
             {:on-click     #(dispatch [:application/rating-form-toggle])
              :data-test-id "close-feedback-form-button"
-             :tab-index    "0"
              :aria-label   (get (:close general-texts) @lang)}
             [:i.zmdi.zmdi-close.close-details-button-mark]]
            [:div.application-feedback-form-container
             (when (not submitted?)
-              [:h2.application-feedback-form__header (translations/get-hakija-translation :feedback-header @lang)])
+              {:aria-live "polite"})
+            (when (not submitted?)
+              [:h2.application-feedback-form__header
+               {:id "application-feedback-form__header"}
+               (translations/get-hakija-translation :feedback-header @lang)])
             (when (not submitted?)
               [:div.application-feedback-form__rating-container.animated.zoomIn
                {:on-click      #(dispatch [:application/rating-submit (star-number-from-event %)])
@@ -276,7 +291,6 @@
         demo?                       (subscribe [:application/demo?])]
     (fn []
       [:div.application__submitted-overlay-wrapper
-       {:aria-live "assertive"}
        (when (and (= :submitted @submit-status)
                   (or (not @feedback-hidden?)
                       (not @submit-notification-hidden?)))

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -142,13 +142,16 @@
        {:role "alertdialog"
         :aria-modal "true"}
        [:div.application__submitted-submit-notification-inner
+         {:role "alert"
+          :aria-live "assertive"}
         [:h1.application__submitted-submit-notification-heading
          (translations/get-hakija-translation
            (if @demo? :application-submitted-demo :application-submitted)
            lang)]]
        [:div.application__submitted-submit-notification-inner
         [:button.application__overlay-button.application__overlay-button--enabled
-         {:on-click     #(reset! hidden? true)
+         {:tab-index    "1"
+          :on-click     #(reset! hidden? true)
           :data-test-id "send-feedback-button"}
          (translations/get-hakija-translation :application-submitted-ok lang)]]])))
 

--- a/src/cljs/ataru/hakija/banner.cljs
+++ b/src/cljs/ataru/hakija/banner.cljs
@@ -58,14 +58,14 @@
              [:submitted (_ :guard #(nil? %))]
              (if @demo?
                [:div.application__sent-indicator.animated.fadeIn
-                {:role "alert"}
+                {:role "text"}
                 (translations/get-hakija-translation :application-confirmation-demo @lang)]
                (when (-> @answers
                          (get-in [:email :value])
                          (string/blank?)
                          not)
                  [:div.application__sent-indicator.animated.fadeIn
-                  {:role "alert"}
+                  {:role "text"}
                   (translations/get-hakija-translation :application-confirmation @lang)]))
 
              :else nil))))


### PR DESCRIPTION
After submitting application, Voiceover did not always read the submit confirmation, nor the request for feedback. Try to instruct it to do so here.

Unfortunately this ended up being a bit of a cargo cult programming type solution, as it's quite hard to make real sense of the focus / reading order at this point in the application flow. However, this seems to solve the reported problem, a least based on repeated manual tests.