### PR TITLE
OY-4276 Rewrite preferred name validation to closer match ONR

### DIFF
--- a/src/cljc/ataru/preferred_name.cljc
+++ b/src/cljc/ataru/preferred_name.cljc
@@ -1,15 +1,29 @@
 (ns ataru.preferred-name
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [clojure.set :as set]))
 
+; This should be equal or tighter than the ONR validation, so that we don't allow for
+; first name + preferred name combos that would later make the ONR create / update fail.
 (defn main-first-name?
   [{:keys [value answers-by-key]}]
-  (let [first-names     (clojure.string/split (clojure.string/trim (or (-> answers-by-key :first-name :value)
-                                                                       "")) #"[\s-]+")
-        num-first-names (count first-names)
-        possible-names  (set
-                          (for [sub-length (range 1 (inc num-first-names))
-                                start-idx  (range 0 num-first-names)
-                                :when (<= (+ sub-length start-idx) num-first-names)]
-                            (clojure.string/join " " (subvec first-names start-idx (+ start-idx sub-length)))))]
-    (or (and (empty? (filter #(not (string/blank? %)) first-names)) (string/blank? value))
-        (contains? possible-names (clojure.string/replace value "-" " ")))))
+  (let [first-name (clojure.string/trim (or (-> answers-by-key :first-name :value) ""))
+        first-names-whitespace      (clojure.string/split first-name #"[\s]")
+        first-names-whitespace-dash (clojure.string/split first-name #"[\s-]")
+        create-name-set-fn (fn [names]
+                             (let [num-names (count names)]
+                               (set
+                                (for [sub-length (range 1 (inc num-names))
+                                      start-idx  (range 0 num-names)
+                                      :when (<= (+ sub-length start-idx) num-names)]
+                                  (clojure.string/join " " (subvec names start-idx (+ start-idx sub-length)))))))
+        possible-names (set/union
+                        ; E.g. "arpa-tupla noppa kuutio" =>
+                        ; "arpa-tupla" "noppa" "kuutio" "arpa-tupla noppa" "noppa kuutio" "arpa-tupla noppa kuutio", ...
+                        (create-name-set-fn first-names-whitespace)
+                        ; E.g. "arpa-tupla noppa kuutio" =>
+                        ; "arpa" "tupla" "noppa" "kuutio" "arpa tupla noppa" "noppa kuutio" "arpa tupla noppa kuutio", ...
+                        (create-name-set-fn first-names-whitespace-dash))]
+    (or (and (empty? (filter #(not (string/blank? %)) first-names-whitespace))
+             (empty? (filter #(not (string/blank? %)) first-names-whitespace-dash))
+             (string/blank? value))
+        (contains? possible-names value))))

--- a/test/cljc/unit/ataru/fixtures/first_name.cljc
+++ b/test/cljc/unit/ataru/fixtures/first_name.cljc
@@ -1,13 +1,25 @@
 (ns ataru.fixtures.first-name)
 
-(def first-name-list [["Kari-Pekka" "Kari-Pekka" true]
+(def first-name-list [["" "Kari" false]
+                      ["Kari" "" false]
+                      ["Kari-Pekka" "Kari-Pekka" true]
                       ["Kari-Pekka" "Kari" true]
                       ["Kari-Pekka" "Pekka" true]
                       ["Kari-Pekka" "Pekk" false]
                       ["Kari-Pekka" "Kar" false]
+                      ["Kari-Pekka" "Kari Pekka" true]
+                      ["Kari Pekka" "Kari-Pekka" false]
+                      ["Kari  Pekka" "Kari Pekka" false]
+                      ["Kari Pekka" "Kari  Pekka" false]
+                      ["Kari Pekka" "Pekka Kari" false]
                       ["Yrjö Liisa Zalgo" "Ykä" false]
                       ["Yrjö Liisa Zalgo" "Yrjö" true]
                       ["Yrjö Liisa Zalgo" "Yrjö Liisa" true]
                       ["Yrjö Liisa Zalgo" "Liisa Zalgo" true]
                       ["Yrjö Liisa Zalgo" "Liisa" true]
-                      ["Yrjö Liisa Zalgo" "Yrjö69" false]])
+                      ["Yrjö Liisa Zalgo" "Yrjö69" false]
+                      ["Yrjö Liisa" "Yrjö  Liisa" false]
+                      ["Yrjö  Liisa Zalgo" "Yrjö Liisa  Zalgo" false]
+                      ["Yrjö-Liisa Zalgo" "Yrjö Liisa" true]
+                      ["Yrjö-Liisa Zalgo" "Liisa Zalgo" true]
+                      ["Yrjö Liisa Zalgo" "Yrjö-Liisa" false]])


### PR DESCRIPTION
Ataru has a looser validation than ONR for preferred names ("kutsumanimi"), which results in some ONR create / update operations failing due to validation errors. 

This PR aims to make Ataru validation equal or stricter to ONR. What stays stricter is case handling: ONR lowercases everything before comparison, Ataru still requires exact case / capitalization.

ONR validator: https://github.com/Opetushallitus/oppijanumerorekisteri/blob/c80de1bf06aa6d1251104d269a5f2fc43d22c41f/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java