### PR TITLE
OY-4237 Turn URLs to links in virkailija hakemus view

### DIFF
--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -131,14 +131,24 @@
                              " ")
                   [:i.zmdi.zmdi-hc-lg.zmdi-chevron-up]])])]))}))))
 
+ (defn- urls-to-links
+  [content]
+  (let [urls (re-seq #"https?://\S+" content)]
+    (reduce
+     #(string/replace-first %1 %2 (str "<a href=\"" %2 "\">" %2 "</a>"))
+     content
+     urls)))
+
 (defn render-paragraphs [s]
   (->> (clojure.string/split s "\n")
+       (map urls-to-links)
        (map-indexed (fn [i p]
                       ^{:key (str "paragraph-" i)}
                       [:div
                        (if (clojure.string/blank? p)
                          [:br]
-                         [:p.application__text-field-paragraph p])]))))
+                         [:p.application__text-field-paragraph
+                          {:dangerouslySetInnerHTML {:__html p}}])]))))
 
 (defn is-required-field?
   [field-descriptor]

--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -135,7 +135,7 @@
   [content]
   (let [urls (re-seq #"https?://\S+" content)]
     (reduce
-     #(string/replace-first %1 %2 (str "<a href=\"" %2 "\">" %2 "</a>"))
+     #(string/replace-first %1 %2 (str "<a href=\"" %2 "\" target=_blank rel=\"noopener noreferrer\">" %2 "</a>"))
      content
      urls)))
 


### PR DESCRIPTION
Turn (sub)strings that look like URLs to links in virkailija read-only view. Using a simple & unsophisticated RegEx, because we don't actually need to validate anything.