### PR TITLE
Oy 4223 lomakesiivous-jobin korjaus ja häläri failanneesta jobista

### DIFF
--- a/config/dev.edn
+++ b/config/dev.edn
@@ -43,6 +43,7 @@
                    :tutu-payment-form-keys              ""
                    :attachment-file-max-size-bytes      10485760
                    :attachment-file-part-max-size-bytes 5242880
+                   :job-failure-alert-recipients        "testi@example.org"
                    :features {:schema-validation true}}
  :temp-files      {:filesystem {:base-path "/tmp"}}
  :dev             {:fake-dependencies true}

--- a/config/test.edn
+++ b/config/test.edn
@@ -43,6 +43,7 @@
                    :tutu-payment-form-keys              ""
                    :attachment-file-max-size-bytes      10485760
                    :attachment-file-part-max-size-bytes 5242880
+                   :job-failure-alert-recipients        "testi@example.org"
                    :features {:schema-validation true}}
  :temp-files      {:filesystem {:base-path "/tmp"}}
  :dev             {:fake-dependencies true}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -49,7 +49,8 @@
                  :attachment-modify-grace-period-days 14
                  :attachment-file-max-size-bytes {{ataru_attachment_file_max_size_bytes}}
                  :attachment-file-part-max-size-bytes {{ataru_attachment_file_part_max_size_bytes}}
-                 :attachment-preview-pages-to-display {{liiteri_attachment_preview_pages_to_display}}}
+                 :attachment-preview-pages-to-display {{liiteri_attachment_preview_pages_to_display}}
+                 :job-failure-alert-recipients {{ataru_job_failure_alert_recipients}}}
  :cas {:username "{{ataru_cas_username}}"
        :password "{{ataru_cas_password}}"}
  :log {:virkailija-base-path "{{ataru_virkailija_log_path}}"

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -50,7 +50,7 @@
                  :attachment-file-max-size-bytes {{ataru_attachment_file_max_size_bytes}}
                  :attachment-file-part-max-size-bytes {{ataru_attachment_file_part_max_size_bytes}}
                  :attachment-preview-pages-to-display {{liiteri_attachment_preview_pages_to_display}}
-                 :job-failure-alert-recipients {{ataru_job_failure_alert_recipients}}}
+                 :job-failure-alert-recipients "{{ataru_job_failure_alert_recipients}}"}
  :cas {:username "{{ataru_cas_username}}"
        :password "{{ataru_cas_password}}"}
  :log {:virkailija-base-path "{{ataru_virkailija_log_path}}"

--- a/resources/sql/form-cleanup-queries.sql
+++ b/resources/sql/form-cleanup-queries.sql
@@ -1,7 +1,8 @@
 -- name: yesql-clean-up-old-forms!
-DELETE FROM forms WHERE id IN (SELECT id FROM forms f
-                               WHERE created_time < (NOW() - interval '1 month')
-                                 AND f.id NOT IN (SELECT form_id FROM applications)
+DELETE FROM forms WHERE id IN (SELECT f.id FROM forms f
+                                LEFT JOIN applications a ON a.form_id=f.id
+                               WHERE a.form_id is null
+                                 AND f.created_time < (NOW() - interval '1 month')
                                  AND f.id NOT IN (SELECT form_id FROM application_feedback)
                                  AND f.id NOT IN (SELECT id FROM forms f2 WHERE f2.key = f.key ORDER BY f2.id DESC LIMIT 5)
                                LIMIT :limit);

--- a/resources/sql/form-cleanup-queries.sql
+++ b/resources/sql/form-cleanup-queries.sql
@@ -2,5 +2,6 @@
 DELETE FROM forms WHERE id IN (SELECT id FROM forms f
                                WHERE created_time < (NOW() - interval '1 month')
                                  AND f.id NOT IN (SELECT form_id FROM applications)
+                                 AND f.id NOT IN (SELECT form_id FROM application_feedback)
                                  AND f.id NOT IN (SELECT id FROM forms f2 WHERE f2.key = f.key ORDER BY f2.id DESC LIMIT 5)
                                LIMIT :limit);

--- a/resources/templates/email_background_job_failed.html
+++ b/resources/templates/email_background_job_failed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title></title>
+</head>
+<body style="margin: 0; font-family: 'Open Sans', Arial, sans-serif;">
+<table style="width: 600px;">
+    <tr>
+        <td style="padding-left: 20px; padding-top: 20px;">
+            Tausta-ajo epäonnistui uudelleenyritysten jälkeen.
+        </td>
+    </tr>
+    <tr>
+        <td style="padding-left: 20px; padding-top: 20px;">
+            Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/resources/templates/email_background_job_failed.html
+++ b/resources/templates/email_background_job_failed.html
@@ -4,15 +4,15 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title></title>
 </head>
-<body style="margin: 0; font-family: 'Open Sans', Arial, sans-serif;">
+<body style="margin-left: 20px; font-family: 'Open Sans', Arial, sans-serif;">
 <p>Tausta-ajo epäonnistui uudelleenyritysten jälkeen.</p>
 <p>Job:</p>
-<pre><code>
-    {{job}}
-</code></pre>
+<pre>
+    <code>{{job}}</code>
+</pre>
 <p>Virhe:</p>
-<pre><code>
-    {{error}}
-</code></pre>
+<pre>
+    <code>{{error}}</code>
+</pre>
 </body>
 </html>

--- a/resources/templates/email_background_job_failed.html
+++ b/resources/templates/email_background_job_failed.html
@@ -5,17 +5,14 @@
     <title></title>
 </head>
 <body style="margin: 0; font-family: 'Open Sans', Arial, sans-serif;">
-<table style="width: 600px;">
-    <tr>
-        <td style="padding-left: 20px; padding-top: 20px;">
-            Tausta-ajo epäonnistui uudelleenyritysten jälkeen.
-        </td>
-    </tr>
-    <tr>
-        <td style="padding-left: 20px; padding-top: 20px;">
-            Älä vastaa tähän viestiin - viesti on lähetetty automaattisesti.
-        </td>
-    </tr>
-</table>
+<p>Tausta-ajo epäonnistui uudelleenyritysten jälkeen.</p>
+<p>Job:</p>
+<pre><code>
+    {{job}}
+</code></pre>
+<p>Virhe:</p>
+<pre><code>
+    {{error}}
+</code></pre>
 </body>
 </html>

--- a/spec/ataru/background_job/job_execution_spec.clj
+++ b/spec/ataru/background_job/job_execution_spec.clj
@@ -1,136 +1,141 @@
-;(ns ataru.background-job.job-execution-spec
-;  (:require
-;   [clj-time.core :as time]
-;   [speclj.core :refer [tags describe it should=]]
-;   [ataru.background-job.job-execution :as job-exec]))
-;
-;;; mocked time for test execution
-;(defn fixed-now [] (time/date-time 2016 10 10))
-;
-;(def
-;  job1
-;  (letfn [(call-fakeservice [service]
-;            (swap! service assoc :call-count (inc (:call-count @service)))
-;            (if (> (:call-count @service) 1)
-;              true
-;              false))
-;
-;          (initial [state context]
-;            {:transition {:id    :to-next
-;                          :step  :fake-remote-call}
-;             :updated-state (assoc state :initialized true)})
-;
-;          (fake-remote-call [state context]
-;            (let [fake-service (:fake-service context)
-;                  service-call-result (call-fakeservice fake-service)]
-;              (if-not service-call-result
-;                {:transition {:id :retry} :updated-state (assoc state :damn (inc (:damn state)))}
-;                {:transition {:id :final}})))]
-;
-;    {:steps {:initial initial
-;             :fake-remote-call fake-remote-call}
-;     :type "job1"}))
-;
-;(def expected-job1-iterations [{:step
-;                                :fake-remote-call,
-;                                :transition :to-next,
-;                                :final false,
-;                                :retry-count 0,
-;                                :next-activation (fixed-now),
-;                                :state {:damn 0, :initialized true},
-;                                :caused-by-error nil}
-;                               {:step
-;                                :fake-remote-call,
-;                                :transition :retry,
-;                                :final false,
-;                                :retry-count 1,
-;                                :next-activation (time/plus (fixed-now) (time/minutes 1)),
-;                                :state {:damn 1, :initialized true},
-;                                :caused-by-error nil}
-;                               {:step :fake-remote-call,
-;                                :transition :final,
-;                                :final true,
-;                                :retry-count 0,
-;                                :next-activation nil,
-;                                :state {:damn 1, :initialized true},
-;                                :caused-by-error nil}])
-;
-;(def
-;  fatally-failing-job
-;  (letfn [(fatally-flawed-step [state context]
-;            (throw (Error. "INSTANT FATAL ISSUE")))]
-;
-;    {:steps {:initial fatally-flawed-step}
-;     :type "fatally-failing-job"}))
-;
-;(def
-;  always-exception-throwing-job
-;  (letfn [(initial [state context]
-;            {:transition {:id  :to-next
-;                          :step  :throwing}})
-;            (throwing-step [state context]
-;                           (throw (Exception. "This exception is normal on test-run! This should happen, so don't be alarmed by it when you see it on test-runs.")))]
-;
-;    {:steps {:initial initial
-;             :throwing throwing-step}
-;     :type "always-exception-throwing-job"}))
-;
-;(def job-definitions {(:type job1) job1
-;                      (:type fatally-failing-job) fatally-failing-job
-;                      (:type always-exception-throwing-job) always-exception-throwing-job})
-;
-;(def default-start-iteration {:state {} :step :initial :retry-count 0 :iteration-id 1})
-;
-;(defn exec-all-iterations [runner job]
-;  (loop [iteration (:iteration job)
-;         result-iterations []]
-;    (let [result-iteration (job-exec/exec-job-step runner (assoc job :iteration iteration))
-;          new-results (conj result-iterations result-iteration)]
-;      (if (:final result-iteration)
-;        new-results
-;        (recur result-iteration new-results)))))
-;
-;(describe
-; "job execution"
-; (tags :unit)
-; (it "exec-job-step runs steps from job with manual retry and produces correct steps up until final iteration"
-;     (with-redefs [time/now fixed-now]
-;       (let [runner            {:job-definitions job-definitions
-;                                :fake-service    (atom {:call-count  0})}
-;             job               {:job-type "job1"
-;                                :job-id 1
-;                                :iteration {:state {:damn 0}
-;                                            :step :initial
-;                                            :retry-count 0}}
-;             result-iterations (exec-all-iterations runner job)]
-;         (should= expected-job1-iterations
-;                  result-iterations))))
-; (it "exec-job-step immediately produces final transition with error description"
-;     (let [runner           {:job-definitions job-definitions}
-;           job              {:job-type "fatally-failing-job"
-;                             :job-id 2
-;                             :iteration default-start-iteration}
-;           result-iterations (exec-all-iterations runner job)]
-;       (should= [{:step :initial,
-;                  :state {},
-;                  :final true,
-;                  :retry-count 0,
-;                  :next-activation nil,
-;                  :transition :fail,
-;                  :caused-by-error "Error occurred while executing step :initial: java.lang.Error: INSTANT FATAL ISSUE"}]
-;                result-iterations)))
-; (it "exec-job-step retries the maximum amount when an ordinary exception is thrown from the same step"
-;     (let [runner          {:job-definitions job-definitions}
-;           job             {:job-type "always-exception-throwing-job"
-;                            :job-id 3
-;                            :iteration default-start-iteration}
-;           result-iterations (exec-all-iterations runner job)
-;           last-iteration    (last result-iterations)]
-;       (should= 102 ;; Limit is 100, it goes one over and the other 1 is the initial step's transition
-;                (count result-iterations))
-;       (should= {:final true,
-;                 :retry-count 101,
-;                 :next-activation nil,
-;                 :transition :fail,
-;                 :caused-by-error "Retry limit exceeded for step :throwing in job always-exception-throwing-job"}
-;                (select-keys last-iteration [:final :retry-count :next-activation :transition :caused-by-error])))))
+(ns ataru.background-job.job-execution-spec
+  (:require
+   [clj-time.core :as time]
+   [speclj.core :refer [around tags describe it should=]]
+   [ataru.background-job.email-job :as email-job]
+   [ataru.background-job.job-execution :as job-exec]))
+
+;; mocked time for test execution
+(defn fixed-now [] (time/date-time 2016 10 10))
+
+(def
+  job1
+  (letfn [(call-fakeservice [service]
+            (swap! service assoc :call-count (inc (:call-count @service)))
+            (if (> (:call-count @service) 1)
+              true
+              false))
+
+          (initial [state context]
+            {:transition {:id    :to-next
+                          :step  :fake-remote-call}
+             :updated-state (assoc state :initialized true)})
+
+          (fake-remote-call [state context]
+            (let [fake-service (:fake-service context)
+                  service-call-result (call-fakeservice fake-service)]
+              (if-not service-call-result
+                {:transition {:id :retry} :updated-state (assoc state :damn (inc (:damn state)))}
+                {:transition {:id :final}})))]
+
+    {:steps {:initial initial
+             :fake-remote-call fake-remote-call}
+     :type "job1"}))
+
+(def expected-job1-iterations [{:step
+                                :fake-remote-call,
+                                :transition :to-next,
+                                :final false,
+                                :retry-count 0,
+                                :next-activation (fixed-now),
+                                :state {:damn 0, :initialized true},
+                                :caused-by-error nil}
+                               {:step
+                                :fake-remote-call,
+                                :transition :retry,
+                                :final false,
+                                :retry-count 1,
+                                :next-activation (time/plus (fixed-now) (time/minutes 1)),
+                                :state {:damn 1, :initialized true},
+                                :caused-by-error nil}
+                               {:step :fake-remote-call,
+                                :transition :final,
+                                :final true,
+                                :retry-count 0,
+                                :next-activation nil,
+                                :state {:damn 1, :initialized true},
+                                :caused-by-error nil}])
+
+(def
+  fatally-failing-job
+  (letfn [(fatally-flawed-step [state context]
+            (throw (Error. "INSTANT FATAL ISSUE")))]
+
+    {:steps {:initial fatally-flawed-step}
+     :type "fatally-failing-job"}))
+
+(def
+  always-exception-throwing-job
+  (letfn [(initial [state context]
+            {:transition {:id  :to-next
+                          :step  :throwing}})
+            (throwing-step [state context]
+                           (throw (Exception. "This exception is normal on test-run! This should happen, so don't be alarmed by it when you see it on test-runs.")))]
+
+    {:steps {:initial initial
+             :throwing throwing-step}
+     :type "always-exception-throwing-job"}))
+
+(def job-definitions {(:type job1) job1
+                      (:type fatally-failing-job) fatally-failing-job
+                      (:type always-exception-throwing-job) always-exception-throwing-job})
+
+(def default-start-iteration {:state {} :step :initial :retry-count 0 :iteration-id 1})
+
+(defn exec-all-iterations [runner job]
+  (loop [iteration (:iteration job)
+         result-iterations []]
+    (let [result-iteration (job-exec/exec-job-step runner (assoc job :iteration iteration))
+          new-results (conj result-iterations result-iteration)]
+      (if (:final result-iteration)
+        new-results
+        (recur result-iteration new-results)))))
+
+(describe
+ "job execution"
+ (tags :unit)
+
+ (around [spec]
+         (with-redefs [email-job/send-email (constantly nil)]
+           (spec)))
+ (it "exec-job-step runs steps from job with manual retry and produces correct steps up until final iteration"
+     (with-redefs [time/now fixed-now]
+       (let [runner            {:job-definitions job-definitions
+                                :fake-service    (atom {:call-count  0})}
+             job               {:job-type "job1"
+                                :job-id 1
+                                :iteration {:state {:damn 0}
+                                            :step :initial
+                                            :retry-count 0}}
+             result-iterations (exec-all-iterations runner job)]
+         (should= expected-job1-iterations
+                  result-iterations))))
+ (it "exec-job-step immediately produces final transition with error description"
+     (let [runner           {:job-definitions job-definitions}
+           job              {:job-type "fatally-failing-job"
+                             :job-id 2
+                             :iteration default-start-iteration}
+           result-iterations (exec-all-iterations runner job)]
+       (should= [{:step :initial,
+                  :state {},
+                  :final true,
+                  :retry-count 0,
+                  :next-activation nil,
+                  :transition :fail,
+                  :caused-by-error "Error occurred while executing step :initial: java.lang.Error: INSTANT FATAL ISSUE"}]
+                result-iterations)))
+ (it "exec-job-step retries the maximum amount when an ordinary exception is thrown from the same step"
+     (let [runner          {:job-definitions job-definitions}
+           job             {:job-type "always-exception-throwing-job"
+                            :job-id 3
+                            :iteration default-start-iteration}
+           result-iterations (exec-all-iterations runner job)
+           last-iteration    (last result-iterations)]
+       (should= 102 ;; Limit is 100, it goes one over and the other 1 is the initial step's transition
+                (count result-iterations))
+       (should= {:final true,
+                 :retry-count 101,
+                 :next-activation nil,
+                 :transition :fail,
+                 :caused-by-error "Retry limit exceeded for step :throwing in job always-exception-throwing-job"}
+                (select-keys last-iteration [:final :retry-count :next-activation :transition :caused-by-error])))))

--- a/spec/ataru/background_job/job_execution_spec.clj
+++ b/spec/ataru/background_job/job_execution_spec.clj
@@ -1,136 +1,136 @@
-(ns ataru.background-job.job-execution-spec
-  (:require
-   [clj-time.core :as time]
-   [speclj.core :refer [tags describe it should=]]
-   [ataru.background-job.job-execution :as job-exec]))
-
-;; mocked time for test execution
-(defn fixed-now [] (time/date-time 2016 10 10))
-
-(def
-  job1
-  (letfn [(call-fakeservice [service]
-            (swap! service assoc :call-count (inc (:call-count @service)))
-            (if (> (:call-count @service) 1)
-              true
-              false))
-
-          (initial [state context]
-            {:transition {:id    :to-next
-                          :step  :fake-remote-call}
-             :updated-state (assoc state :initialized true)})
-
-          (fake-remote-call [state context]
-            (let [fake-service (:fake-service context)
-                  service-call-result (call-fakeservice fake-service)]
-              (if-not service-call-result
-                {:transition {:id :retry} :updated-state (assoc state :damn (inc (:damn state)))}
-                {:transition {:id :final}})))]
-
-    {:steps {:initial initial
-             :fake-remote-call fake-remote-call}
-     :type "job1"}))
-
-(def expected-job1-iterations [{:step
-                                :fake-remote-call,
-                                :transition :to-next,
-                                :final false,
-                                :retry-count 0,
-                                :next-activation (fixed-now),
-                                :state {:damn 0, :initialized true},
-                                :caused-by-error nil}
-                               {:step
-                                :fake-remote-call,
-                                :transition :retry,
-                                :final false,
-                                :retry-count 1,
-                                :next-activation (time/plus (fixed-now) (time/minutes 1)),
-                                :state {:damn 1, :initialized true},
-                                :caused-by-error nil}
-                               {:step :fake-remote-call,
-                                :transition :final,
-                                :final true,
-                                :retry-count 0,
-                                :next-activation nil,
-                                :state {:damn 1, :initialized true},
-                                :caused-by-error nil}])
-
-(def
-  fatally-failing-job
-  (letfn [(fatally-flawed-step [state context]
-            (throw (Error. "INSTANT FATAL ISSUE")))]
-
-    {:steps {:initial fatally-flawed-step}
-     :type "fatally-failing-job"}))
-
-(def
-  always-exception-throwing-job
-  (letfn [(initial [state context]
-            {:transition {:id  :to-next
-                          :step  :throwing}})
-            (throwing-step [state context]
-                           (throw (Exception. "This exception is normal on test-run! This should happen, so don't be alarmed by it when you see it on test-runs.")))]
-
-    {:steps {:initial initial
-             :throwing throwing-step}
-     :type "always-exception-throwing-job"}))
-
-(def job-definitions {(:type job1) job1
-                      (:type fatally-failing-job) fatally-failing-job
-                      (:type always-exception-throwing-job) always-exception-throwing-job})
-
-(def default-start-iteration {:state {} :step :initial :retry-count 0 :iteration-id 1})
-
-(defn exec-all-iterations [runner job]
-  (loop [iteration (:iteration job)
-         result-iterations []]
-    (let [result-iteration (job-exec/exec-job-step runner (assoc job :iteration iteration))
-          new-results (conj result-iterations result-iteration)]
-      (if (:final result-iteration)
-        new-results
-        (recur result-iteration new-results)))))
-
-(describe
- "job execution"
- (tags :unit)
- (it "exec-job-step runs steps from job with manual retry and produces correct steps up until final iteration"
-     (with-redefs [time/now fixed-now]
-       (let [runner            {:job-definitions job-definitions
-                                :fake-service    (atom {:call-count  0})}
-             job               {:job-type "job1"
-                                :job-id 1
-                                :iteration {:state {:damn 0}
-                                            :step :initial
-                                            :retry-count 0}}
-             result-iterations (exec-all-iterations runner job)]
-         (should= expected-job1-iterations
-                  result-iterations))))
- (it "exec-job-step immediately produces final transition with error description"
-     (let [runner           {:job-definitions job-definitions}
-           job              {:job-type "fatally-failing-job"
-                             :job-id 2
-                             :iteration default-start-iteration}
-           result-iterations (exec-all-iterations runner job)]
-       (should= [{:step :initial,
-                  :state {},
-                  :final true,
-                  :retry-count 0,
-                  :next-activation nil,
-                  :transition :fail,
-                  :caused-by-error "Error occurred while executing step :initial: java.lang.Error: INSTANT FATAL ISSUE"}]
-                result-iterations)))
- (it "exec-job-step retries the maximum amount when an ordinary exception is thrown from the same step"
-     (let [runner          {:job-definitions job-definitions}
-           job             {:job-type "always-exception-throwing-job"
-                            :job-id 3
-                            :iteration default-start-iteration}
-           result-iterations (exec-all-iterations runner job)
-           last-iteration    (last result-iterations)]
-       (should= 102 ;; Limit is 100, it goes one over and the other 1 is the initial step's transition
-                (count result-iterations))
-       (should= {:final true,
-                 :retry-count 101,
-                 :next-activation nil,
-                 :transition :fail,
-                 :caused-by-error "Retry limit exceeded for step :throwing in job always-exception-throwing-job"}
-                (select-keys last-iteration [:final :retry-count :next-activation :transition :caused-by-error])))))
+;(ns ataru.background-job.job-execution-spec
+;  (:require
+;   [clj-time.core :as time]
+;   [speclj.core :refer [tags describe it should=]]
+;   [ataru.background-job.job-execution :as job-exec]))
+;
+;;; mocked time for test execution
+;(defn fixed-now [] (time/date-time 2016 10 10))
+;
+;(def
+;  job1
+;  (letfn [(call-fakeservice [service]
+;            (swap! service assoc :call-count (inc (:call-count @service)))
+;            (if (> (:call-count @service) 1)
+;              true
+;              false))
+;
+;          (initial [state context]
+;            {:transition {:id    :to-next
+;                          :step  :fake-remote-call}
+;             :updated-state (assoc state :initialized true)})
+;
+;          (fake-remote-call [state context]
+;            (let [fake-service (:fake-service context)
+;                  service-call-result (call-fakeservice fake-service)]
+;              (if-not service-call-result
+;                {:transition {:id :retry} :updated-state (assoc state :damn (inc (:damn state)))}
+;                {:transition {:id :final}})))]
+;
+;    {:steps {:initial initial
+;             :fake-remote-call fake-remote-call}
+;     :type "job1"}))
+;
+;(def expected-job1-iterations [{:step
+;                                :fake-remote-call,
+;                                :transition :to-next,
+;                                :final false,
+;                                :retry-count 0,
+;                                :next-activation (fixed-now),
+;                                :state {:damn 0, :initialized true},
+;                                :caused-by-error nil}
+;                               {:step
+;                                :fake-remote-call,
+;                                :transition :retry,
+;                                :final false,
+;                                :retry-count 1,
+;                                :next-activation (time/plus (fixed-now) (time/minutes 1)),
+;                                :state {:damn 1, :initialized true},
+;                                :caused-by-error nil}
+;                               {:step :fake-remote-call,
+;                                :transition :final,
+;                                :final true,
+;                                :retry-count 0,
+;                                :next-activation nil,
+;                                :state {:damn 1, :initialized true},
+;                                :caused-by-error nil}])
+;
+;(def
+;  fatally-failing-job
+;  (letfn [(fatally-flawed-step [state context]
+;            (throw (Error. "INSTANT FATAL ISSUE")))]
+;
+;    {:steps {:initial fatally-flawed-step}
+;     :type "fatally-failing-job"}))
+;
+;(def
+;  always-exception-throwing-job
+;  (letfn [(initial [state context]
+;            {:transition {:id  :to-next
+;                          :step  :throwing}})
+;            (throwing-step [state context]
+;                           (throw (Exception. "This exception is normal on test-run! This should happen, so don't be alarmed by it when you see it on test-runs.")))]
+;
+;    {:steps {:initial initial
+;             :throwing throwing-step}
+;     :type "always-exception-throwing-job"}))
+;
+;(def job-definitions {(:type job1) job1
+;                      (:type fatally-failing-job) fatally-failing-job
+;                      (:type always-exception-throwing-job) always-exception-throwing-job})
+;
+;(def default-start-iteration {:state {} :step :initial :retry-count 0 :iteration-id 1})
+;
+;(defn exec-all-iterations [runner job]
+;  (loop [iteration (:iteration job)
+;         result-iterations []]
+;    (let [result-iteration (job-exec/exec-job-step runner (assoc job :iteration iteration))
+;          new-results (conj result-iterations result-iteration)]
+;      (if (:final result-iteration)
+;        new-results
+;        (recur result-iteration new-results)))))
+;
+;(describe
+; "job execution"
+; (tags :unit)
+; (it "exec-job-step runs steps from job with manual retry and produces correct steps up until final iteration"
+;     (with-redefs [time/now fixed-now]
+;       (let [runner            {:job-definitions job-definitions
+;                                :fake-service    (atom {:call-count  0})}
+;             job               {:job-type "job1"
+;                                :job-id 1
+;                                :iteration {:state {:damn 0}
+;                                            :step :initial
+;                                            :retry-count 0}}
+;             result-iterations (exec-all-iterations runner job)]
+;         (should= expected-job1-iterations
+;                  result-iterations))))
+; (it "exec-job-step immediately produces final transition with error description"
+;     (let [runner           {:job-definitions job-definitions}
+;           job              {:job-type "fatally-failing-job"
+;                             :job-id 2
+;                             :iteration default-start-iteration}
+;           result-iterations (exec-all-iterations runner job)]
+;       (should= [{:step :initial,
+;                  :state {},
+;                  :final true,
+;                  :retry-count 0,
+;                  :next-activation nil,
+;                  :transition :fail,
+;                  :caused-by-error "Error occurred while executing step :initial: java.lang.Error: INSTANT FATAL ISSUE"}]
+;                result-iterations)))
+; (it "exec-job-step retries the maximum amount when an ordinary exception is thrown from the same step"
+;     (let [runner          {:job-definitions job-definitions}
+;           job             {:job-type "always-exception-throwing-job"
+;                            :job-id 3
+;                            :iteration default-start-iteration}
+;           result-iterations (exec-all-iterations runner job)
+;           last-iteration    (last result-iterations)]
+;       (should= 102 ;; Limit is 100, it goes one over and the other 1 is the initial step's transition
+;                (count result-iterations))
+;       (should= {:final true,
+;                 :retry-count 101,
+;                 :next-activation nil,
+;                 :transition :fail,
+;                 :caused-by-error "Retry limit exceeded for step :throwing in job always-exception-throwing-job"}
+;                (select-keys last-iteration [:final :retry-count :next-activation :transition :caused-by-error])))))

--- a/spec/ataru/background_job/job_execution_spec.clj
+++ b/spec/ataru/background_job/job_execution_spec.clj
@@ -16,7 +16,7 @@
 
 (defn send-email-assert-max-retry [_ recipients _ body]
   (should= recipients ["testi@example.org"])
-  (should (clojure.string/includes? body "Retry limit exceeded")))
+  (should (str/includes? body "Retry limit exceeded")))
 
 (def
   job1

--- a/spec/ataru/background_job/job_execution_spec.clj
+++ b/spec/ataru/background_job/job_execution_spec.clj
@@ -1,12 +1,22 @@
 (ns ataru.background-job.job-execution-spec
   (:require
    [clj-time.core :as time]
-   [speclj.core :refer [around tags describe it should=]]
+   [clojure.string :as str]
+   [speclj.core :refer [tags describe it should= should]]
    [ataru.background-job.email-job :as email-job]
    [ataru.background-job.job-execution :as job-exec]))
 
 ;; mocked time for test execution
 (defn fixed-now [] (time/date-time 2016 10 10))
+
+;; mocked email sending with parameter check
+(defn send-email-assert-error [_ recipients _ body]
+  (should= recipients ["testi@example.org"])
+  (should (str/includes? body "INSTANT FATAL ISSUE")))
+
+(defn send-email-assert-max-retry [_ recipients _ body]
+  (should= recipients ["testi@example.org"])
+  (should (clojure.string/includes? body "Retry limit exceeded")))
 
 (def
   job1
@@ -95,9 +105,6 @@
  "job execution"
  (tags :unit)
 
- (around [spec]
-         (with-redefs [email-job/send-email (constantly nil)]
-           (spec)))
  (it "exec-job-step runs steps from job with manual retry and produces correct steps up until final iteration"
      (with-redefs [time/now fixed-now]
        (let [runner            {:job-definitions job-definitions
@@ -111,6 +118,7 @@
          (should= expected-job1-iterations
                   result-iterations))))
  (it "exec-job-step immediately produces final transition with error description"
+     (with-redefs [email-job/send-email send-email-assert-error]
      (let [runner           {:job-definitions job-definitions}
            job              {:job-type "fatally-failing-job"
                              :job-id 2
@@ -123,8 +131,9 @@
                   :next-activation nil,
                   :transition :fail,
                   :caused-by-error "Error occurred while executing step :initial: java.lang.Error: INSTANT FATAL ISSUE"}]
-                result-iterations)))
+                result-iterations))))
  (it "exec-job-step retries the maximum amount when an ordinary exception is thrown from the same step"
+     (with-redefs [email-job/send-email send-email-assert-max-retry]
      (let [runner          {:job-definitions job-definitions}
            job             {:job-type "always-exception-throwing-job"
                             :job-id 3
@@ -138,4 +147,4 @@
                  :next-activation nil,
                  :transition :fail,
                  :caused-by-error "Retry limit exceeded for step :throwing in job always-exception-throwing-job"}
-                (select-keys last-iteration [:final :retry-count :next-activation :transition :caused-by-error])))))
+                (select-keys last-iteration [:final :retry-count :next-activation :transition :caused-by-error]))))))

--- a/spec/ataru/background_job/job_spec.clj
+++ b/spec/ataru/background_job/job_spec.clj
@@ -1,87 +1,87 @@
-(ns ataru.background-job.job-spec
-  "This tests how everything works together with database. More detailed tests are in job_execution_spec.clj."
-  (:require
-   [yesql.core :refer [defqueries]]
-   [ataru.config.core :refer [config]]
-   [clj-time.core :as time]
-   [speclj.core :refer [tags describe it should= before-all after-all]]
-   [ataru.background-job.job :as job]
-   [camel-snake-kebab.extras :refer [transform-keys]]
-   [camel-snake-kebab.core :refer [->kebab-case-keyword]]
-   [ataru.db.db :as db]
-   [clojure.java.jdbc :as jdbc]))
-
-(defqueries "sql/dev-job-queries.sql")
-
-;; mock time to be in the the past so that delayed retries
-;; still happen immediately. We don't want to wait minutes here.
-(defn fixed-now [] (time/date-time 2015 10 10))
-(def fake-config (merge config {:background-job {:exec-interval-seconds 1}}))
-
-(def
-  retrying-job
-  (letfn [(initial [state context]
-            {:transition {:id    :to-next
-                          :step  :second-step}})
-
-          (second-step [state context]
-            {:transition {:id    :to-next
-                          :step  :try-three-times}
-             :updated-state (assoc state :second-step-ok true)})
-
-          (try-three-times [state context]
-            (if (= 3 (:counter state))
-              {:transition {:id :final}}
-              {:transition {:id :retry}
-               :updated-state (assoc state :counter (inc (:counter state)))}))]
-
-    {:steps {:initial initial
-             :second-step second-step
-             :try-three-times try-three-times}
-     :type "retrying-job"}))
-
-(def job-definitions {(:type retrying-job) retrying-job})
-
-(def expected-final-iteration {:step "try-three-times"
-                               :state {:counter 3, :second-step-ok true},
-                               :next-activation nil,
-                               :transition "final"
-                               :retry-count 0,
-                               :final true,
-                               :caused-by-error nil})
-
-(defn start-job-runner []
-  (let [runner (job/->PersistentJobRunner job-definitions)]
-    (.start runner)))
-
-(defn get-final-iteration-for-job [job-id]
-  (transform-keys ->kebab-case-keyword (first (db/exec :db yesql-get-final-iteration-for-job {:job_id job-id}))))
-
-(def max-poll-count 100)
-
-(defn wait-for-final-iteration [job-id]
-  (loop [poll-count 1]
-    (if (= max-poll-count poll-count)
-      (throw (Exception. (str "Didn't find final iteration after polling " max-poll-count " times"))))
-    (let [final-iteration (get-final-iteration-for-job job-id)]
-      (if final-iteration
-        final-iteration
-        (do
-          (Thread/sleep 200) ;; Let's not busy-loop while polling DB
-          (println "Waiting for final iteration of job" job-id)
-          (recur (inc poll-count)))))))
-
-(describe
- "background job runner"
- (tags :unit :dev)
-
- (it "checks that job finishes without errors and with correct state"
-     (with-redefs [time/now fixed-now
-                   config   fake-config]
-       (let [job-runner      (start-job-runner)
-             job-id          (jdbc/with-db-transaction [connection {:datasource (db/get-datasource :db)}]
-                               (job/start-job job-runner connection (:type retrying-job) {:counter 0}))
-             final-iteration (wait-for-final-iteration job-id)]
-         (should= expected-final-iteration
-                  final-iteration)
-         (.stop job-runner)))))
+;(ns ataru.background-job.job-spec
+;  "This tests how everything works together with database. More detailed tests are in job_execution_spec.clj."
+;  (:require
+;   [yesql.core :refer [defqueries]]
+;   [ataru.config.core :refer [config]]
+;   [clj-time.core :as time]
+;   [speclj.core :refer [tags describe it should= before-all after-all]]
+;   [ataru.background-job.job :as job]
+;   [camel-snake-kebab.extras :refer [transform-keys]]
+;   [camel-snake-kebab.core :refer [->kebab-case-keyword]]
+;   [ataru.db.db :as db]
+;   [clojure.java.jdbc :as jdbc]))
+;
+;(defqueries "sql/dev-job-queries.sql")
+;
+;;; mock time to be in the the past so that delayed retries
+;;; still happen immediately. We don't want to wait minutes here.
+;(defn fixed-now [] (time/date-time 2015 10 10))
+;(def fake-config (merge config {:background-job {:exec-interval-seconds 1}}))
+;
+;(def
+;  retrying-job
+;  (letfn [(initial [state context]
+;            {:transition {:id    :to-next
+;                          :step  :second-step}})
+;
+;          (second-step [state context]
+;            {:transition {:id    :to-next
+;                          :step  :try-three-times}
+;             :updated-state (assoc state :second-step-ok true)})
+;
+;          (try-three-times [state context]
+;            (if (= 3 (:counter state))
+;              {:transition {:id :final}}
+;              {:transition {:id :retry}
+;               :updated-state (assoc state :counter (inc (:counter state)))}))]
+;
+;    {:steps {:initial initial
+;             :second-step second-step
+;             :try-three-times try-three-times}
+;     :type "retrying-job"}))
+;
+;(def job-definitions {(:type retrying-job) retrying-job})
+;
+;(def expected-final-iteration {:step "try-three-times"
+;                               :state {:counter 3, :second-step-ok true},
+;                               :next-activation nil,
+;                               :transition "final"
+;                               :retry-count 0,
+;                               :final true,
+;                               :caused-by-error nil})
+;
+;(defn start-job-runner []
+;  (let [runner (job/->PersistentJobRunner job-definitions)]
+;    (.start runner)))
+;
+;(defn get-final-iteration-for-job [job-id]
+;  (transform-keys ->kebab-case-keyword (first (db/exec :db yesql-get-final-iteration-for-job {:job_id job-id}))))
+;
+;(def max-poll-count 100)
+;
+;(defn wait-for-final-iteration [job-id]
+;  (loop [poll-count 1]
+;    (if (= max-poll-count poll-count)
+;      (throw (Exception. (str "Didn't find final iteration after polling " max-poll-count " times"))))
+;    (let [final-iteration (get-final-iteration-for-job job-id)]
+;      (if final-iteration
+;        final-iteration
+;        (do
+;          (Thread/sleep 200) ;; Let's not busy-loop while polling DB
+;          (println "Waiting for final iteration of job" job-id)
+;          (recur (inc poll-count)))))))
+;
+;(describe
+; "background job runner"
+; (tags :unit :dev)
+;
+; (it "checks that job finishes without errors and with correct state"
+;     (with-redefs [time/now fixed-now
+;                   config   fake-config]
+;       (let [job-runner      (start-job-runner)
+;             job-id          (jdbc/with-db-transaction [connection {:datasource (db/get-datasource :db)}]
+;                               (job/start-job job-runner connection (:type retrying-job) {:counter 0}))
+;             final-iteration (wait-for-final-iteration job-id)]
+;         (should= expected-final-iteration
+;                  final-iteration)
+;         (.stop job-runner)))))

--- a/spec/ataru/background_job/job_spec.clj
+++ b/spec/ataru/background_job/job_spec.clj
@@ -1,87 +1,87 @@
-;(ns ataru.background-job.job-spec
-;  "This tests how everything works together with database. More detailed tests are in job_execution_spec.clj."
-;  (:require
-;   [yesql.core :refer [defqueries]]
-;   [ataru.config.core :refer [config]]
-;   [clj-time.core :as time]
-;   [speclj.core :refer [tags describe it should= before-all after-all]]
-;   [ataru.background-job.job :as job]
-;   [camel-snake-kebab.extras :refer [transform-keys]]
-;   [camel-snake-kebab.core :refer [->kebab-case-keyword]]
-;   [ataru.db.db :as db]
-;   [clojure.java.jdbc :as jdbc]))
-;
-;(defqueries "sql/dev-job-queries.sql")
-;
-;;; mock time to be in the the past so that delayed retries
-;;; still happen immediately. We don't want to wait minutes here.
-;(defn fixed-now [] (time/date-time 2015 10 10))
-;(def fake-config (merge config {:background-job {:exec-interval-seconds 1}}))
-;
-;(def
-;  retrying-job
-;  (letfn [(initial [state context]
-;            {:transition {:id    :to-next
-;                          :step  :second-step}})
-;
-;          (second-step [state context]
-;            {:transition {:id    :to-next
-;                          :step  :try-three-times}
-;             :updated-state (assoc state :second-step-ok true)})
-;
-;          (try-three-times [state context]
-;            (if (= 3 (:counter state))
-;              {:transition {:id :final}}
-;              {:transition {:id :retry}
-;               :updated-state (assoc state :counter (inc (:counter state)))}))]
-;
-;    {:steps {:initial initial
-;             :second-step second-step
-;             :try-three-times try-three-times}
-;     :type "retrying-job"}))
-;
-;(def job-definitions {(:type retrying-job) retrying-job})
-;
-;(def expected-final-iteration {:step "try-three-times"
-;                               :state {:counter 3, :second-step-ok true},
-;                               :next-activation nil,
-;                               :transition "final"
-;                               :retry-count 0,
-;                               :final true,
-;                               :caused-by-error nil})
-;
-;(defn start-job-runner []
-;  (let [runner (job/->PersistentJobRunner job-definitions)]
-;    (.start runner)))
-;
-;(defn get-final-iteration-for-job [job-id]
-;  (transform-keys ->kebab-case-keyword (first (db/exec :db yesql-get-final-iteration-for-job {:job_id job-id}))))
-;
-;(def max-poll-count 100)
-;
-;(defn wait-for-final-iteration [job-id]
-;  (loop [poll-count 1]
-;    (if (= max-poll-count poll-count)
-;      (throw (Exception. (str "Didn't find final iteration after polling " max-poll-count " times"))))
-;    (let [final-iteration (get-final-iteration-for-job job-id)]
-;      (if final-iteration
-;        final-iteration
-;        (do
-;          (Thread/sleep 200) ;; Let's not busy-loop while polling DB
-;          (println "Waiting for final iteration of job" job-id)
-;          (recur (inc poll-count)))))))
-;
-;(describe
-; "background job runner"
-; (tags :unit :dev)
-;
-; (it "checks that job finishes without errors and with correct state"
-;     (with-redefs [time/now fixed-now
-;                   config   fake-config]
-;       (let [job-runner      (start-job-runner)
-;             job-id          (jdbc/with-db-transaction [connection {:datasource (db/get-datasource :db)}]
-;                               (job/start-job job-runner connection (:type retrying-job) {:counter 0}))
-;             final-iteration (wait-for-final-iteration job-id)]
-;         (should= expected-final-iteration
-;                  final-iteration)
-;         (.stop job-runner)))))
+(ns ataru.background-job.job-spec
+  "This tests how everything works together with database. More detailed tests are in job_execution_spec.clj."
+  (:require
+   [yesql.core :refer [defqueries]]
+   [ataru.config.core :refer [config]]
+   [clj-time.core :as time]
+   [speclj.core :refer [tags describe it should= before-all after-all]]
+   [ataru.background-job.job :as job]
+   [camel-snake-kebab.extras :refer [transform-keys]]
+   [camel-snake-kebab.core :refer [->kebab-case-keyword]]
+   [ataru.db.db :as db]
+   [clojure.java.jdbc :as jdbc]))
+
+(defqueries "sql/dev-job-queries.sql")
+
+;; mock time to be in the the past so that delayed retries
+;; still happen immediately. We don't want to wait minutes here.
+(defn fixed-now [] (time/date-time 2015 10 10))
+(def fake-config (merge config {:background-job {:exec-interval-seconds 1}}))
+
+(def
+  retrying-job
+  (letfn [(initial [state context]
+            {:transition {:id    :to-next
+                          :step  :second-step}})
+
+          (second-step [state context]
+            {:transition {:id    :to-next
+                          :step  :try-three-times}
+             :updated-state (assoc state :second-step-ok true)})
+
+          (try-three-times [state context]
+            (if (= 3 (:counter state))
+              {:transition {:id :final}}
+              {:transition {:id :retry}
+               :updated-state (assoc state :counter (inc (:counter state)))}))]
+
+    {:steps {:initial initial
+             :second-step second-step
+             :try-three-times try-three-times}
+     :type "retrying-job"}))
+
+(def job-definitions {(:type retrying-job) retrying-job})
+
+(def expected-final-iteration {:step "try-three-times"
+                               :state {:counter 3, :second-step-ok true},
+                               :next-activation nil,
+                               :transition "final"
+                               :retry-count 0,
+                               :final true,
+                               :caused-by-error nil})
+
+(defn start-job-runner []
+  (let [runner (job/->PersistentJobRunner job-definitions)]
+    (.start runner)))
+
+(defn get-final-iteration-for-job [job-id]
+  (transform-keys ->kebab-case-keyword (first (db/exec :db yesql-get-final-iteration-for-job {:job_id job-id}))))
+
+(def max-poll-count 100)
+
+(defn wait-for-final-iteration [job-id]
+  (loop [poll-count 1]
+    (if (= max-poll-count poll-count)
+      (throw (Exception. (str "Didn't find final iteration after polling " max-poll-count " times"))))
+    (let [final-iteration (get-final-iteration-for-job job-id)]
+      (if final-iteration
+        final-iteration
+        (do
+          (Thread/sleep 200) ;; Let's not busy-loop while polling DB
+          (println "Waiting for final iteration of job" job-id)
+          (recur (inc poll-count)))))))
+
+(describe
+ "background job runner"
+ (tags :unit :dev)
+
+ (it "checks that job finishes without errors and with correct state"
+     (with-redefs [time/now fixed-now
+                   config   fake-config]
+       (let [job-runner      (start-job-runner)
+             job-id          (jdbc/with-db-transaction [connection {:datasource (db/get-datasource :db)}]
+                               (job/start-job job-runner connection (:type retrying-job) {:counter 0}))
+             final-iteration (wait-for-final-iteration job-id)]
+         (should= expected-final-iteration
+                  final-iteration)
+         (.stop job-runner)))))

--- a/src/clj/ataru/background_job/email_job.clj
+++ b/src/clj/ataru/background_job/email_job.clj
@@ -8,7 +8,7 @@
 (defn- viestintapalvelu-address []
   (resolve-url :ryhmasahkoposti-service))
 
-(defn- send-email [from recipients subject body]
+(defn send-email [from recipients subject body]
   (let [url                (viestintapalvelu-address)
         wrapped-recipients (mapv (fn [rcp] {:email rcp}) recipients)
         response           (http-util/do-post url {:headers      {"content-type" "application/json"}
@@ -22,6 +22,9 @@
       (throw (Exception. (str "Could not send email to " (apply str recipients)))))))
 
 (defn send-email-step [{:keys [from recipients subject body]} _]
+  (log/info "mailiparametrit" from recipients subject body)
+  (throw (new RuntimeException
+           "Tilapäinen virhe testausta varten"))
   {:pre [(every? #(identity %) [from recipients subject body])]}
   (log/info "Trying to send email" subject "to" recipients "via viestintäpalvelu at address" (viestintapalvelu-address))
   (send-email from recipients subject body)

--- a/src/clj/ataru/background_job/email_job.clj
+++ b/src/clj/ataru/background_job/email_job.clj
@@ -23,8 +23,6 @@
       (throw (Exception. (str "Could not send email to " (apply str recipients)))))))
 
 (defn send-email-step [{:keys [from recipients subject body]} _]
-  (log/info "mailiparametrit" from recipients subject body)
-  (log/info (str/split (-> config :public-config :job-failure-alert-recipients) #";"))
   (throw (new RuntimeException
            "Tilapäinen virhe testausta varten"))
   {:pre [(every? #(identity %) [from recipients subject body])]}

--- a/src/clj/ataru/background_job/email_job.clj
+++ b/src/clj/ataru/background_job/email_job.clj
@@ -3,8 +3,7 @@
   (:require [ataru.config.url-helper :refer [resolve-url]]
             [ataru.util.http-util :as http-util]
             [cheshire.core :as json]
-            [taoensso.timbre :as log]
-            [clojure.string :as str]))
+            [taoensso.timbre :as log]))
 
 (defn- viestintapalvelu-address []
   (resolve-url :ryhmasahkoposti-service))

--- a/src/clj/ataru/background_job/email_job.clj
+++ b/src/clj/ataru/background_job/email_job.clj
@@ -3,7 +3,8 @@
   (:require [ataru.config.url-helper :refer [resolve-url]]
             [ataru.util.http-util :as http-util]
             [cheshire.core :as json]
-            [taoensso.timbre :as log]))
+            [taoensso.timbre :as log]
+            [clojure.string :as str]))
 
 (defn- viestintapalvelu-address []
   (resolve-url :ryhmasahkoposti-service))
@@ -23,6 +24,7 @@
 
 (defn send-email-step [{:keys [from recipients subject body]} _]
   (log/info "mailiparametrit" from recipients subject body)
+  (log/info (str/split (-> config :public-config :job-failure-alert-recipients) #";"))
   (throw (new RuntimeException
            "Tilapäinen virhe testausta varten"))
   {:pre [(every? #(identity %) [from recipients subject body])]}

--- a/src/clj/ataru/background_job/email_job.clj
+++ b/src/clj/ataru/background_job/email_job.clj
@@ -23,8 +23,6 @@
       (throw (Exception. (str "Could not send email to " (apply str recipients)))))))
 
 (defn send-email-step [{:keys [from recipients subject body]} _]
-  (throw (new RuntimeException
-           "Tilapäinen virhe testausta varten"))
   {:pre [(every? #(identity %) [from recipients subject body])]}
   (log/info "Trying to send email" subject "to" recipients "via viestintäpalvelu at address" (viestintapalvelu-address))
   (send-email from recipients subject body)

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -67,12 +67,12 @@
 
 (defn- final-error-iteration [step state retry-count msg]
   (log/info "Background job failed after maximum retries, sending email to administrators")
-;  (let [from        "no-reply@opintopolku.fi"
-;        recipients  ["marja.testaa@example.org"]
-;        subject     "Jobi meni pieleen"
-;        body        (selmer/render-file "templates/email_background_job_failed.html")]
-;    (ataru.background-job.email-job/send-email from recipients subject body)
-  (ataru.background-job.email-job/send-email "no-reply@opintopolku.fi" ["marja.testaa@example.org"] "Jobi meni pieleen" "")
+  (let [from        "no-reply@opintopolku.fi"
+        recipients  ["marja.testaa@example.org"]
+        subject     "Jobi meni pieleen"
+        body        (selmer/render-file "templates/email_background_job_failed.html")]
+    (ataru.background-job.email-job/send-email from recipients subject body)
+;  (ataru.background-job.email-job/send-email "no-reply@opintopolku.fi" ["marja.testaa@example.org"] "Jobi meni pieleen" "")
   {:step            step
    :state           state
    :final           true

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -138,7 +138,7 @@
     (log/info "job definition:")
     (log/info job-definition)
     (log/info "job type:")
-    (log/info (:job-type job-definition))
+    (log/info (:type job-definition))
     (cond
       (nil? step-fn)
       (final-error-iteration (:step iteration)
@@ -147,7 +147,8 @@
                              (str "Could not find step "
                                   (:step iteration)
                                   " from job definition for "
-                                  (:job-type job-definition)))
+                                  (:type job-definition))
+                             (:type job-definition))
       (>= (:retry-count iteration) max-retries)
       (final-error-iteration (:step iteration)
                              (:state iteration)
@@ -156,7 +157,7 @@
                                   (:step iteration)
                                   " in job "
                                   (:type job-definition))
-                             (:job-type job-definition))
+                             (:type job-definition))
 
       (:stop? iteration)
       (final-error-iteration (:step iteration)
@@ -180,7 +181,7 @@
       (maybe-exec-step runner (:iteration job) job-definition)
       (let [msg (str "Could not find job definition for " (:job-type job))]
         (log/error msg)
-        (final-error-iteration (-> job :iteration :step) {} 0 msg (:job-type job))))))
+        (final-error-iteration (-> job :iteration :step) {} 0 msg (:type job))))))
 
 (defn- get-job-step-and-exec [runner]
   (job-store/with-due-job

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -71,7 +71,7 @@
   (log/info (-> config :public-config :job-failure-alert-recipients))
   (log/info (str/split (-> config :public-config :job-failure-alert-recipients) #";"))
   (let [from        "no-reply@opintopolku.fi"
-        recipients  ["marja.testaa@example.org" "toinen.osoite@example.org"]
+        recipients  ["toinen.osoite@example.org" "marja.testaa@example.org"]
         subject     "Tausta-ajo päättyi virheeseen"
         body        (selmer/render-file "templates/email_background_job_failed.html" {{:job "information-request-job"},{:error msg}})]
     (ataru.background-job.email-job/send-email from recipients subject body)

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -70,7 +70,7 @@
   (let [from        "no-reply@opintopolku.fi"
         recipients  ["marja.testaa@example.org"]
         subject     "Jobi meni pieleen"
-        body        (selmer/render-file "templates/email_background_job_failed.html")]
+        body        (selmer/render-file "templates/email_background_job_failed.html" {})]
     (ataru.background-job.email-job/send-email from recipients subject body)
 ;  (ataru.background-job.email-job/send-email "no-reply@opintopolku.fi" ["marja.testaa@example.org"] "Jobi meni pieleen" "")
   {:step            step

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -135,10 +135,12 @@
    if we haven't exceeded retry-limit"
   [runner iteration job-definition]
   (let [step-fn (get (:steps job-definition) (:step iteration))]
-    (log/info "job definition:")
-    (log/info job-definition)
     (log/info "job type:")
     (log/info (:type job-definition))
+    (log/info "iteration")
+    (log/info iteration)
+    (log/info "caused by error")
+    (log/info (:caused-by-error iteration))
     (cond
       (nil? step-fn)
       (final-error-iteration (:step iteration)

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -4,12 +4,14 @@
    [schema.core :as s]
    [clj-time.core :as time]
    [clojure.core.match :refer [match]]
+   [selmer.parser :as selmer]
    [ataru.background-job.job-store :as job-store]
+   [ataru.background-job.email-job :as email-job]
    [ataru.config.core :refer [config]])
   (:import
    (java.util.concurrent Executors TimeUnit)))
 
-(def max-retries 100)
+(def max-retries 1)
 
 ;; Iterations resulting in running or attempting to run steps
 ;; are so central, that we've specified them with schema
@@ -64,6 +66,13 @@
         (time/now))))
 
 (defn- final-error-iteration [step state retry-count msg]
+  (log/info "Background job failed after maximum retries, sending email to administrators")
+;  (let [from        "no-reply@opintopolku.fi"
+;        recipients  ["marja.testaa@example.org"]
+;        subject     "Jobi meni pieleen"
+;        body        (selmer/render-file "templates/email_background_job_failed.html")]
+;    (ataru.background-job.email-job/send-email from recipients subject body)
+  (ataru.background-job.email-job/send-email "no-reply@opintopolku.fi" ["marja.testaa@example.org"] "Jobi meni pieleen" "")
   {:step            step
    :state           state
    :final           true

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -79,7 +79,7 @@
    :retry-count     retry-count
    :next-activation nil
    :transition      :fail
-   :caused-by-error msg})
+   :caused-by-error msg}))
 
 (defn- retry-error-iteration [step state retry-count msg]
   {:step            step

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -76,7 +76,7 @@
         recipients  (str/split (-> config :public-config :job-failure-alert-recipients) #";")
         subject     "Tausta-ajo päättyi virheeseen"
         body        (selmer/render-file "templates/email_background_job_failed.html"
-                                        {:job "information-request-job"
+                                        {:job job
                                          :error msg})]
     (ataru.background-job.email-job/send-email from recipients subject body)
     {:step            step
@@ -137,6 +137,8 @@
   (let [step-fn (get (:steps job-definition) (:step iteration))]
     (log/info "job definition:")
     (log/info job-definition)
+    (log/info "job type:")
+    (log/info (:job-type job-definition))
     (cond
       (nil? step-fn)
       (final-error-iteration (:step iteration)
@@ -154,7 +156,7 @@
                                   (:step iteration)
                                   " in job "
                                   (:type job-definition))
-                             (:type job-definition))
+                             (:job-type job-definition))
 
       (:stop? iteration)
       (final-error-iteration (:step iteration)

--- a/src/clj/ataru/background_job/job_execution.clj
+++ b/src/clj/ataru/background_job/job_execution.clj
@@ -4,6 +4,7 @@
    [schema.core :as s]
    [clj-time.core :as time]
    [clojure.core.match :refer [match]]
+   [clojure.string :as str]
    [selmer.parser :as selmer]
    [ataru.background-job.job-store :as job-store]
    [ataru.background-job.email-job :as email-job]
@@ -67,12 +68,13 @@
 
 (defn- final-error-iteration [step state retry-count msg]
   (log/info "Background job failed after maximum retries, sending email to administrators")
+  (log/info (-> config :public-config :job-failure-alert-recipients))
+  (log/info (str/split (-> config :public-config :job-failure-alert-recipients) #";"))
   (let [from        "no-reply@opintopolku.fi"
-        recipients  ["marja.testaa@example.org"]
-        subject     "Jobi meni pieleen"
-        body        (selmer/render-file "templates/email_background_job_failed.html" {})]
+        recipients  ["marja.testaa@example.org" "toinen.osoite@example.org"]
+        subject     "Tausta-ajo päättyi virheeseen"
+        body        (selmer/render-file "templates/email_background_job_failed.html" {{:job "information-request-job"},{:error msg}})]
     (ataru.background-job.email-job/send-email from recipients subject body)
-;  (ataru.background-job.email-job/send-email "no-reply@opintopolku.fi" ["marja.testaa@example.org"] "Jobi meni pieleen" "")
   {:step            step
    :state           state
    :final           true


### PR DESCRIPTION
Korjattu vanhat lomakkeet siivoavan background jobin sql ja lisätty sähköpostin lähetys konfiguroitaviin osoitteisiin jos tausta-ajo epäonnistuu lopullisesti.