### PR TITLE
 Disallow comma in e-mail address validation

### DIFF
--- a/spec/ataru/email_spec.clj
+++ b/spec/ataru/email_spec.clj
@@ -1,0 +1,29 @@
+(ns ataru.email-spec
+  (:require [ataru.email :as email]
+            [speclj.core :refer :all]))
+
+(describe "ataru.email/email?"
+  (tags :unit)
+
+  (def email-list
+    [["franksmith@example.com" true]
+     ["frank.smith@example.com" true]
+     ["frank.smith+tag@example.com" true]
+     ["frank.smith.lloyd@example.com" true]
+     ["franksmith@example.domain.com" true]
+     ["frank-smith@example.com" true]
+     ["frank_smith@example.com" true]
+     ["franksmith@example-domain.com" true]
+     ["smith,frank@example.com" false]
+     ["frank smith@example.com" false]
+     ["frank@smith+tag@example.com" false]
+     ["franksmith@example,com" false]
+     ["franksmith@example domain.com" false]
+     ["franksmith@äää.com" false]
+     ["äää@example.com" false]
+     [nil false]])
+
+  (doall
+  (for [[email expected] email-list]
+    (it (str "should validate email " email " as " expected)
+      (should= expected (email/email? email))))))

--- a/src/cljc/ataru/email.cljc
+++ b/src/cljc/ataru/email.cljc
@@ -1,6 +1,6 @@
 (ns ataru.email)
 
-(def ^:private email-pattern #"^[^\s@]+@(([a-zA-Z\-0-9])+\.)+([a-zA-Z\-0-9]){2,}$")
+(def ^:private email-pattern #"^[^\s,@]+@(([a-zA-Z\-0-9])+\.)+([a-zA-Z\-0-9]){2,}$")
 (def ^:private invalid-email-pattern #".*([^\x00-\x7F]|%0[aA]).")
 
 (defn email?


### PR DESCRIPTION
Disallow comma in the local part of the e-mail, because people often typo that and fail to get e-mail. The domain part already has tighter validation so that doesn't need to be changed.

The e-mail validation is quite relaxed in general, so it still allows a lot of characters not allowed in RFC. We decided to go with an incremental / micro change, and perhaps rewrite validation or use a validation library later.