### PR TITLE
OY-4221 Do not treat underscores in full URLs in e-mail content as Markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ npm-debug.log*
 .clj-kondo/.cache
 .java
 .java-version
+.lsp/

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ lein with-profile test spec <PATH_TO_TEST_FILE>
 e.g.
 
 ```
-lein with-profile test spec spec/ataru/applications/suoritus_filter_spec.clj
+lein with-profile test spec spec/ataru/applications/answer_util_spec.clj
 ```
 
 ### ClojureScript unit tests

--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ make start-docker test-clojure
 #### Single backend unit test
 
 ```
-lein spec <PATH_TO_TEST_FILE>
+lein with-profile test spec <PATH_TO_TEST_FILE>
 ```
 
 e.g.
 
 ```
-lein spec spec/ataru/applications/suoritus_filter_spec.clj
+lein with-profile test spec spec/ataru/applications/suoritus_filter_spec.clj
 ```
 
 ### ClojureScript unit tests

--- a/spec/ataru/email/application_email_spec.clj
+++ b/spec/ataru/email/application_email_spec.clj
@@ -53,8 +53,8 @@
         (should= true (str/includes? body "Lähetä liite osoitteeseen: Hiuskatu 2, 00500 HELSINKI"))
         (should= true (str/includes? body "Palautettava viimeistään 31.1.2022 klo 12:00"))
         (should= true (str/includes? body "Palautettava viimeistään 30.5.2022 klo 13:05"))
-        (should= true (str/includes? body "Tai käytä: <a href='https://hampaat-liitteena.fi'>https://hampaat-liitteena.fi</a>"))
-      ))
+        (should= true (str/includes? body "Tai käytä: <a href=\"https://elintie-liite.fi\" target=\"_blank\" style=\"color: #0093C4;\" rel=\"noopener noreferrer\">https://elintie-liite.fi</a>"))
+        ))
 
   (it "creates email with payment-url"
       (let [template-name-fn (constantly "templates/email_submit_confirmation_template_fi.html")
@@ -120,4 +120,24 @@
           body    (:body email)]
       (should= (str (:fi email/edit-email-subjects) " (Hakemusnumero: " (:key fixtures/application) ")") (:subject email))
       (should= false (str/includes? body "Upload liite"))
-      (should= true (str/includes? body "Perinteinen liitepyyntö")))))
+      (should= true (str/includes? body "Perinteinen liitepyyntö"))))
+
+  (it "creates email without transforming link text using markdown"
+      (let [template-name-fn (constantly "templates/email_submit_confirmation_template_fi.html")
+            application-attachment-reviews []
+            get-attachment-type (fn [attachment-type] {:fi attachment-type
+                                                       :sv attachment-type
+                                                       :en attachment-type})
+            [email] (email/create-emails email/edit-email-subjects
+                                         template-name-fn
+                                         fixtures/application
+                                         fixtures/tarjonta-info
+                                         fixtures/form
+                                         application-attachment-reviews
+                                         fixtures/email-template
+                                         get-attachment-type
+                                         false
+                                         nil)
+            body    (:body email)]
+        (should= (str (:fi email/edit-email-subjects) " (Hakemusnumero: " (:key fixtures/application) ")") (:subject email))
+        (should= true (str/includes? body "Tai käytä: <a href=\"https://kauniit_puhtaat_hampaat-liitteena.fi\" target=\"_blank\" style=\"color: #0093C4;\" rel=\"noopener noreferrer\">https://kauniit_puhtaat_hampaat-liitteena.fi</a>")))))

--- a/spec/ataru/email/email_fixtures.clj
+++ b/spec/ataru/email/email_fixtures.clj
@@ -411,7 +411,7 @@
                                                                                                                             {:osoite     {:fi "Hammasportti 500", :sv "Hammasportti 500 (SV)"},
                                                                                                                              :postinumero
                                                                                                                                          {:koodiUri "posti_01600#2", :nimi {:sv "VANDA", :fi "VANTAA"}},
-                                                                                                                             :verkkosivu "https://hampaat-liitteena.fi"}}],
+                                                                                                                             :verkkosivu "https://kauniit_puhtaat_hampaat-liitteena.fi"}}],
                                        :liitteiden-toimitusosoite                                   nil,
                                        :liitteiden-toimitusaika                                     nil,
                                        :tarjoaja-name

--- a/src/clj/ataru/email/application_email.clj
+++ b/src/clj/ataru/email/application_email.clj
@@ -70,9 +70,23 @@
       (get-in [:public-config :applicant :service_url])
       (str "/hakemus?modify=" secret)))
 
+(defn- escape-full-urls
+  [content]
+  (let [full-urls (re-seq #"\w+:\/\/\S*" content)]
+    (reduce
+      #(string/replace-first %1 %2 (string/escape %2 {\_ "\\_"}))
+      content
+      full-urls)))
+
+(defn- markdown->html
+  [content]
+  (-> content
+      (escape-full-urls)
+      (md/md-to-html-string)))
+
 (defn ->safe-html
   [content]
-  (.sanitize html-policy (md/md-to-html-string content)))
+  (.sanitize html-policy (markdown->html content)))
 
 (defn- hakukohde-names [tarjonta-info lang application]
   (when (:haku application)
@@ -148,7 +162,7 @@
         attachment-type      (get-in field [:params :attachment-type])
         attachment-type-text (util/from-multi-lang (get-attachment-type attachment-type) lang)
         attachment           (liitteet/attachment-for-hakukohde attachment-type hakukohde)
-        address              (md/md-to-html-string (liitteet/attachment-address-with-hakukohde lang attachment hakukohde))
+        address              (->safe-html (liitteet/attachment-address-with-hakukohde lang attachment hakukohde))
         default-deadline     (-> field :params :deadline-label (get lang))
         deadline             (or (liitteet/attachment-deadline lang attachment hakukohde) default-deadline)
         info-text            (-> field :params :info-text :value (get lang))]


### PR DESCRIPTION
Previously, if URLs in sent e-mails had pairs of underscores, they could be treated as Markdown, and vanish due to Markdown conversion and the following HTML sanitization.

After this change, the underscores in matched URL-like strings are escaped and not considered as Markdown control characters. The matching should be "good enough" for the purpose.

The attachment address URLs in e-mails also now undergo the same HTML styling and sanitization as the rest of the links.