### PR TITLE
OY-4277 email subject char limit

### DIFF
--- a/spec/ataru/email/email_util_spec.clj
+++ b/spec/ataru/email/email_util_spec.clj
@@ -62,7 +62,7 @@
               application-key "1.2.246.562.11.00000000000000012345"
               lang :fi
               subject (util/enrich-subject-with-application-key-and-limit-length prefix application-key lang)]
-          (should= "Vahvistusviesti sinulle: onneksi olkoon - sinut on valittu haluamaasi opiskelupaikkaan, ohjeet paikan vastaanottoon sisältyvät viestiin - avaa viesti saadaksesi lisätietoja vastaanotosta määräaikaan mennessä... (Hakemusnumero: 1.2.246.562.11.00000000000000012345)" subject)
+          (should= "Vahvistusviesti sinulle: onneksi olkoon - sinut on valittu haluamaasi opiskelupaikkaan, ohjeet paikan vastaanottoon sisältyvät viestiin - avaa viesti saadaksesi lisätietoja vastaanotosta määräaikaan men (Hakemusnumero: 1.2.246.562.11.00000000000000012345)" subject)
           (should= 255 (count subject))))
       (it "renders subject with full application key and no message"
         (let [prefix ""

--- a/spec/ataru/email/email_util_spec.clj
+++ b/spec/ataru/email/email_util_spec.clj
@@ -41,4 +41,32 @@
         (should-have-invoked :render {:with [{}]})
         (should= 2 (count emails))
         (should= ["teppo.testaa@testi.fi" "tiina.testaa@testi.fi"] (:recipients (first emails)))
-        (should= ["huoltaja.testaa@testi.fi"] (:recipients (last emails)))))))
+        (should= ["huoltaja.testaa@testi.fi"] (:recipients (last emails))))))
+
+    (describe "subject length limiting"
+      (it "renders subject with full application key and full message when total is less than 255 chars"
+        (let [prefix "Vahvistusviesti: sinut on valittu haluamaasi opiskelupaikkaan, lue ohjeet paikan vastaanottoon"
+              application-key "1.2.246.562.11.00000000000000012345"
+              lang :fi
+              subject (util/enrich-subject-with-application-key-and-limit-length prefix application-key lang)]
+          (should= "Vahvistusviesti: sinut on valittu haluamaasi opiskelupaikkaan, lue ohjeet paikan vastaanottoon (Hakemusnumero: 1.2.246.562.11.00000000000000012345)" subject)))
+      (it "renders subject with full application key and full message when total is exactly 255 chars"
+        (let [prefix "Vahvistusviesti: onneksi olkoon - sinut on valittu haluamaasi opiskelupaikkaan, ohjeet paikan vastaanottoon sisältyvät viestiin - avaa viesti saadaksesi lisätietoja vastaanotosta määräaikaan mennessä..."
+              application-key "1.2.246.562.11.00000000000000012345"
+              lang :fi
+              subject (util/enrich-subject-with-application-key-and-limit-length prefix application-key lang)]
+          (should= "Vahvistusviesti: onneksi olkoon - sinut on valittu haluamaasi opiskelupaikkaan, ohjeet paikan vastaanottoon sisältyvät viestiin - avaa viesti saadaksesi lisätietoja vastaanotosta määräaikaan mennessä... (Hakemusnumero: 1.2.246.562.11.00000000000000012345)" subject)
+          (should= 255 (count subject))))
+      (it "renders subject with full application key and truncated message when total length more than 255 chars"
+        (let [prefix "Vahvistusviesti sinulle: onneksi olkoon - sinut on valittu haluamaasi opiskelupaikkaan, ohjeet paikan vastaanottoon sisältyvät viestiin - avaa viesti saadaksesi lisätietoja vastaanotosta määräaikaan mennessä... Tärkeää tietoa!"
+              application-key "1.2.246.562.11.00000000000000012345"
+              lang :fi
+              subject (util/enrich-subject-with-application-key-and-limit-length prefix application-key lang)]
+          (should= "Vahvistusviesti sinulle: onneksi olkoon - sinut on valittu haluamaasi opiskelupaikkaan, ohjeet paikan vastaanottoon sisältyvät viestiin - avaa viesti saadaksesi lisätietoja vastaanotosta määräaikaan mennessä... (Hakemusnumero: 1.2.246.562.11.00000000000000012345)" subject)
+          (should= 255 (count subject))))
+      (it "renders subject with full application key and no message"
+        (let [prefix ""
+              application-key "1.2.246.562.11.00000000000000012345"
+              lang :fi
+              subject (util/enrich-subject-with-application-key-and-limit-length prefix application-key lang)]
+          (should= " (Hakemusnumero: 1.2.246.562.11.00000000000000012345)" subject)))))

--- a/src/clj/ataru/email/application_email.clj
+++ b/src/clj/ataru/email/application_email.clj
@@ -21,7 +21,6 @@
             [ataru.koodisto.koodisto :as koodisto])
   (:import [org.owasp.html HtmlPolicyBuilder ElementPolicy]))
 
-(def languages #{:fi :sv :en})
 (def languages-map {:fi nil :sv nil :en nil})
 
 (def edit-email-subjects
@@ -202,12 +201,6 @@
   (fn [attachment-type]
     (koodisto/get-attachment-type-label koodisto-cache attachment-type)))
 
-(defn- enrich-subject-with-application-key [prefix application-key lang]
-  (if application-key
-    (let [postfix (str "(" (get-in email-default-texts [:hakemusnumero (or lang :fi)]) ": " application-key ")")]
-      (string/join " " [prefix postfix]))
-    prefix))
-
 (defn create-emails
   [subject template-name application tarjonta-info raw-form application-attachment-reviews email-template get-attachment-type guardian? payment-url]
    (let [now                             (t/now)
@@ -254,7 +247,7 @@
                                                 (mapcat :value)
                                                 (filter (comp not clojure.string/blank?))))
          subject-prefix                  (if subject (subject lang) (email-template :subject))
-         subject                         (enrich-subject-with-application-key subject-prefix (:key application) lang)
+         subject                         (email-util/enrich-subject-with-application-key-and-limit-length subject-prefix (:key application) lang)
          application-url                 (modify-link (:secret application))
          template-params                 {:hakukohteet                (hakukohde-names tarjonta-info lang application)
                                           :application-oid            (:key application)

--- a/src/clj/ataru/email/email_util.clj
+++ b/src/clj/ataru/email/email_util.clj
@@ -1,6 +1,21 @@
-(ns ataru.email.email-util)
+(ns ataru.email.email-util
+   (:require [ataru.translations.texts :refer [email-default-texts]]
+             [clojure.string :as string]))
 
 (def from-address "no-reply@opintopolku.fi")
+
+(def subject-max-length 255)
+
+(defn enrich-subject-with-application-key-and-limit-length [prefix application-key lang]
+  (if application-key
+    (let [label (get-in email-default-texts [:hakemusnumero (or lang :fi)])
+          postfix (str "(" label ": " application-key ")")
+          over-length (max 0
+                           (- (count (string/join " " [prefix postfix])) subject-max-length))
+          trimmed-prefix (subs prefix
+                               0 (- (count prefix) over-length))]
+      (string/join " " [trimmed-prefix postfix]))
+    prefix))
 
 (defn- filter-template-params
   [template-params guardian?]

--- a/src/clj/ataru/information_request/information_request_service.clj
+++ b/src/clj/ataru/information_request/information_request_service.clj
@@ -3,8 +3,8 @@
             [ataru.db.db :as db]
             [ataru.log.audit-log :as audit-log]
             [ataru.translations.translation-util :as translations]
-            [ataru.translations.texts :refer [email-default-texts]]
             [ataru.util :as u]
+            [ataru.email.email-util :as email-util]
             [ataru.email.application-email-jobs :refer [->safe-html]]
             [ataru.information-request.information-request-job :as information-request-job]
             [ataru.information-request.information-request-store :as information-request-store]
@@ -15,12 +15,6 @@
             [clojure.string :as string]
             [ataru.background-job.job :as job]
             [taoensso.timbre :as log]))
-
-(defn- enrich-subject-with-application-key [prefix application-key lang]
-  (if application-key
-    (let [postfix (str "(" (get-in email-default-texts [:hakemusnumero (or lang :fi)]) ": " application-key ")")]
-      (string/join " " [prefix postfix]))
-    prefix))
 
 (defn- extract-answer-value [answer-key-str application]
   (->> (:answers application)
@@ -52,7 +46,8 @@
                                                       {}
                                                       {:application-url application-url})
                                                     translations))
-        subject-with-application-key (enrich-subject-with-application-key (:subject information-request) (:application-key information-request) lang)]
+        subject-with-application-key (email-util/enrich-subject-with-application-key-and-limit-length
+                                      (:subject information-request) (:application-key information-request) lang)]
     (when (not-empty recipient-emails)
       (-> (select-keys information-request [:application-key :id])
           (merge {:from       "no-reply@opintopolku.fi"

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1568,15 +1568,15 @@
    :mass-information-request-sending-messages                {:fi "Käsitellään viestejä..."
                                                               :sv "Meddelanden behandlas..."
                                                               :en "Sending the messages"}
-   :mass-information-request-subject                         {:fi "Aihe:"
-                                                              :sv "Ämne:"
-                                                              :en "Subject:"}
+   :mass-information-request-subject                         {:fi "Aihe (max. 120 merkkiä):"
+                                                              :sv "Ämne (max. 120 tecken):"
+                                                              :en "Subject (max. 120 characters):"}
    :single-information-request                               {:fi "Viesti"
                                                               :sv "Meddelande"
                                                               :en "Message"}
-   :single-information-request-subject                       {:fi "Aihe:"
-                                                              :sv "Ämne:"
-                                                              :en "Subject:"}
+   :single-information-request-subject                       {:fi "Aihe (max. 120 merkkiä):"
+                                                              :sv "Ämne (max. 120 tecken):"
+                                                              :en "Subject (max. 120 characters):"}
    :single-information-request-email-applicant               {:fi "Olet lähettämässä sähköpostia 1 hakijalle: %s"
                                                               :sv "Skicka e-post till 1 sökande: "
                                                               :en "Send email to applicants:"}

--- a/src/cljs/ataru/virkailija/application/application_review_view.cljs
+++ b/src/cljs/ataru/virkailija/application/application_review_view.cljs
@@ -714,7 +714,7 @@
 (defn- application-information-request-subject []
   (let [subject (subscribe [:state-query [:application :information-request :subject]])]
     [:div.application-handling__information-request-row
-     [:div.application-handling__information-request-info-heading "Aihe:"]
+     [:div.application-handling__information-request-info-heading @(subscribe [:editor/virkailija-translation :mass-information-request-subject])]
      [:div.application-handling__information-request-text-input-container
       [:input.application-handling__information-request-text-input
        {:value     @subject

--- a/src/cljs/ataru/virkailija/application/application_review_view.cljs
+++ b/src/cljs/ataru/virkailija/application/application_review_view.cljs
@@ -718,7 +718,7 @@
      [:div.application-handling__information-request-text-input-container
       [:input.application-handling__information-request-text-input
        {:value     @subject
-        :maxLength 200
+        :maxLength 120
         :on-change (fn [event]
                      (let [subject (-> event .-target .-value)]
                        (dispatch [:application/set-information-request-subject subject])))}]]]))

--- a/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
+++ b/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
@@ -31,7 +31,7 @@
            [:div.application-handling__information-request-text-input-container
             [:input.application-handling__information-request-text-input
              {:value     @subject
-              :maxLength 200
+              :maxLength 120
               :on-change #(dispatch [:application/set-single-information-request-subject (-> % .-target .-value)])}]]]
           [:div.application-handling__information-request-row
            [:textarea.application-handling__information-request-message-area.application-handling__information-request-message-area--large

--- a/src/cljs/ataru/virkailija/application/mass_information_request/virkailija_mass_information_request_view.cljs
+++ b/src/cljs/ataru/virkailija/application/mass_information_request/virkailija_mass_information_request_view.cljs
@@ -33,7 +33,7 @@
            [:div.application-handling__information-request-text-input-container
             [:input.application-handling__information-request-text-input
              {:value     @subject
-              :maxLength 200
+              :maxLength 120
               :on-change #(dispatch [:application/set-mass-information-request-subject (-> % .-target .-value)])}]]]
           [:div.application-handling__information-request-row
            [:textarea.application-handling__information-request-message-area.application-handling__information-request-message-area--large


### PR DESCRIPTION
- Limit freely definable e-mail subject to 120 characters in the UI, add note about the limit where there previously was none
- Hard limit subject to 255 characters in the backend so that application id never gets truncated