### PR TITLE
Oy 4160 hakemuksen tekstivastausten trimmaus

### DIFF
--- a/cypress/integration/hakemuksenValidoinnitSpec.ts
+++ b/cypress/integration/hakemuksenValidoinnitSpec.ts
@@ -95,7 +95,7 @@ describe('Hakulomakkeen henkilötietojen tekstikentät trimmataan', () => {
         )
       })
       hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
-        it('Trimmaa henkilötiedoista vain sähköpostikentät', () => {
+        it('Trimmaa henkilötiedoista async-validoitavat kentät', () => {
           hakijanNakyma.henkilotiedot.henkilotunnus().should('exist')
           tekstinSyotto.syotaTeksti(
             hakijanNakyma.henkilotiedot.henkilotunnus(),
@@ -124,6 +124,23 @@ describe('Hakulomakkeen henkilötietojen tekstikentät trimmataan', () => {
           hakijanNakyma.henkilotiedot
             .sahkopostitoisto()
             .should('have.value', 'testi@example.org')
+        })
+        it('Trimmaa henkilötiedoista validoitavat tekstikentät', () => {
+          tekstinSyotto.syotaTeksti(
+            hakijanNakyma.henkilotiedot.matkapuhelin(),
+            ' 0401234567   '
+          )
+          // kentän trimmaus tapahtuu on-blur-eventillä joten fokusoidaan toiseen kenttään
+          hakijanNakyma.henkilotiedot.etunimi().click()
+          hakijanNakyma.henkilotiedot
+            .matkapuhelin()
+            .should('have.value', '0401234567')
+          tekstinSyotto.syotaTeksti(
+            hakijanNakyma.henkilotiedot.etunimi(),
+            ' Testi   '
+          )
+          hakijanNakyma.henkilotiedot.sukunimi().click()
+          hakijanNakyma.henkilotiedot.etunimi().should('have.value', 'Testi')
         })
       })
     })

--- a/cypress/integration/hakemuksenValidoinnitSpec.ts
+++ b/cypress/integration/hakemuksenValidoinnitSpec.ts
@@ -77,3 +77,59 @@ describe('Hakulomakkeen validoinnit', () => {
     })
   })
 })
+// describe('Hakulomakkeen tekstikentät trimmataan', () => {
+//   kirjautuminenVirkailijanNakymaan('lomakkeen luomista varten', () => {
+//     lomakkeenLuonti((lomakkeenTunnisteet) => {
+//       it('Lisää huoltajan yhteystietomoduulin', () => {
+//         lomakkeenMuokkaus.henkilotiedot.valitseHenkilotietolomakkeenKentat(
+//           'Opiskelijavalinta, perusopetuksen jälkeinen yhteishaku',
+//           lomakkeenTunnisteet().lomakkeenId
+//         )
+//         lomakkeenMuokkaus.komponentinLisays.lisaaElementti(
+//           lomakkeenTunnisteet().lomakkeenId,
+//           'Huoltajan yhteystiedot'
+//         )
+//         tekstikentanLisakysymyksenLisays(lomakkeenTunnisteet, () => {})
+//       })
+//       hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
+//         it('Trimmaa henkilötietokentät', () => {
+//           hakijanNakyma.henkilotiedot.henkilotunnus().should('exist')
+//           tekstinSyotto.syotaTeksti(
+//             hakijanNakyma.henkilotiedot.henkilotunnus(),
+//             '010123A968L   '
+//           )
+//           hakijanNakyma.henkilotiedot
+//             .henkilotunnus()
+//             .should('have.value', '010123A968L   ')
+//           tekstinSyotto.syotaTeksti(
+//             hakijanNakyma.henkilotiedot.sahkoposti(),
+//             '  testi@example.org  '
+//           )
+//           hakijanNakyma.henkilotiedot
+//             .sahkoposti()
+//             .should('have.value', 'testi@example.org')
+//           tekstinSyotto.syotaTeksti(
+//             hakijanNakyma.henkilotiedot.sahkopostitoisto(),
+//             '  testi@example.org  '
+//           )
+//           hakijanNakyma.henkilotiedot
+//             .sahkopostitoisto()
+//             .should('have.value', 'testi@example.org')
+//         })
+//         it('Trimmaa lisäkysymysten vastaukset', () => {
+//           lisakysymys
+//             .syötäTekstikenttäänVastaus('  Vastaus  ')
+//             .then(() =>
+//               lisakysymys.syötäLisäkysymykseenVastaus(
+//                 ' Vastaus lisäkysymykseen '
+//               )
+//             )
+//           lisakysymys.kysymysKenttä().should('have.value', '  Vastaus  ')
+//           lisakysymys
+//             .haeLisäkysymyksenVastaus()
+//             .should('have.value', ' Vastaus lisäkysymykseen ')
+//         })
+//       })
+//     })
+//   })
+// })

--- a/cypress/integration/hakemuksenValidoinnitSpec.ts
+++ b/cypress/integration/hakemuksenValidoinnitSpec.ts
@@ -6,7 +6,8 @@ import * as hakijanNakyma from '../hakijanNakyma'
 import * as tekstinSyotto from '../tekstinSyotto'
 import tekstikentanLisakysymyksenLisays from '../testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstikentanLisakysymyksenLisays'
 import { lisakysymys } from '../testit/lomake-elementit/tekstikentta/hakija/hakemus/lisakysymys'
-import henkilotietoModuulinTayttaminen from '../testit/henkilotietoModuulinTayttaminen'
+import { tekstikentta } from '../testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstikentta'
+import { tekstialue } from '../testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstialue'
 
 describe('Hakulomakkeen validoinnit', () => {
   kirjautuminenVirkailijanNakymaan('lomakkeen luomista varten', () => {
@@ -133,22 +134,20 @@ describe('Lisäkysymyksen tekstikenttä trimmataan', () => {
     lomakkeenLuonti((lomakkeenTunnisteet) => {
       tekstikentanLisakysymyksenLisays(lomakkeenTunnisteet, () => {
         hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
-          henkilotietoModuulinTayttaminen(() => {
-            it('Trimmaa lisäkysymysten vastaukset', () => {
-              lisakysymys
-                .syötäTekstikenttäänVastaus('  Vastaus  ')
-                .then(() =>
-                  lisakysymys.syötäLisäkysymykseenVastaus(
-                    ' Vastaus lisäkysymykseen '
-                  )
+          it('Trimmaa lisäkysymysten vastaukset', () => {
+            lisakysymys
+              .syötäTekstikenttäänVastaus('  Vastaus  ')
+              .then(() =>
+                lisakysymys.syötäLisäkysymykseenVastaus(
+                  ' Vastaus lisäkysymykseen '
                 )
-              // trimmaus tapahtuu on-blur-eventillä joten fokusoidaan toiseen kenttään
-              hakijanNakyma.henkilotiedot.matkapuhelin().click()
-              lisakysymys.kysymysKenttä().should('have.value', 'Vastaus')
-              lisakysymys
-                .haeLisäkysymyksenVastaus()
-                .should('have.value', 'Vastaus lisäkysymykseen')
-            })
+              )
+            // trimmaus tapahtuu on-blur-eventillä joten fokusoidaan toiseen kenttään
+            hakijanNakyma.henkilotiedot.matkapuhelin().click()
+            lisakysymys.kysymysKenttä().should('have.value', 'Vastaus')
+            lisakysymys
+              .haeLisäkysymyksenVastaus()
+              .should('have.value', 'Vastaus lisäkysymykseen')
           })
         })
       })
@@ -158,37 +157,66 @@ describe('Lisäkysymyksen tekstikenttä trimmataan', () => {
 
 // pakko tehdä erillinen testi erityyppisille teksti-inputeille,
 // koska lomake-editorissa ei saa yksilöityä eri tekstikenttiä
-// describe('Tekstialue trimmataan', () => {
-//   kirjautuminenVirkailijanNakymaan('lomakkeen luomista varten', () => {
-//     lomakkeenLuonti((lomakkeenTunnisteet) => {
-//       it('Lisää tekstialue', () => {
-//         tekstialue
-//           .lisaaTekstialue(lomakkeenTunnisteet().lomakkeenId)
-//           .then(() => tekstialue.asetaKysymys('Tekstialuekysymys'))
-//           .then(() => tekstialue.asetaMaxMerkkimaara('50'))
-//       })
-//       hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
-//         it('Trimmaa tekstialueen', () => {
-//           cy.get('textarea').should('exist')
-//         })
-//       })
-//     })
-//   })
-// })
-// describe('Hakulomakkeen toistuvat tekstikentät trimmataan', () => {
-//   kirjautuminenVirkailijanNakymaan('lomakkeen luomista varten', () => {
-//     lomakkeenLuonti((lomakkeenTunnisteet) => {
-//       tekstikentta
-//         .lisaaTekstikentta(lomakkeenTunnisteet().lomakkeenId)
-//         .then(() =>
-//           tekstikentta.asetaKysymys('Toistettavan tekstikentän kysymys')
-//         )
-//         .then(() => tekstikentta.voiLisätäUseitaValinta().click())
-//       hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
-//         it('Trimmaa toistettavan tekstikentän', () => {
-//           tekstikentta.kysymysKenttä().should('exist')
-//         })
-//       })
-//     })
-//   })
-// })
+describe('Tekstialue trimmataan', () => {
+  kirjautuminenVirkailijanNakymaan('lomakkeen luomista varten', () => {
+    lomakkeenLuonti((lomakkeenTunnisteet) => {
+      it('Lisää tekstialue', () => {
+        tekstialue
+          .lisaaTekstialue(lomakkeenTunnisteet().lomakkeenId)
+          .then(() => tekstialue.asetaKysymys('Tekstialuekysymys'))
+          .then(() => tekstialue.asetaMaxMerkkimaara('50'))
+      })
+      hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
+        it('Trimmaa tekstialueen', () => {
+          tekstialue.syötäTekstialueenVastaus(
+            '  Tekstiä\nja toinen rivi\nja kolmas rivi  \n\n'
+          )
+          // trimmaus tapahtuu on-blur-eventillä joten fokusoidaan toiseen kenttään
+          hakijanNakyma.henkilotiedot.matkapuhelin().click()
+          tekstialue
+            .haeTekstialue()
+            .should('have.value', 'Tekstiä\nja toinen rivi\nja kolmas rivi')
+        })
+      })
+    })
+  })
+})
+describe('Hakulomakkeen toistuvat tekstikentät trimmataan', () => {
+  kirjautuminenVirkailijanNakymaan('lomakkeen luomista varten', () => {
+    lomakkeenLuonti((lomakkeenTunnisteet) => {
+      it('Lisää toistuva tekstikenttä', () => {
+        lomakkeenMuokkaus.teeJaodotaLomakkeenTallennusta(
+          lomakkeenTunnisteet().lomakkeenId,
+          () =>
+            tekstikentta
+              .lisaaTekstikentta(lomakkeenTunnisteet().lomakkeenId)
+              .then(() =>
+                tekstikentta.asetaKysymys('Toistettavan tekstikentän kysymys')
+              )
+              .then(() => tekstikentta.voiLisätäUseitaValinta().click())
+        )
+      })
+      hakijanNakymaanSiirtyminen(lomakkeenTunnisteet, () => {
+        it('Trimmaa toistettavan tekstikentän', () => {
+          tekstinSyotto.syotaTekstiTarkistamatta(
+            cy.get('[data-test-id=repeatable-text-field-0]'),
+            '  ensimmäinen teksti  '
+          )
+          tekstinSyotto.syotaTekstiTarkistamatta(
+            cy.get('[data-test-id=repeatable-text-field-1]'),
+            '  toinen teksti  '
+          )
+          hakijanNakyma.henkilotiedot.matkapuhelin().click()
+          cy.get('[data-test-id=repeatable-text-field-0]').should(
+            'have.value',
+            'ensimmäinen teksti'
+          )
+          cy.get('[data-test-id=repeatable-text-field-1]').should(
+            'have.value',
+            'toinen teksti'
+          )
+        })
+      })
+    })
+  })
+})

--- a/cypress/integration/hakemuksenValidoinnitSpec.ts
+++ b/cypress/integration/hakemuksenValidoinnitSpec.ts
@@ -6,8 +6,6 @@ import * as hakijanNakyma from '../hakijanNakyma'
 import * as tekstinSyotto from '../tekstinSyotto'
 import tekstikentanLisakysymyksenLisays from '../testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstikentanLisakysymyksenLisays'
 import { lisakysymys } from '../testit/lomake-elementit/tekstikentta/hakija/hakemus/lisakysymys'
-import { tekstikentta } from '../testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstikentta'
-import { tekstialue } from '../testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstialue'
 import henkilotietoModuulinTayttaminen from '../testit/henkilotietoModuulinTayttaminen'
 
 describe('Hakulomakkeen validoinnit', () => {

--- a/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstialue.ts
+++ b/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstialue.ts
@@ -1,5 +1,6 @@
 import * as asetukset from '../../../../../asetukset'
 import * as lomakkeenMuokkaus from '../../../../../lomakkeenMuokkaus'
+import * as tekstinSyotto from '../../../../../tekstinSyotto'
 
 export const tekstialue = {
   haeLisaaLinkki: () => cy.get('[data-test-id=component-toolbar-tekstialue]'),
@@ -7,6 +8,8 @@ export const tekstialue = {
   kysymysKenttä: () => cy.get('[data-test-id=tekstikenttä-kysymys]'),
 
   maksimiMerkkimaara: () => cy.get('[data-test-id=tekstialue-max-merkkimaara]'),
+
+  haeTekstialue: () => cy.get('textarea'),
 
   lisaaTekstialue: (formId: number) =>
     lomakkeenMuokkaus.teeJaodotaLomakkeenTallennusta(formId, () => {
@@ -24,5 +27,12 @@ export const tekstialue = {
     return tekstialue
       .maksimiMerkkimaara()
       .type(teksti, { delay: asetukset.tekstikentanSyotonViive })
+  },
+
+  syötäTekstialueenVastaus: (teksti: string) => {
+    return tekstinSyotto.syotaTekstiTarkistamatta(
+      tekstialue.haeTekstialue(),
+      teksti
+    )
   },
 }

--- a/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstialue.ts
+++ b/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstialue.ts
@@ -1,0 +1,28 @@
+import * as asetukset from '../../../../../asetukset'
+import * as lomakkeenMuokkaus from '../../../../../lomakkeenMuokkaus'
+
+export const tekstialue = {
+  haeLisaaLinkki: () => cy.get('[data-test-id=component-toolbar-tekstialue]'),
+
+  kysymysKenttä: () => cy.get('[data-test-id=tekstikenttä-kysymys]'),
+
+  maksimiMerkkimaara: () => cy.get('[data-test-id=tekstialue-max-merkkimaara]'),
+
+  lisaaTekstialue: (formId: number) =>
+    lomakkeenMuokkaus.teeJaodotaLomakkeenTallennusta(formId, () => {
+      lomakkeenMuokkaus.komponentinLisays.avaaValikko()
+      return tekstialue.haeLisaaLinkki().click()
+    }),
+
+  asetaKysymys: (teksti: string) => {
+    return tekstialue
+      .kysymysKenttä()
+      .type(teksti, { delay: asetukset.tekstikentanSyotonViive })
+  },
+
+  asetaMaxMerkkimaara: (teksti: string) => {
+    return tekstialue
+      .maksimiMerkkimaara()
+      .type(teksti, { delay: asetukset.tekstikentanSyotonViive })
+  },
+}

--- a/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstikentta.ts
+++ b/cypress/testit/lomake-elementit/tekstikentta/virkailija/lomakkeet/tekstikentta.ts
@@ -9,6 +9,9 @@ export const tekstikentta = {
   kenttäänVainNumeroitaValinta: () =>
     cy.get('[data-test-id=tekstikenttä-valinta-kenttään-vain-numeroita]'),
 
+  voiLisätäUseitaValinta: () =>
+    cy.get('[data-test-id=tekstikenttä-valinta-voi-lisätä-useita]'),
+
   lisaaTekstikentta: (formId: number) =>
     lomakkeenMuokkaus.teeJaodotaLomakkeenTallennusta(formId, () => {
       lomakkeenMuokkaus.komponentinLisays.avaaValikko()

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -309,7 +309,7 @@
 (defn- remove-null-bytes-from-value
   [value]
   (cond (string? value)
-        (clojure.string/replace value "\u0000" "")
+        (clojure.string/replace (clojure.string/trim value) "\u0000" "")
         (sequential? value)
         (mapv remove-null-bytes-from-value value)
         :else

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -306,18 +306,18 @@
        first
        :virkailija_oid))
 
-(defn- remove-null-bytes-from-value
+(defn- trim-and-remove-null-bytes-from-value
   [value]
   (cond (string? value)
         (clojure.string/replace (clojure.string/trim value) "\u0000" "")
         (sequential? value)
-        (mapv remove-null-bytes-from-value value)
+        (mapv trim-and-remove-null-bytes-from-value value)
         :else
         value))
 
 (defn- remove-null-bytes-from-answer
   [answer]
-  (update answer :value remove-null-bytes-from-value))
+  (update answer :value trim-and-remove-null-bytes-from-value))
 
 (defn add-application [new-application applied-hakukohteet form session audit-logger]
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -356,6 +356,7 @@
                                    " application__form-text-input--normal")
                                  (when last?
                                    " application__form-text-input--disabled"))
+           :data-test-id    (str "repeatable-text-field-" repeatable-idx)
            :value           (cond last?
                                   nil
                                   (:focused? @local-state)

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -175,7 +175,7 @@
                                              (swap! local-state assoc
                                                     :focused-verify? false)
                                              (email-verify-field-change field-descriptor (:value answer)
-                                                                          (trimmed-or-empty-value get-verify-value)))
+                                                                          (trimmed-or-empty-value (get-verify-value))))
 
                              :on-paste     (fn [event]
                                                (.preventDefault event))

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -55,6 +55,9 @@
 (defn- multi-value-field-change [field-descriptor question-group-idx value]
   (dispatch [:application/set-repeatable-application-field field-descriptor question-group-idx nil value]))
 
+(defn- trimmed-or-empty-value [value]
+  (clojure.string/trim (or value "")))
+
 (defn- validation-error
   [errors]
   (let [languages @(subscribe [:application/default-languages])]
@@ -124,8 +127,9 @@
                                                       " application__form-text-input--normal"))
                               :on-blur       (event->value (fn [value]
                                                                (swap! local-state assoc
-                                                                      :focused? false)
-                                                               (on-change (clojure.string/trim (or value "")))
+                                                                      :focused? false
+                                                                      :value (trimmed-or-empty-value value))
+                                                               (on-change (trimmed-or-empty-value value))
                                                                (textual-field-blur field-descriptor)))
                               :on-change    (event->value (fn [value]
                                                               (swap! local-state assoc
@@ -171,7 +175,7 @@
                                              (swap! local-state assoc
                                                     :focused-verify? false)
                                              (email-verify-field-change field-descriptor (:value answer)
-                                                                          (clojure.string/trim (or (get-verify-value) ""))))
+                                                                          (trimmed-or-empty-value get-verify-value)))
 
                              :on-paste     (fn [event]
                                                (.preventDefault event))
@@ -272,8 +276,9 @@
                                        " application__form-text-input--normal"))
                   :on-blur      (fn [evt]
                                   (swap! local-state assoc
-                                         :focused? false)
-                                  (on-change (clojure.string/trim (or value "")))
+                                         :focused? false
+                                         :value (trimmed-or-empty-value value))
+                                  (on-change (trimmed-or-empty-value value))
                                   (on-blur evt))
                   :on-change    (event->value (fn [value]
                                                 (swap! local-state assoc
@@ -324,7 +329,8 @@
             on-blur                      (fn [evt]
                                            (let [value (-> evt .-target .-value)]
                                              (swap! local-state assoc
-                                                    :focused? false)
+                                                    :focused? false
+                                                    :value (trimmed-or-empty-value value))
                                              (if (and (empty? value) (not last?))
                                                (dispatch [:application/remove-repeatable-application-field-value
                                                           field-descriptor
@@ -334,7 +340,7 @@
                                                           field-descriptor
                                                           question-group-idx
                                                           repeatable-idx
-                                                          (clojure.string/trim (or value ""))]))))
+                                                          (trimmed-or-empty-value value)]))))
             on-change                    (fn [evt]
                                            (let [value (-> evt .-target .-value)]
                                              (swap! local-state assoc
@@ -444,8 +450,9 @@
                                       :else value)
                   :on-blur      (fn [_]
                                   (swap! local-state assoc
-                                         :focused? false)
-                                  (on-change (clojure.string/trim (or value ""))))
+                                         :focused? false
+                                         :value (trimmed-or-empty-value value))
+                                  (on-change (trimmed-or-empty-value value)))
                   :on-change    (event->value (fn [value]
                                                 (swap! local-state assoc
                                                        :focused? true
@@ -722,12 +729,13 @@
             show-error?     @(subscribe [:application/show-validation-error-class? id question-group-idx row-idx nil])
             on-blur         (fn [_]
                               (swap! local-state assoc
-                                     :focused? false)
+                                     :focused? false
+                                     :value (trimmed-or-empty-value value))
                               (dispatch [:application/set-repeatable-application-field
                                          field-descriptor
                                          question-group-idx
                                          row-idx
-                                         (clojure.string/trim (or value ""))]))
+                                         (trimmed-or-empty-value value)]))
             on-change       (fn [evt]
                               (let [value (-> evt .-target .-value)]
                                 (swap! local-state assoc

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -273,6 +273,7 @@
                   :on-blur      (fn [evt]
                                   (swap! local-state assoc
                                          :focused? false)
+                                  (on-change (clojure.string/trim (or value "")))
                                   (on-blur evt))
                   :on-change    (event->value (fn [value]
                                                 (swap! local-state assoc
@@ -324,11 +325,16 @@
                                            (let [value (-> evt .-target .-value)]
                                              (swap! local-state assoc
                                                     :focused? false)
-                                             (when (and (empty? value) (not last?))
+                                             (if (and (empty? value) (not last?))
                                                (dispatch [:application/remove-repeatable-application-field-value
                                                           field-descriptor
                                                           question-group-idx
-                                                          repeatable-idx]))))
+                                                          repeatable-idx])
+                                               (dispatch [:application/set-repeatable-application-field
+                                                          field-descriptor
+                                                          question-group-idx
+                                                          repeatable-idx
+                                                          (clojure.string/trim (or value ""))]))))
             on-change                    (fn [evt]
                                            (let [value (-> evt .-target .-value)]
                                              (swap! local-state assoc
@@ -437,7 +443,8 @@
                                       :else value)
                   :on-blur      (fn [_]
                                   (swap! local-state assoc
-                                         :focused? false))
+                                         :focused? false)
+                                  (on-change (clojure.string/trim (or value ""))))
                   :on-change    (event->value (fn [value]
                                                 (swap! local-state assoc
                                                        :focused? true
@@ -714,7 +721,12 @@
             show-error?     @(subscribe [:application/show-validation-error-class? id question-group-idx row-idx nil])
             on-blur         (fn [_]
                               (swap! local-state assoc
-                                     :focused? false))
+                                     :focused? false)
+                              (dispatch [:application/set-repeatable-application-field
+                                         field-descriptor
+                                         question-group-idx
+                                         row-idx
+                                         (clojure.string/trim (or value ""))]))
             on-change       (fn [evt]
                               (let [value (-> evt .-target .-value)]
                                 (swap! local-state assoc

--- a/src/cljs/ataru/virkailija/editor/components/repeater_checkbox_component.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/repeater_checkbox_component.cljs
@@ -14,6 +14,7 @@
                                     :id        id
                                     :checked   checked?
                                     :disabled  disabled?
+                                    :data-test-id "tekstikenttä-valinta-voi-lisätä-useita"
                                     :on-change (fn [event]
                                                  (when (not disabled?)
                                                    (dispatch [:editor/set-component-value (-> event .-target .-checked) path :params :repeatable])))}]

--- a/src/cljs/ataru/virkailija/editor/components/text_component.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/text_component.cljs
@@ -487,7 +487,8 @@
               [:input.editor-form__text-field.editor-form__text-field-auto-width
                {:value     @max-length
                 :disabled  @component-locked?
-                :on-change #(max-length-change (get-val %))}]])]
+                :on-change #(max-length-change (get-val %))
+                :data-test-id "tekstialue-max-merkkimaara"}]])]
           [:div.editor-form__checkbox-wrapper
            [validator-checkbox-component/validator-checkbox path initial-content :required (required-disabled initial-content)]
            (when (and text-area? (or @toisen-asteen-yhteishaku?

--- a/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
@@ -25,7 +25,7 @@
                                        :koodisto-source {:uri "" :title "" :version 1}
                                        :options []))]
    [:text-field component/text-field {:data-test-id "component-toolbar-tekstikenttä"}]
-   [:text-area component/text-area]
+   [:text-area component/text-area {:data-test-id "component-toolbar-tekstialue"}]
    [:adjacent-fieldset component/adjacent-fieldset]
    [:attachment component/attachment]
    [:question-group component/question-group]


### PR DESCRIPTION
Trimmaus tekstikentille ja tekstialueelle backendiin ja myös käliin, jotta saadaan validaatiot käyttäytymään halutulla tavalla.
Cypress-testit eri tyyppisten tekstikenttien trimmauksille.