### PR TITLE
OY-4302 application default language

### DIFF
--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -4,7 +4,10 @@
             [ataru.application-common.application-field-common :refer [required-validators pad sanitize-value]]
             [clojure.core.match :refer [match]]))
 
-(defn- initial-valid-status [flattened-form-fields preselected-hakukohteet]
+(def selected-language-map
+  { :fi "FI" :sv "SV" })
+
+(defn- initial-valid-status [flattened-form-fields preselected-hakukohteet selected-language]
   (->> flattened-form-fields
        (filter util/answerable?)
        (map-indexed
@@ -20,6 +23,7 @@
                              :label  label
                              :value  (mapv :value values)
                              :values values}])
+
             [{:id    "pohjakoulutusristiriita"
               :label label}]
             [:pohjakoulutusristiriita {:valid  true
@@ -27,6 +31,16 @@
                                        :value  nil
                                        :values {:value nil
                                                 :valid true}}]
+
+            ; Override default language based on selected form language
+            [{:id    "language"
+              :label label}]
+            (let [value (or (get selected-language-map selected-language) "")]
+              [:language {:valid  (not (empty? value))
+                          :label  label
+                          :value  value
+                          :values {:value value
+                                   :valid (not (empty? value))}}])
 
             [{:id         id
               :fieldClass "formField"
@@ -93,6 +107,7 @@
                              :value  [[(or value "")]]
                              :values [[{:value (or value "")
                                         :valid (or (some? value) (not required?))}]]}])
+
             [{:id         id
               :fieldClass "formField"
               :fieldType  "dropdown"
@@ -111,6 +126,7 @@
                                       :valid (or (some? value)
                                                     (or (not required?)
                                                     (boolean (:per-hakukohde field))))}}])
+
             [{:id         id
               :fieldClass "formField"
               :fieldType  "singleChoice"
@@ -159,6 +175,7 @@
                       :value  []
                       :values []
                       :label  label}]
+
             [{:id         id
               :fieldClass "formField"
               :fieldType  "attachment"
@@ -183,9 +200,9 @@
 
 (defn create-initial-answers
   "Create initial answer structure based on form structure.
-  Validity, dropdown default value and default hakukohde for now."
-  [flat-form-content preselected-hakukohde-oids]
-  (initial-valid-status flat-form-content preselected-hakukohde-oids))
+  Validity, dropdown default value and default hakukohde + language for now."
+  [flat-form-content preselected-hakukohde-oids selected-language]
+  (initial-valid-status flat-form-content preselected-hakukohde-oids selected-language))
 
 (defn contains-id? [content id]
   (contains? (set (map :id content)) id))

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -460,7 +460,8 @@
                                       preselected-hakukohde-oids)
         questions-with-duplicates  (handlers-util/duplicate-questions-for-hakukohteet-during-form-load (get-in form [:tarjonta :hakukohteet]) hakukohde-oids-to-duplicate questions)
         flat-form-content          (autil/flatten-form-fields questions-with-duplicates)
-        initial-answers            (create-initial-answers flat-form-content preselected-hakukohde-oids)]
+        selected-language          (:selected-language form)
+        initial-answers            (create-initial-answers flat-form-content preselected-hakukohde-oids selected-language)]
     (-> db
         (update :form (fn [{:keys [selected-language]}]
                         (cond-> form
@@ -771,7 +772,8 @@
   [check-schema-interceptor]
   (fn [db [_ field-descriptor]]
     (let [id             (keyword (:id field-descriptor))
-          initial-answer (get (create-initial-answers [field-descriptor] []) id)
+          lang-kw        (keyword (-> db :form :selected-language))
+          initial-answer (get (create-initial-answers [field-descriptor] [] lang-kw) id)
           answer         (assoc initial-answer :original-value (:value initial-answer))
           limit-reached  (get-in db [:application :answers id :limit-reached])]
       (cond-> (assoc-in db [:application :answers id] answer)

--- a/test/cljs/unit/ataru/hakija/application_test.cljs
+++ b/test/cljs/unit/ataru/hakija/application_test.cljs
@@ -183,7 +183,7 @@
     (is (= expected actual))))
 
 (deftest correct-initial-validity-for-nested-form
-  (let [initial-answers (create-initial-answers (util/flatten-form-fields (:content form1)) nil)]
+  (let [initial-answers (create-initial-answers (util/flatten-form-fields (:content form1)) nil nil)]
     (is (= {:G__2  {:value  ""
                     :values {:value ""
                              :valid false}

--- a/test/cljs/unit/ataru/hakija/application_test.cljs
+++ b/test/cljs/unit/ataru/hakija/application_test.cljs
@@ -97,6 +97,23 @@
                    :params {}}],
      :params {}}]})
 
+(defn form-with-language [lang]
+  {:id 37,
+   :name {:fi "uusi lomake"},
+   :created-time "x",
+   :created-by "1.2.246.562.11.11111111111",
+   :selected-language lang,
+   :content [{:id "language",
+                          :label {:fi "kieli", :sv ""},
+                          :params {},
+                          :validators ["required"],
+                          :fieldType "dropdown",
+                          :fieldClass "formField",
+                          :koodisto-source {:uri "kieli",
+                                            :version 1,
+                                            :default-option "suomi"}
+                          :metadata metadata}]})
+
 (deftest flattens-correctly
   (let [expected [{:id         "G__1",
                    :label      {:fi "osio1", :sv "Avsnitt namn"},
@@ -200,6 +217,31 @@
                     :valid  true
                     :label  {:fi "ulkokenttä", :sv ""}}}
            initial-answers))))
+
+(defn check-language-and-validity [initial-answers, lang, valid]
+  (is (= {:language {:value  lang
+                     :values {:value lang :valid valid}
+                     :valid  valid
+                     :label  {:fi "kieli", :sv ""}}}
+         initial-answers)))
+
+(deftest default-language-finnish-for-finnish-form
+  (let [form (form-with-language :fi)
+        flattened-form (util/flatten-form-fields (:content form))
+        initial-answers (create-initial-answers flattened-form nil (:selected-language form))]
+    (check-language-and-validity initial-answers "FI" true)))
+
+(deftest default-language-swedish-for-swedish-form
+  (let [form (form-with-language :sv)
+        flattened-form (util/flatten-form-fields (:content form))
+        initial-answers (create-initial-answers flattened-form nil (:selected-language form))]
+    (check-language-and-validity initial-answers "SV" true)))
+
+(deftest default-language-empty-for-english-form
+  (let [form (form-with-language :en)
+        flattened-form (util/flatten-form-fields (:content form))
+        initial-answers (create-initial-answers flattened-form nil (:selected-language form))]
+    (check-language-and-validity initial-answers "" false)))
 
 (deftest answers->valid-status-gives-false-when-one-answer-is-not-valid
   (is (= {:invalid-fields '({:key :one :label {:fi "invaliidi"}})}


### PR DESCRIPTION
Default language (äidinkieli) should follow form language selection: fi -> fi, sv -> sv, en -> empty.