### PR TITLE
OY-4303 indicate possible guardians in resend modify link UI

### DIFF
--- a/resources/less/virkailija-application.less
+++ b/resources/less/virkailija-application.less
@@ -1262,8 +1262,8 @@ i.arkistoitu {
   color: @white;
   border-radius: 3px;
   box-shadow :none;
-  padding: 5px;
-  height: 41px;
+  padding: 12px;
+  min-height: 41px;
   width: 100%;
   margin-right: 0;
   font-family: 'Open Sans', sans-serif;

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1844,6 +1844,9 @@
    :send-confirmation-email-to-applicant                     {:fi "Lähetä vahvistussähköposti hakijalle"
                                                               :sv "Skicka e-post med bekräftelse till sökanden"
                                                               :en "Send confirmation email again"}
+   :send-confirmation-email-to-applicant-and-guardian        {:fi "Lähetä vahvistussähköposti hakijalle ja huoltajalle"
+                                                              :sv "Skicka e-post med bekräftelse till sökanden och vårdnadshavaren"
+                                                              :en "Send confirmation email again"}
    :send-edit-link-to-applicant                              {:fi "Vahvistussähköposti lähetetty uudelleen hakijalle"
                                                               :sv "Bearbetningslänken har skickats till sökande per e-post"
                                                               :en "Confirmation email has been sent"}

--- a/src/cljs/ataru/virkailija/application/application_review_view.cljs
+++ b/src/cljs/ataru/virkailija/application/application_review_view.cljs
@@ -793,10 +793,17 @@
           @(subscribe [:editor/virkailija-translation :send-information-request-to-applicant])]]))))
 
 (defn- application-resend-modify-link []
-  (let [recipient         (subscribe [:state-query [:application :selected-application-and-form :application :answers :email :value]])
-        enabled?          (subscribe [:application/resend-modify-application-link-enabled?])
-        settings-visible? (subscribe [:state-query [:application :review-settings :visible?]])
-        can-edit?         (subscribe [:state-query [:application :selected-application-and-form :application :can-edit?]])]
+  (let [recipient          (subscribe [:state-query [:application :selected-application-and-form
+                                                     :application :answers :email :value]])
+        first-guardian     (subscribe [:state-query [:application :selected-application-and-form
+                                                     :application :answers :guardian-email :value]])
+        second-guardian    (subscribe [:state-query [:application :selected-application-and-form
+                                                     :application :answers :guardian-email-secondary :value]])
+        recipients         (remove string/blank? (flatten [@recipient @first-guardian @second-guardian]))
+        enabled?           (subscribe [:application/resend-modify-application-link-enabled?])
+        settings-visible?  (subscribe [:state-query [:application :review-settings :visible?]])
+        can-edit?          (subscribe [:state-query [:application :selected-application-and-form
+                                                     :application :can-edit?]])]
     [:button.application-handling__send-information-request-button.application-handling__button
      {:on-click #(dispatch [:application/resend-modify-application-link])
       :disabled (or (not @enabled?)
@@ -808,8 +815,10 @@
                      (if (or @settings-visible? (not @can-edit?))
                        " application-handling__send-information-request-button--cursor-default"
                        " application-handling__send-information-request-button--cursor-pointer"))}
-     [:div @(subscribe [:editor/virkailija-translation :send-confirmation-email-to-applicant])]
-     [:div.application-handling__resend-modify-application-link-email-text @recipient]]))
+     (if (> (count recipients) 1)
+       [:div @(subscribe [:editor/virkailija-translation :send-confirmation-email-to-applicant-and-guardian])]
+       [:div @(subscribe [:editor/virkailija-translation :send-confirmation-email-to-applicant])])
+     [:div.application-handling__resend-modify-application-link-email-text (string/join ", " recipients)]]))
 
 
 (defn- application-resend-modify-link-confirmation []


### PR DESCRIPTION
Resending confirmation mail to applicant also resends it to guardians in case there are guardian e-mails. Indicate that, and the guardian e-mails in UI whenever defined.