### PR TITLE
OY-4562 Use "form-allows-ht" parameter to display correct e-mail previews

### DIFF
--- a/src/clj/ataru/email/application_email.clj
+++ b/src/clj/ataru/email/application_email.clj
@@ -118,7 +118,7 @@
 
 
 (defn preview-submit-email
-  [lang subject content content-ending signature]
+  [lang subject content content-ending signature form-allows-ht?]
   {:from           email-util/from-address
    :subject        subject
    :content        content
@@ -135,7 +135,9 @@
                                                                          {:label "Liite 3"
                                                                           :deadline ""}]
                                             :application-url "https://opintopolku.fi/hakemus/01234567890abcdefghijklmn"
-                                            :application-url-text (get-in email-link-section-texts [:default (keyword lang)])
+                                            :application-url-text (if form-allows-ht?
+                                                                    (get-in email-link-section-texts [:default (keyword lang)])
+                                                                    nil)
                                             :application-oid "1.2.246.562.11.00000000000000000000"
                                             :content         (->safe-html content)
                                             :content-ending  (->safe-html content-ending)
@@ -145,7 +147,7 @@
   [form-key form-allows-ht?]
   (as-> (email-store/get-email-templates form-key) x
         (add-blank-templates x form-allows-ht?)
-        (map #(preview-submit-email (:lang %) (:subject %) (:content %) (:content-ending %) (:signature %)) x)))
+        (map #(preview-submit-email (:lang %) (:subject %) (:content %) (:content-ending %) (:signature %) form-allows-ht?) x)))
 
 (defn- attachment-with-deadline [_ lang field]
   (let [attachment {:label (-> field

--- a/src/clj/ataru/email/application_email.clj
+++ b/src/clj/ataru/email/application_email.clj
@@ -135,9 +135,8 @@
                                                                          {:label "Liite 3"
                                                                           :deadline ""}]
                                             :application-url "https://opintopolku.fi/hakemus/01234567890abcdefghijklmn"
-                                            :application-url-text (if form-allows-ht?
-                                                                    (get-in email-link-section-texts [:default (keyword lang)])
-                                                                    nil)
+                                            :application-url-text (when form-allows-ht?
+                                                                    (get-in email-link-section-texts [:default (keyword lang)]))
                                             :application-oid "1.2.246.562.11.00000000000000000000"
                                             :content         (->safe-html content)
                                             :content-ending  (->safe-html content-ending)

--- a/src/clj/ataru/email/application_email_jobs.clj
+++ b/src/clj/ataru/email/application_email_jobs.clj
@@ -17,14 +17,14 @@
   [form-key form-allows-ht?]
   (application-email/get-email-templates form-key form-allows-ht?))
 
-(defn preview-submit-emails [previews]
+(defn preview-submit-emails [previews form-allows-ht]
   (map
    #(let [lang           (:lang %)
           subject        (:subject %)
           content        (:content %)
           content-ending (:content-ending %)
           signature      (:signature %)]
-      (application-email/preview-submit-email lang subject content content-ending signature)) previews))
+      (application-email/preview-submit-email lang subject content content-ending signature form-allows-ht)) previews))
 
 (defn start-email-job [job-runner email]
   (let [job-id (jdbc/with-db-transaction [connection {:datasource (db/get-datasource :db)}]
@@ -71,7 +71,7 @@
        (start-email-job job-runner email)))))
 
 (defn store-email-templates
-  [form-key session templates]
+  [form-key session templates form-allows-ht?]
   (let [stored-templates (mapv #(email-store/create-or-update-email-template
                                   form-key
                                   (:lang %)
@@ -81,4 +81,4 @@
                                   (:content-ending %)
                                   (:signature %))
                            templates)]
-    (map #(application-email/preview-submit-email (:lang %) (:subject %) (:content %) (:content_ending %) (:signature %)) stored-templates)))
+    (map #(application-email/preview-submit-email (:lang %) (:subject %) (:content %) (:content_ending %) (:signature %) form-allows-ht?) stored-templates)))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -310,13 +310,15 @@
 
     (api/POST "/email-template/:form-key/previews" []
       :path-params [form-key :- s/Str]
+      :query-params [{form-allows-ht :- s/Bool false}]
       :body [body {:contents [ataru-schema/EmailTemplate]}]
-      (ok (email/preview-submit-emails (:contents body))))
+      (ok (email/preview-submit-emails (:contents body) form-allows-ht)))
 
     (api/POST "/email-templates/:form-key" {session :session}
       :path-params [form-key :- s/Str]
+      :query-params [{form-allows-ht :- s/Bool false}]
       :body [body {:contents [ataru-schema/EmailTemplate]}]
-      (ok (email/store-email-templates form-key session (:contents body))))
+      (ok (email/store-email-templates form-key session (:contents body) form-allows-ht)))
 
     (api/GET "/email-templates/:form-key" []
       :path-params [form-key :- s/Str]

--- a/src/cljs/ataru/virkailija/editor/handlers.cljs
+++ b/src/cljs/ataru/virkailija/editor/handlers.cljs
@@ -1358,11 +1358,12 @@
   :editor/update-email-preview-immediately
   (fn [{db :db} [_]]
     (let [form-key              (get-in db [:editor :selected-form-key])
+          form-allows-ht?       (boolean (get-in db [:editor :forms form-key :properties :allow-hakeminen-tunnistautuneena]))
           contents              (preview-map-to-list (get-in db [:editor :email-template form-key]))]
       {:http {:method              :post
               :params              {:contents contents}
               :handler-args        {:form-key form-key}
-              :path                (str "/lomake-editori/api/email-template/" form-key "/previews")
+              :path                (str "/lomake-editori/api/email-template/" form-key "/previews?form-allows-ht=" form-allows-ht?)
               :handler-or-dispatch :editor/update-email-template-preview}})))
 
 (reg-event-fx
@@ -1392,11 +1393,12 @@
   :editor/save-email-template
   (fn [{db :db} [_]]
     (let [contents (preview-map-to-list @(subscribe [:editor/email-template]))
-          form-key (get-in db [:editor :selected-form-key])]
+          form-key (get-in db [:editor :selected-form-key])
+          form-allows-ht? (boolean (get-in db [:editor :forms form-key :properties :allow-hakeminen-tunnistautuneena]))]
       {:http {:method              :post
               :params              {:contents contents}
               :handler-args        {:form-key form-key}
-              :path                (str "/lomake-editori/api/email-templates/" form-key)
+              :path                (str "/lomake-editori/api/email-templates/" form-key "?form-allows-ht=" form-allows-ht?)
               :handler-or-dispatch :editor/update-saved-email-template-preview}})))
 
 (reg-event-fx


### PR DESCRIPTION
Make e-mail previews follow form "hakeminen tunnistautuneena" setting.