### PR TITLE
OY-4266 Job failure mail config + job error reporting improvements

### DIFF
--- a/config/dev.edn
+++ b/config/dev.edn
@@ -44,6 +44,7 @@
                    :attachment-file-max-size-bytes      10485760
                    :attachment-file-part-max-size-bytes 5242880
                    :job-failure-alert-recipients        "testi@example.org"
+                   :send-job-failure-alert-emails        true
                    :features {:schema-validation true}}
  :temp-files      {:filesystem {:base-path "/tmp"}}
  :dev             {:fake-dependencies true}

--- a/config/test.edn
+++ b/config/test.edn
@@ -44,6 +44,7 @@
                    :attachment-file-max-size-bytes      10485760
                    :attachment-file-part-max-size-bytes 5242880
                    :job-failure-alert-recipients        "testi@example.org"
+                   :send-job-failure-alert-emails        true
                    :features {:schema-validation true}}
  :temp-files      {:filesystem {:base-path "/tmp"}}
  :dev             {:fake-dependencies true}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -51,7 +51,7 @@
                  :attachment-file-part-max-size-bytes {{ataru_attachment_file_part_max_size_bytes}}
                  :attachment-preview-pages-to-display {{liiteri_attachment_preview_pages_to_display}}
                  :job-failure-alert-recipients "{{ataru_job_failure_alert_recipients}}"}
-                 :send-job-failure-alert-emails "{{ataru-send-job-failure-alert-emails | default('true')}}}"
+                 :send-job-failure-alert-emails "{{ataru_send_job_failure_alert_emails | default('true')}}}"
  :cas {:username "{{ataru_cas_username}}"
        :password "{{ataru_cas_password}}"}
  :log {:virkailija-base-path "{{ataru_virkailija_log_path}}"

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -50,8 +50,8 @@
                  :attachment-file-max-size-bytes {{ataru_attachment_file_max_size_bytes}}
                  :attachment-file-part-max-size-bytes {{ataru_attachment_file_part_max_size_bytes}}
                  :attachment-preview-pages-to-display {{liiteri_attachment_preview_pages_to_display}}
-                 :job-failure-alert-recipients "{{ataru_job_failure_alert_recipients}}"}
-                 :send-job-failure-alert-emails "{{ataru_send_job_failure_alert_emails | default('true')}}}"
+                 :job-failure-alert-recipients "{{ataru_job_failure_alert_recipients}}"
+                 :send-job-failure-alert-emails {{ataru_send_job_failure_alert_emails | default('true')}}}
  :cas {:username "{{ataru_cas_username}}"
        :password "{{ataru_cas_password}}"}
  :log {:virkailija-base-path "{{ataru_virkailija_log_path}}"

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -51,6 +51,7 @@
                  :attachment-file-part-max-size-bytes {{ataru_attachment_file_part_max_size_bytes}}
                  :attachment-preview-pages-to-display {{liiteri_attachment_preview_pages_to_display}}
                  :job-failure-alert-recipients "{{ataru_job_failure_alert_recipients}}"}
+                 :send-job-failure-alert-emails "{{ataru-send-job-failure-alert-emails | default('true')}}}"
  :cas {:username "{{ataru_cas_username}}"
        :password "{{ataru_cas_password}}"}
  :log {:virkailija-base-path "{{ataru_virkailija_log_path}}"


### PR DESCRIPTION
- Allow enabling / disabling job failure mails per environment
- Add job id to failure mails to allow finding it from the db more easily
- Add full trace information to error msgs containing throwables / exceptions (log, database, e-mail)