### PR TITLE
OY-4357 Use application created at instead of haku end year for jatkuva haku school data

### DIFF
--- a/src/clj/ataru/applications/suoritus_filter.clj
+++ b/src/clj/ataru/applications/suoritus_filter.clj
@@ -3,7 +3,8 @@
 
 (defn year-for-suoritus-filter
   [now]
-  (time/year now))
+  (when now
+    (time/year now)))
 
 (defn luokkatasot-for-suoritus-filter
   []

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -474,6 +474,7 @@
         :path-params [henkilo-oid :- String]
         :query-params [haku-oid :- String
                        {hakemus-datetime :- s/Str nil}]
+        :summary "Returns opiskelija information from suoritusrekisteri"
         :return ataru-schema/OpiskelijaResponse
         (let [haku       (tarjonta/get-haku tarjonta-service haku-oid)
               hakemus-year (some->> hakemus-datetime

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -477,6 +477,7 @@
         (let [haku       (tarjonta/get-haku tarjonta-service haku-oid)
               hakuvuodet (->> (:hakuajat haku)
                               (map #(suoritus-filter/year-for-suoritus-filter (:end %)))
+                              (remove nil?)
                               distinct)
               luokkatasot (suoritus-filter/luokkatasot-for-suoritus-filter)
               linked-oids (get (person-service/linked-oids person-service [henkilo-oid]) henkilo-oid)

--- a/src/cljs/ataru/virkailija/application/handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/handlers.cljs
@@ -624,9 +624,10 @@
 
 (reg-event-fx
   :application/fetch-applicant-school
-  (fn [_ [_ haku-oid applicant-henkilo-oid]]
+  (fn [_ [_ haku-oid applicant-henkilo-oid hakemus-datetime]]
     {:http {:method              :get
-            :path                (str "/lomake-editori/api/applications/opiskelija/" applicant-henkilo-oid "?haku-oid=" haku-oid)
+            :path                (str "/lomake-editori/api/applications/opiskelija/" applicant-henkilo-oid
+                                      "?haku-oid=" haku-oid "&hakemus-datetime=" hakemus-datetime)
             :handler-or-dispatch :application/handle-fetch-applicant-school-response}}))
 
 (reg-event-db
@@ -643,7 +644,10 @@
   (when (or
           (haku/toisen-asteen-yhteishaku? (:tarjonta application))
           (haku/jatkuva-haku? (:tarjonta application)))
-    [:application/fetch-applicant-school (:haku application) (-> application :person :oid)]))
+    [:application/fetch-applicant-school
+     (:haku application)
+     (-> application :person :oid)
+     (:created-time application)]))
 
 (reg-event-fx
   :application/handle-fetch-application


### PR DESCRIPTION
There was an error in the UI when loading applications from jatkuva haku / toisen asteen yhteishaku, because the API that fetches school data used haku end year for fetching, and those particular ones don't necessarily have that.

After this PR, application created year is used for jatkuva haku & toisen asteen yhteishaku. We pass the application created date as a parameter for now to avoid extra roundtrip to database - if more application info is needed within the endpoint later, application OID + database query would be a better idea.