### PR TITLE
OY-4492 mark demo overlay as alert dialog to fix focus issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ npm-debug.log*
 .java
 .java-version
 .lsp
+.calva

--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -2104,6 +2104,9 @@ th.application__readonly-adjacent--header {
       .primary-button;
       margin-top: 1rem;
       padding: 0.6rem 2rem;
+      &:focus-visible {
+        outline: 2px solid @primary-green-700;
+      }
     }
   }
 

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -357,16 +357,23 @@
           (if (and @demo-requested? @demo-open?)
             [:div.application__notification-overlay
              [:div.application__notification-container
+             {:role "alertdialog"
+              :aria-modal "true"
+              :aria-live "polite"}
               [:h1.application__notification-title
                (translations/get-hakija-translation :demo-notification-title (keyword @demo-lang))]
               [:p (translations/get-hakija-translation :demo-notification (keyword @demo-lang))]
               [:button.application__overlay-button.application__overlay-button--enabled.application__notification-button
                {:on-click     #(dispatch [:application/close-demo-modal])
-                :data-test-id "dismiss-demo-notification-button"}
+                :data-test-id "dismiss-demo-notification-button"
+                :tab-index    "1"}
                (translations/get-hakija-translation :dismiss-demo-notification (keyword @demo-lang))]]]
 
             [:div.application__notification-overlay
              [:div.application__notification-container
+             {:role "alertdialog"
+              :aria-modal "true"
+              :aria-live "polite"}
               [:h1.application__notification-title
                (translations/get-hakija-translation :demo-closed-title (keyword @demo-lang))]
               [:p text1

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -103,12 +103,16 @@
         delivery-status        (subscribe [:state-query [:application :secret-delivery-status]])
         lang                   (subscribe [:application/form-language])
         secret-link-valid-days (config/get-public-config [:secret-link-valid-days])
-        demo?                  (subscribe [:application/demo?])]
+        demo?                  (subscribe [:application/demo?])
+        demo-modal-open?       (subscribe [:application/demo-modal-open?])]
     (fn []
       (let [root-element (if @demo?
                            :div.application__form-content-area.application__form-content-area--demo
                            :div.application__form-content-area)]
         [root-element
+         (when @demo-modal-open?
+           {:visibility "hidden"
+            :display "none"})
          (when-not (or @load-failure?
                      @form)
            [:div.application__form-loading-spinner
@@ -128,9 +132,10 @@
             [:p (translations/get-hakija-translation :expired-secret-contact @lang)]])
 
          ^{:key (:id @form)}
-         [application-header]
+         (when (not @demo-modal-open?)
+           [application-header])
 
-         (when (or @can-apply? @editing?)
+         (when (and (not @demo-modal-open?) (or @can-apply? @editing?))
            ^{:key "form-fields"}
            [render-fields @form])]))))
 
@@ -359,14 +364,18 @@
              [:div.application__notification-container
              {:role "alertdialog"
               :aria-modal "true"
-              :aria-live "polite"}
+              :aria-live "polite"
+              :aria-labelledby "demo-notification-title demo-notification-p"}
               [:h1.application__notification-title
+               {:id "demo-notification-title"}
                (translations/get-hakija-translation :demo-notification-title (keyword @demo-lang))]
-              [:p (translations/get-hakija-translation :demo-notification (keyword @demo-lang))]
+              [:p
+               {:id "demo-notification-p"}
+               (translations/get-hakija-translation :demo-notification (keyword @demo-lang))]
               [:button.application__overlay-button.application__overlay-button--enabled.application__notification-button
-               {:on-click     #(dispatch [:application/close-demo-modal])
-                :data-test-id "dismiss-demo-notification-button"
-                :tab-index    "1"}
+               {:on-click        #(dispatch [:application/close-demo-modal])
+                :data-test-id    "dismiss-demo-notification-button"
+                :tab-index       "1"}
                (translations/get-hakija-translation :dismiss-demo-notification (keyword @demo-lang))]]]
 
             [:div.application__notification-overlay


### PR DESCRIPTION
Make demo overlay get focus priority, so the user can close it easily with keyboard navigation. Before this change, all the numerous form elements hidden behind the modal were first in focus order.

~~(Note: turns out actively hiding the parent container(s) with visibility / display / aria-hidden does not remove the focusable elements from accessibility tree, they would probably need to be temporarily "deactivated" recursively. So now they still exist, they're now just after the modal in tab order.)~~

The initial trick didn't work for the screen reader, so now the application is conditionally rendered only when demo dialog is not on the screen.