### PR TITLE
OY-4044 Allow "yksi valittavissa" without selection limit for form root

### DIFF
--- a/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/toolbar.cljs
@@ -124,9 +124,9 @@
              [:div.plus-component [:span "+"]])])))
 
 (defn handle-root-level-components [elements]
-  (let [elements-with-arvosanat (conj elements [:arvosanat-peruskoulu arvosanat/arvosanat-peruskoulu {:data-test-id "component-toolbar-arvosanat"}]
-                                      [:arvosanat-lukio arvosanat/arvosanat-lukio])]
-    (filterv (fn [x] (not (= (first x) :single-choice-button))) elements-with-arvosanat)))
+  (conj elements
+        [:arvosanat-peruskoulu arvosanat/arvosanat-peruskoulu {:data-test-id "component-toolbar-arvosanat"}]
+        [:arvosanat-lukio arvosanat/arvosanat-lukio]))
 
 (defn add-component [path root-level-add-component?]
   (let [elements (cond-> (toolbar-elements)

--- a/src/cljs/ataru/virkailija/editor/subs.cljs
+++ b/src/cljs/ataru/virkailija/editor/subs.cljs
@@ -393,6 +393,7 @@
   (fn [component [_ & path]]
     (and
      (= (:fieldType component) "singleChoice")
+     (> (count (flatten path)) 1)
      (not
        (loop [part (butlast (rest (flatten path)))]
          (if-let [parent (get-in component part)]


### PR DESCRIPTION
"Painikkeet, yksi valittavissa" was earlier disabled on form root level, because it allowed for selection limit ("rajoitettu valinta") that we didn't want to allow on root level.

This PR allows "yksi valittavissa" on root level again, but hides selection limit option in that case.