### PR TITLE
OY-3070 Synthetic applications to ataru

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ npm-debug.log*
 .clj-kondo/.cache
 .java
 .lsp
-.calva
+.calva/
 /test-results/
 /playwright-report/
 /blob-report/

--- a/resources/sql/form-queries.sql
+++ b/resources/sql/form-queries.sql
@@ -74,6 +74,7 @@ SELECT
   f.deleted,
   f.organization_oid,
   f.locked,
+  f.locked_by as locked_by_oid,
   f.properties,
   (CASE WHEN f.locked_by IS NULL THEN NULL ELSE CONCAT(first_name, ' ', last_name) END) as locked_by,
   (SELECT count(*)

--- a/spec/ataru/fixtures/form.clj
+++ b/spec/ataru/fixtures/form.clj
@@ -275,3 +275,45 @@
                  :metadata   metadata
                  :fieldType  "attachment"
                  :label      {:fi "Liite ilman vastausta"}}]})
+
+(def synthetic-application-test-form
+  {:id         808808
+   :key        "synthetic-application-test-form"
+   :name       {:fi "Synthetic application test form"}
+   :locked     nil
+   :locked-by  nil
+   :created-by "1.2.246.562.11.11111111111"
+   :organization-oid "1.2.246.562.10.0439845"
+   :content    [(component/hakukohteet)
+                (person-info-module/person-info-module)
+                {:id "secondary-completed-base-education"
+                 :metadata metadata
+                 :label {:en "Have you completed general upper secondary education or a vocational qualification?"
+                         :fi "Oletko suorittanut lukion/ylioppilastutkinnon tai ammatillisen tutkinnon?"
+                         :sv "Har du avlagt gymnasiet/studentexamen eller yrkesinriktad examen?"}
+                 :options [{:label {:en "Yes" :fi "Kyllä" :sv "Ja"}
+                            :value "0"
+                            :followups [{:id "secondary-completed-base-education–country"
+                                         :metadata metadata
+                                         :label {:en "Country of completion" :fi "Suoritusmaa" :sv "Land där examen är avlagd"}
+                                         :fieldType "dropdown"
+                                         :fieldClass "formField"
+                                         :validators ["required"],
+                                         :koodisto-source {:uri "maatjavaltiot2" :title "Maat ja valtiot" :version 2 :allow-invalid? true}}]}
+                           {:label {:en "No" :fi "En" :sv "Nej"}
+                            :value "1"}],
+                 :fieldType "singleChoice"
+                 :fieldClass "formField"
+                 :validators ["required"]}
+                {:id "asiointikieli"
+                 :metadata metadata
+                 :label {:en "Contact language" :fi "Asiointikieli" :sv "Ärendespråk"}
+                 :options [{:label {:en "Finnish" :fi "Suomi" :sv "Finska"}
+                            :value "1"}
+                           {:label {:en "Swedish" :fi "Ruotsi" :sv "Svenska"}
+                            :value "2"}
+                           {:label {:en "English" :fi "Englanti" :sv "Engelska"}
+                            :value "3"}],
+                 :fieldType "dropdown"
+                 :fieldClass "formField"
+                 :validators ["required"]}]})

--- a/spec/ataru/fixtures/synthetic_application.clj
+++ b/spec/ataru/fixtures/synthetic_application.clj
@@ -1,0 +1,84 @@
+(ns ataru.fixtures.synthetic-application)
+
+(def synthetic-application-basic
+  {:hakuOid          "1.2.246.562.29.93102260101"
+   :hakukohdeOid     "1.2.246.562.20.49028196522"
+   :sukunimi         "Ankka"
+   :etunimi          "Aku Fauntleroy"
+   :kutsumanimi      "Aku"
+   :kansalaisuus     "246"
+   :syntymaAika      nil
+   :syntymapaikka    nil
+   :henkilotunnus    "010105A923H"
+   :sukupuoli        nil
+   :passinNumero     nil
+   :idTunnus         nil
+   :sahkoposti       "aku.ankka@example.com"
+   :puhelinnumero    "050123"
+   :asuinmaa         "246"
+   :osoite           "Paratiisitie 13"
+   :postinumero      "00013"
+   :postitoimipaikka "Ankkalinna"
+   :kotikunta        "273"
+   :kaupunkiJaMaa    nil
+   :aidinkieli       "FI"
+   :asiointikieli    "1"
+   :toisenAsteenSuoritus "1"
+   :toisenAsteenSuoritusmaa nil
+   })
+
+; Mock ohjausparametrit service returns false / empty synthetic application data with this haku OID
+(def synthetic-application-with-disabled-haku
+  (merge synthetic-application-basic {:hakuOid "1.2.246.562.29.12345678910"}))
+
+(def synthetic-application-foreign
+  {:hakuOid          "1.2.246.562.29.93102260101"
+   :hakukohdeOid     "1.2.246.562.20.49028196522"
+   :sukunimi         "Duck"
+   :etunimi          "Donald Fauntleroy"
+   :kutsumanimi      "Donald"
+   :kansalaisuus     "840"
+   :syntymaAika      "1.1.2001"
+   :syntymapaikka    "Duckburg, USA"
+   :henkilotunnus    nil
+   :sukupuoli        "1"
+   :passinNumero     "1234"
+   :idTunnus         "333"
+   :sahkoposti       "donald.duck@example.com"
+   :puhelinnumero    "050123"
+   :asuinmaa         "840"
+   :osoite           "1313 Webfoot Street"
+   :postinumero      "00013"
+   :postitoimipaikka nil
+   :kotikunta        nil
+   :kaupunkiJaMaa    "Duckburg, USA"
+   :aidinkieli       "EN"
+   :asiointikieli    "3"
+   :toisenAsteenSuoritus "0"
+   :toisenAsteenSuoritusmaa "840"})
+
+(def synthetic-application-malformed
+  {:hakuOid          "1.2.246.562.29.93102260101"
+   :hakukohdeOid     "1.2.246.562.20.49028196522"
+   :sukunimi         "Duck"
+   :etunimi          "Donald Fauntleroy"
+   :kutsumanimi      "Donald"
+   :kansalaisuus     "840"
+   :syntymaAika      nil
+   :syntymapaikka    "Duckburg, USA"
+   :henkilotunnus    nil
+   :sukupuoli        "1"
+   :passinNumero     "1234"
+   :idTunnus         "333"
+   :sahkoposti       "donald.duck@example.com"
+   :puhelinnumero    "050123"
+   :asuinmaa         "840"
+   :osoite           "1313 Webfoot Street"
+   :postinumero      "00013"
+   :postitoimipaikka nil
+   :kotikunta        nil
+   :kaupunkiJaMaa    "Duckburg, USA"
+   :aidinkieli       "EN"
+   :asiointikieli    "3"
+   :toisenAsteenSuoritus "0"
+   :toisenAsteenSuoritusmaa "840"})

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -58,26 +58,26 @@
 
 (def handler
   (let [form-by-id-cache                     (reify cache-service/Cache
-                                               (get-from [this key]
+                                               (get-from [_ key]
                                                  (form-store/fetch-by-id (Integer/valueOf key)))
-                                               (get-many-from [this keys])
-                                               (remove-from [this key])
-                                               (clear-all [this]))
+                                               (get-many-from [_ _])
+                                               (remove-from [_ _])
+                                               (clear-all [_]))
         tarjonta-service                     (tarjonta-service/new-tarjonta-service)
         organization-service                 (organization-service/new-organization-service)
         ohjausparametrit-service             (ohjausparametrit-service/new-ohjausparametrit-service)
         application-service                  (common-application-service/new-application-service)
         audit-logger                         (audit-log/new-dummy-audit-logger)
         koodisto-cache                       (reify cache-service/Cache
-                                               (get-from [this key])
-                                               (get-many-from [this keys])
-                                               (remove-from [this key])
-                                               (clear-all [this]))
+                                               (get-from [_ _])
+                                               (get-many-from [_ _])
+                                               (remove-from [_ _])
+                                               (clear-all [_]))
         hakukohderyhma-settings-cache         (reify cache-service/Cache
-                                               (get-from [this key])
-                                               (get-many-from [this keys])
-                                               (remove-from [this key])
-                                               (clear-all [this]))
+                                               (get-from [_ _])
+                                               (get-many-from [_ _])
+                                               (remove-from [_ _])
+                                               (clear-all [_]))
         form-by-haku-oid-str-cache-loader    (hakija-form-service/map->FormByHakuOidStrCacheLoader
                                               {:form-by-id-cache         form-by-id-cache
                                                :koodisto-cache           koodisto-cache
@@ -93,11 +93,11 @@
         (assoc :application-service application-service)
         (assoc :form-by-id-cache form-by-id-cache)
         (assoc :form-by-haku-oid-str-cache (reify cache-service/Cache
-                                             (get-from [this key]
+                                             (get-from [_ key]
                                                (.load form-by-haku-oid-str-cache-loader key))
-                                             (get-many-from [this keys])
-                                             (remove-from [this key])
-                                             (clear-all [this])))
+                                             (get-many-from [_ _])
+                                             (remove-from [_ _])
+                                             (clear-all [_])))
         (assoc :koodisto-cache koodisto-cache)
         (assoc :audit-logger audit-logger)
         .start

--- a/spec/ataru/test_utils.clj
+++ b/spec/ataru/test_utils.clj
@@ -14,14 +14,16 @@
 
 (defn login
   "Generate ring-session=abcdefgh cookie"
-  [virkailija-routes]
-  (-> (mock/request :get "/lomake-editori/auth/cas")
-      virkailija-routes
-      :headers
-      (get "Set-Cookie")
-      first
-      (clj-string/split #";")
-      first))
+  ([virkailija-routes]
+   (login virkailija-routes nil))
+  ([virkailija-routes ticket]
+   (-> (mock/request :get (str "/lomake-editori/auth/cas?ticket=" ticket))
+       virkailija-routes
+       :headers
+       (get "Set-Cookie")
+       first
+       (clj-string/split #";")
+       first)))
 
 (defn should-have-header
   [header expected-val resp]

--- a/src/clj/ataru/applications/synthetic_application_util.clj
+++ b/src/clj/ataru/applications/synthetic_application_util.clj
@@ -4,8 +4,8 @@
 (defn synthetic-application->application
   [synthetic form-id]
   (let [ssn (:henkilotunnus synthetic)
-        birth-date (or (seq (:syntymaAika synthetic)) (ssn/ssn->birth-date ssn))
-        gender (or (seq (:sukupuoli synthetic)) (ssn/ssn->gender ssn))
+        birth-date (or (not-empty (:syntymaAika synthetic)) (ssn/ssn->birth-date ssn))
+        gender (or (not-empty (:sukupuoli synthetic)) (ssn/ssn->gender ssn))
         birthplace (when (empty? ssn) (:syntymapaikka synthetic)) ; Doesn't pass validation together with Finnish SSN, so silently remove.
         answers [{:key "hakukohteet" :value [(:hakukohdeOid synthetic)] :fieldType "hakukohteet" :label {:fi "Hakukohteet"}}
                  {:key "first-name" :value (:etunimi synthetic) :fieldType "textField" :label {:fi "Etunimet"}}

--- a/src/clj/ataru/applications/synthetic_application_util.clj
+++ b/src/clj/ataru/applications/synthetic_application_util.clj
@@ -4,8 +4,8 @@
 (defn synthetic-application->application
   [synthetic form-id]
   (let [ssn (:henkilotunnus synthetic)
-        birth-date (or (:syntymaAika synthetic) (ssn/ssn->birth-date ssn))
-        gender (or (:sukupuoli synthetic) (ssn/ssn->gender ssn))
+        birth-date (or (seq (:syntymaAika synthetic)) (ssn/ssn->birth-date ssn))
+        gender (or (seq (:sukupuoli synthetic)) (ssn/ssn->gender ssn))
         birthplace (when (empty? ssn) (:syntymapaikka synthetic)) ; Doesn't pass validation together with Finnish SSN, so silently remove.
         answers [{:key "hakukohteet" :value [(:hakukohdeOid synthetic)] :fieldType "hakukohteet" :label {:fi "Hakukohteet"}}
                  {:key "first-name" :value (:etunimi synthetic) :fieldType "textField" :label {:fi "Etunimet"}}

--- a/src/clj/ataru/applications/synthetic_application_util.clj
+++ b/src/clj/ataru/applications/synthetic_application_util.clj
@@ -1,0 +1,37 @@
+(ns ataru.applications.synthetic-application-util
+  (:require [ataru.ssn :as ssn]))
+
+(defn synthetic-application->application
+  [synthetic form-id]
+  (let [ssn (:henkilotunnus synthetic)
+        birth-date (or (:syntymaAika synthetic) (ssn/ssn->birth-date ssn))
+        gender (or (:sukupuoli synthetic) (ssn/ssn->gender ssn))
+        birthplace (when (empty? ssn) (:syntymapaikka synthetic)) ; Doesn't pass validation together with Finnish SSN, so silently remove.
+        answers [{:key "hakukohteet" :value [(:hakukohdeOid synthetic)] :fieldType "hakukohteet" :label {:fi "Hakukohteet"}}
+                 {:key "first-name" :value (:etunimi synthetic) :fieldType "textField" :label {:fi "Etunimet"}}
+                 {:key "preferred-name" :value (:kutsumanimi synthetic) :fieldType "textField" :label {:fi "Kutsumanimi"}}
+                 {:key "last-name" :value (:sukunimi synthetic) :fieldType "textField" :label {:fi "Sukunimi"}}
+                 {:key "phone" :value (:puhelinnumero synthetic) :fieldType "textField"  :label {:fi "Matkapuhelin"}}
+                 {:key "email" :value (:sahkoposti synthetic) :fieldType "textField" :label {:fi "Sähköpostiosoite"}}
+                 {:key "ssn" :value (:henkilotunnus synthetic) :fieldType "textField" :label {:fi "Henkilötunnus"}}
+                 {:key "nationality" :value [[(:kansalaisuus synthetic)]] :fieldType "dropdown" :label {:fi "Kansalaisuus"}}
+                 {:key "gender" :value gender :fieldType "dropdown" :label {:fi "Sukupuoli"}}
+                 {:key "birth-date" :value birth-date :fieldType "textField" :label {:fi "Syntymäaika"}}
+                 {:key "birthplace" :value birthplace :fieldType "textField" :label {:fi "Syntymäpaikka ja -maa"}}
+                 {:key "passport-number" :value (:passinNumero synthetic) :fieldType "textField" :label {:fi "Passin numero"}}
+                 {:key "national-id-number" :value (:idTunnus synthetic) :fieldType "textField" :label {:fi "Kansallinen ID-tunnus"}}
+                 {:key "country-of-residence" :value (:asuinmaa synthetic) :fieldType "dropdown" :label {:fi "Asuinmaa"}}
+                 {:key "address" :value (:osoite synthetic) :fieldType "textField" :label {:fi "Katuosoite"}}
+                 {:key "postal-code" :value (:postinumero synthetic) :fieldType "textField" :label {:fi "Postinumero"}}
+                 {:key "postal-office" :value (:postitoimipaikka synthetic) :fieldType "textField" :label {:fi "Postitoimipaikka"}}
+                 {:key "home-town" :value (:kotikunta synthetic) :fieldType "dropdown" :label {:fi "Kotikunta"}}
+                 {:key "city" :value (:kaupunkiJaMaa synthetic) :fieldType "textField" :label {:fi "Kaupunki ja maa"}}
+                 {:key "language" :value (:aidinkieli synthetic) :fieldType "dropdown" :label {:fi "Äidinkieli"}}
+                 {:key "asiointikieli" :value (:asiointikieli synthetic) :fieldType "dropdown" :label {:fi "Asiointikieli"}}
+                 {:key "secondary-completed-base-education" :value (:toisenAsteenSuoritus synthetic) :fieldType "singleChoice" :label {:fi "Oletko suorittanut lukion/ylioppilastutkinnon tai ammatillisen tutkinnon?"}}
+                 {:key "secondary-completed-base-education–country" :value (:toisenAsteenSuoritusmaa synthetic) :fieldType "dropdown" :label {:fi "Suoritusmaa"}}]]
+        {:haku (:hakuOid synthetic)
+         :hakukohde [(:hakukohdeOid synthetic)]
+         :form form-id
+         :lang "fi"
+         :answers (remove #(empty? (:value %)) answers)}))

--- a/src/clj/ataru/hakija/hakija_form_service.clj
+++ b/src/clj/ataru/hakija/hakija_form_service.clj
@@ -356,6 +356,10 @@
                                      roles
                                      use-toisen-asteen-yhteishaku-restrictions?))))
 
+(defn latest-form-id-by-key
+  [key]
+  (form-store/latest-id-by-key key))
+
 (defn- form-by-haku-oid-cache-key
   [haku-oid roles]
   (apply str

--- a/src/clj/ataru/kayttooikeus_service/kayttooikeus_service.clj
+++ b/src/clj/ataru/kayttooikeus_service/kayttooikeus_service.clj
@@ -70,7 +70,14 @@
                                        {:palvelu "ATARU_HAKEMUS"
                                         :oikeus  "CRUD"}
                                        {:palvelu "ATARU_HAKEMUS"
-                                        :oikeus  "opinto-ohjaaja"}]}]}})
+                                        :oikeus  "opinto-ohjaaja"}]}]}
+   "1.2.246.562.11.44444444444"
+   {:oidHenkilo    "1.2.246.562.11.11111111014"
+    :organisaatiot [{:organisaatioOid "1.2.246.562.10.00000000001"
+                     :kayttooikeudet  [{:palvelu "ATARU_EDITORI"
+                                        :oikeus  "CRUD"}
+                                       {:palvelu "ATARU_HAKEMUS"
+                                        :oikeus  "CRUD"}]}]}})
 
 (defrecord FakeKayttooikeusService []
   KayttooikeusService

--- a/src/clj/ataru/ohjausparametrit/mock_ohjausparametrit_service.clj
+++ b/src/clj/ataru/ohjausparametrit/mock_ohjausparametrit_service.clj
@@ -4,7 +4,7 @@
 (defrecord MockOhjausparametritService []
   OhjausparametritService
 
-  (get-parametri [_ _]
+  (get-parametri [_ haku-oid]
     {:PH_SS          {:dateStart 1506920400000, :dateEnd nil},
      :PH_OPVP        {:date nil},
      :PH_HKMT        {:date nil},
@@ -20,5 +20,7 @@
      :target         "1.2.246.562.29.75477542726",
      :PH_VTJH        {:dateStart nil, :dateEnd nil},
      :PH_IP          {:date nil},
+     :synteettisetHakemukset (not (= haku-oid "1.2.246.562.29.12345678910")),
+     :synteettisetLomakeavain (if (= haku-oid "1.2.246.562.29.12345678910") "" "synthetic-application-test-form"),
      :__modifiedBy__ "1.2.246.562.24.64667668834",
      :__modified__   1508400869203}))

--- a/src/clj/ataru/organization_service/organization_service.clj
+++ b/src/clj/ataru/organization_service/organization_service.clj
@@ -68,7 +68,8 @@
    "1.2.246.562.28.2"                    {:name {:fi "Test group 2"}, :oid "1.2.246.562.28.2" :type :group}
    "1.2.246.562.10.10826252480"          {:name {:fi "Testiorganisaatio"}, :oid "1.2.246.562.10.10826252480" :type :organization}
    "form-access-control-test-oppilaitos" {:name {:fi "Testioppilaitos"}, :oid "form-access-control-test-oppilaitos" :type :organization}
-   "1.2.246.562.10.10826252479"          {:name {:fi "Tarjoajan oppilaitos"} :oid "1.2.246.562.10.10826252479" :type :organization}})
+   "1.2.246.562.10.10826252479"          {:name {:fi "Tarjoajan oppilaitos"} :oid "1.2.246.562.10.10826252479" :type :organization}
+   "1.2.246.562.10.00000000001"          {:name {:fi "Test OPH"}, :oid "1.2.246.562.10.00000000001" :type :organization}})
 
 (defn fake-orgs-by-root-orgs [root-orgs]
   (some->> root-orgs

--- a/src/clj/ataru/person_service/person_integration.clj
+++ b/src/clj/ataru/person_service/person_integration.clj
@@ -66,10 +66,23 @@
       (application-store/add-person-oid application-id oid)
       (log/info "Added person" oid "to application" application-id)
       (start-jobs-for-person job-runner oid)
-      (log/info "Started person info update job for application" application-id))
+      (log/info "Started person info update job for application" application-id)
+      oid)
     (catch IllegalArgumentException e
       (log/error e "Failed to create-or-find person for application"
         application-id))))
+
+(defn upsert-person-synchronized
+  [job-runner person-service application-id]
+  {:pre [(not (nil? application-id))
+         (not (nil? person-service))
+         (not (nil? job-runner))]}
+    (let [application (application-store/get-application application-id)]
+    (if (muu-person-info-module? application)
+      (log/info "Not adding applicant from application"
+                application-id
+                "to oppijanumerorekisteri")
+      (upsert-and-log-person job-runner person-service application-id application))))
 
 (defn upsert-person
   [{:keys [application-id]}

--- a/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
@@ -101,6 +101,10 @@
 
 (def haut
   {:1.2.246.562.29.65950024185               base-haku
+   :1.2.246.562.29.93102260101               (merge
+                                               base-haku
+                                               {:oid "1.2.246.562.29.93102260101"
+                                                :ataruLomakeAvain "synthetic-application-test-form"})
    :haku.oid                                 (merge
                                                base-haku
                                                {:oid           "haku.oid"

--- a/src/clj/ataru/virkailija/authentication/auth_routes.clj
+++ b/src/clj/ataru/virkailija/authentication/auth_routes.clj
@@ -21,6 +21,7 @@
       (let [username      (case ticket
                             "USER-WITH-HAKUKOHDE-ORGANIZATION" "1.2.246.562.11.22222222222"
                             "OPINTO-OHJAAJA" "1.2.246.562.11.33333333333"
+                            "SUPERUSER" "1.2.246.562.11.44444444444"
                             "1.2.246.562.11.11111111111")
             unique-ticket (str (System/currentTimeMillis) "-" (rand-int (Integer/MAX_VALUE)))]
         [username unique-ticket])))

--- a/src/clj/ataru/virkailija/virkailija_application_service.clj
+++ b/src/clj/ataru/virkailija/virkailija_application_service.clj
@@ -1,0 +1,128 @@
+(ns ataru.virkailija.virkailija-application-service 
+  (:require [ataru.applications.application-store :as application-store]
+            [ataru.applications.synthetic-application-util :as synthetic-application-util]
+            [ataru.hakija.hakija-form-service :as hakija-form-service]
+            [ataru.hakija.validator :as validator]
+            [ataru.log.audit-log :as audit-log]
+            [ataru.tarjonta-service.tarjonta-parser :as tarjonta-parser]
+            [ataru.util :as util]
+            [taoensso.timbre :as log]
+            [ataru.person-service.person-integration :as person-integration]
+            [ataru.ohjausparametrit.ohjausparametrit-protocol :as ohjausparametrit]))
+
+(defn- uses-synthetic-applications?
+  [ohjausparametrit-service haku-oid]
+  (get (ohjausparametrit/get-parametri ohjausparametrit-service haku-oid) :synteettisetHakemukset))
+
+(defn- synthetic-application-form-key
+  [ohjausparametrit-service haku-oid]
+  (get (ohjausparametrit/get-parametri ohjausparametrit-service haku-oid) :synteettisetLomakeavain))
+
+
+(defn- store-synthetic-application [{:keys [application form applied-hakukohteet]}
+                                    {:keys [session audit-logger job-runner person-service]}]
+  (let [key-and-id (application-store/add-application application applied-hakukohteet form session audit-logger nil)
+        person-oid (person-integration/upsert-person-synchronized job-runner person-service (:id key-and-id))]
+    (log/info "Stored synthetic application with id" (:id key-and-id) ", oid " (:key key-and-id) " and person oid" person-oid)
+    {:passed? true :hakemusOid (:key key-and-id) :personOid person-oid}))
+
+(defn- validate-synthetic-application [application
+                                       {:keys [form-by-id-cache
+                                               koodisto-cache
+                                               tarjonta-service
+                                               organization-service
+                                               ohjausparametrit-service
+                                               audit-logger
+                                               session]}]
+  (let [tarjonta-info                 (when (:haku application)
+                                        (tarjonta-parser/parse-tarjonta-info-by-haku
+                                         koodisto-cache
+                                         tarjonta-service
+                                         organization-service
+                                         ohjausparametrit-service
+                                         (:haku application)))
+        hakukohteet                   (get-in tarjonta-info [:tarjonta :hakukohteet])
+        applied-hakukohteet           (filter #(contains? (set (:hakukohde application)) (:oid %))
+                                              hakukohteet)
+        applied-hakukohderyhmat       (set (mapcat :hakukohderyhmat applied-hakukohteet))
+        form                          (when (:form application) (hakija-form-service/fetch-form-by-id
+                                                                 (:form application)
+                                                                 [:virkailija]
+                                                                 form-by-id-cache
+                                                                 koodisto-cache
+                                                                 nil
+                                                                 false
+                                                                 {}
+                                                                 false))
+        validation-result             (when form (validator/valid-application?
+                                                  koodisto-cache
+                                                  false ; TODO: has-applied OK?
+                                                  application
+                                                  form
+                                                  applied-hakukohderyhmat
+                                                  true
+                                                  "NEW_APPLICATION_ID"
+                                                  "NEW_APPLICATION_KEY"))
+        result (cond
+                 (and (:haku application)
+                      (not (uses-synthetic-applications? ohjausparametrit-service (:haku application))))
+                 {:passed? false
+                  :failures ["Synthetic applications not enabled for haku"]
+                  :code :internal-server-error}
+
+                 (not (:form application))
+                 {:passed? false
+                  :failures ["Synthetic form key not defined for haku"]
+                  :code :internal-server-error}
+
+                 (not form)
+                 {:passed? false
+                  :failures ["Synthetic form was not found with form key"]
+                  :code :internal-server-error}
+
+                 (and (:haku application)
+                      (empty? (:hakukohde application)))
+                 {:passed? false
+                  :failures ["Hakukohde must be specified"]
+                  :code :internal-server-error}
+
+                 (true? (get-in form [:properties :closed] false))
+                 {:passed? false
+                  :failures ["Form is closed"]
+                  :code :form-closed}
+
+                 (not (:passed? validation-result))
+                 validation-result
+
+                 :else
+                 {:passed? true
+                  :application application
+                  :form form
+                  :applied-hakukohteet applied-hakukohteet})]
+    (if (:passed? result)
+      result
+      (do
+        (audit-log/log audit-logger
+                       {:new       application
+                        :operation audit-log/operation-failed
+                        :session   session
+                        :id        {:email (util/extract-email application)}})
+        (log/warn "Synthetic application failed verification" result)
+        result))))
+
+(defn- convert-synthetic-application
+  [application {:keys [ohjausparametrit-service]}]
+  (let [haku-oid (:hakuOid application)
+        form-id (hakija-form-service/latest-form-id-by-key (synthetic-application-form-key ohjausparametrit-service haku-oid))
+        converted (synthetic-application-util/synthetic-application->application application form-id)]
+    (log/info "Synthetic application submitted and converted" converted)
+    converted))
+
+(defn batch-submit-synthetic-applications
+  [applications data]
+  (let [converted-applications (map #(convert-synthetic-application % data) applications)
+        validation-results     (map #(validate-synthetic-application % data) converted-applications)
+        all-applications-valid (not-any? #(= false (:passed? %)) validation-results)]
+    (if all-applications-valid
+      {:success true :applications (doall (map #(store-synthetic-application % data) validation-results))}
+      {:success false :applications validation-results})))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -87,7 +87,8 @@
             [ataru.person-service.person-service :as person-service]
             [ataru.valintalaskentakoostepalvelu.pohjakoulutus-toinen-aste :as pohjakoulutus-toinen-aste]
             [cuerdas.core :as str]
-            [clj-time.format :as f])
+            [clj-time.format :as f]
+            [ataru.virkailija.virkailija-application-service :as virkailija-application-service])
   (:import java.util.Locale
            java.time.ZonedDateTime
            org.joda.time.DateTime
@@ -222,10 +223,31 @@
                           application-service
                           suoritus-service
                           valinta-laskenta-service
-                          valinta-tulos-service]
+                          valinta-tulos-service
+                          form-by-id-cache]
                    :as   dependencies}]
   (api/context "/api" []
     :tags ["form-api"]
+
+    (api/POST "/synthetic-applications" {session :session}
+      :summary "Store one or more synthetic applications"
+      :body [applications [ataru-schema/SyntheticApplication]]
+      (if (get-in session [:identity :superuser])
+        (let [submit-results (virkailija-application-service/batch-submit-synthetic-applications
+                              applications
+                                {:form-by-id-cache form-by-id-cache
+                                 :koodisto-cache koodisto-cache
+                                 :tarjonta-service tarjonta-service
+                                 :organization-service organization-service
+                                 :ohjausparametrit-service ohjausparametrit-service
+                                 :person-service person-service
+                                 :audit-logger audit-logger
+                                 :job-runner job-runner
+                                 :session session})]
+        (if (:success submit-results)
+          (ok (:applications submit-results))
+          (response/bad-request (:applications submit-results))))
+         (response/unauthorized {})))
 
     (api/GET "/user-info" {session :session}
       (ok {:organizations         (organization-list session)

--- a/src/cljc/ataru/schema/form_element_schema.cljc
+++ b/src/cljc/ataru/schema/form_element_schema.cljc
@@ -9,6 +9,7 @@
                    (s/optional-key :locked)            #?(:clj  (s/maybe DateTime)
                                                           :cljs (s/maybe s/Str))
                    (s/optional-key :locked-by)         (s/maybe s/Str)
+                   (s/optional-key :locked-by-oid)     (s/maybe s/Str)
                    (s/optional-key :languages)         [s/Str]
                    (s/optional-key :key)               s/Str
                    (s/optional-key :created-by)        s/Str

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -935,3 +935,33 @@
    (s/optional-key :suoritusvuosi)        s/Str
    (s/optional-key :lisapistekoulutukset) [s/Keyword]
    (s/optional-key :arvosanat)            [Arvosana]})
+
+(s/defschema SyntheticApplication
+  {(s/optional-key :personOid)      s/Str
+   (s/optional-key :applicationOid) s/Str
+
+   :hakuOid          s/Str
+   :hakukohdeOid     s/Str
+   :sukunimi         s/Str
+   :etunimi          s/Str
+   :kutsumanimi      s/Str
+   :kansalaisuus     s/Str
+   :syntymaAika      (s/maybe s/Str)
+   :syntymapaikka    (s/maybe s/Str)
+   :henkilotunnus    (s/maybe s/Str)
+   :sukupuoli        (s/maybe s/Str)
+   :passinNumero     (s/maybe s/Str)
+   :idTunnus         (s/maybe s/Str)
+   :sahkoposti       s/Str
+   :puhelinnumero    s/Str
+   :asuinmaa         s/Str
+   :osoite           s/Str
+   :postinumero      s/Str
+   :postitoimipaikka (s/maybe s/Str)
+   :kaupunkiJaMaa    (s/maybe s/Str)
+   :kotikunta        (s/maybe s/Str)
+   :aidinkieli       s/Str
+   :asiointikieli    s/Str
+
+   :toisenAsteenSuoritus    s/Str
+   :toisenAsteenSuoritusmaa (s/maybe s/Str)})

--- a/src/cljc/ataru/ssn.cljc
+++ b/src/cljc/ataru/ssn.cljc
@@ -83,6 +83,17 @@
                        (= century-sign "+") 18)]
     (str day "." month "." century year)))
 
+;; based on koodisto-values
+(defn- parse-gender-from-ssn
+  [ssn]
+  (if (zero? (mod (->int (subs ssn 9 10)) 2))
+    "2"
+    "1"))
+
 (defn ssn->birth-date [ssn]
   (when-not (string/blank? ssn)
     (parse-birth-date-from-ssn ssn)))
+
+(defn ssn->gender [ssn]
+  (when-not (string/blank? ssn)
+    (parse-gender-from-ssn ssn)))


### PR DESCRIPTION
Move synthetic / external applications from haku-app to ataru.

Rolling TODO:

- [x] Users should be able to upload synthetic applications only to admissions enabled via ohjausparametrit
- [x] Admissions accepting synthetic applications should use a form specified in ohjausparametrit
- [x] Special synthetic form should be able to be locked from editing on a database level (similar to current locking)
- [x] Move logic to virkailija side
- [x] Restrict use to superusers only
- [x] Synchronized person creation at application creation time
- [x] Allow applications to be created in batch with one POST
- [x] Error handling: should we validate all applications in POST batch first, or accept partial success? (Now validated before creating anything)
- [x] Error handling: how to handle cases when application save OK, person creation not OK (Decision: let's just return the information that a person needs to be created separately)

Are more thorough tests needed?