### PR TITLE
OY-4456 disable messaging buttons when user has no edit rights

### DIFF
--- a/resources/less/virkailija-application.less
+++ b/resources/less/virkailija-application.less
@@ -1399,6 +1399,10 @@ i.arkistoitu {
 .application-handling__button--disabled {
   cursor: auto;
   background-color: @section-gray-border;
+
+  &:hover {
+    background-color: @section-gray-border;
+  }
 }
 
 .application-handling__button:not(:last-child) {

--- a/src/cljs/ataru/virkailija/application/application_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/application_subs.cljs
@@ -897,9 +897,9 @@
  :application/mass-information-request-allowed?
  (fn [_ _]
    [(re-frame/subscribe [:editor/opinto-ohjaaja-or-admin?])
-    (re-frame/subscribe [:editor/editor-rights-for-selected-organization?])])
- (fn [[opinto-ohjaaja-or-admin? editor-rights-for-selected-organization?] _]
-   (or opinto-ohjaaja-or-admin? editor-rights-for-selected-organization?)))
+    (re-frame/subscribe [:editor/editor-rights-for-any-organization?])])
+ (fn [[opinto-ohjaaja-or-admin? editor-rights-for-any-organization?] _]
+   (or opinto-ohjaaja-or-admin? editor-rights-for-any-organization?)))
 
 (re-frame/reg-sub
   :application/review-field-editable?

--- a/src/cljs/ataru/virkailija/application/application_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/application_subs.cljs
@@ -897,9 +897,9 @@
  :application/mass-information-request-allowed?
  (fn [_ _]
    [(re-frame/subscribe [:editor/opinto-ohjaaja-or-admin?])
-    (re-frame/subscribe [:editor/editor-rights-for-any-organization?])])
- (fn [[opinto-ohjaaja-or-admin? editor-rights-for-any-organization?] _]
-   (or opinto-ohjaaja-or-admin? editor-rights-for-any-organization?)))
+    (re-frame/subscribe [:editor/edit-rights-for-any-organization?])])
+ (fn [[opinto-ohjaaja-or-admin? edit-rights-for-any-organization?] _]
+   (or opinto-ohjaaja-or-admin? edit-rights-for-any-organization?)))
 
 (re-frame/reg-sub
   :application/review-field-editable?

--- a/src/cljs/ataru/virkailija/application/application_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/application_subs.cljs
@@ -886,6 +886,14 @@
     (get-in db [:editor :user-info :superuser?])))
 
 (re-frame/reg-sub
+  :application/single-email-sending-enabled?
+  (fn [_ _]
+    [(re-frame/subscribe [:application/can-edit-application?])
+      re-frame/subscribe [:editor/opinto-ohjaaja-or-admin?]])
+  (fn [[can-edit-application? opinto-ohjaaja-or-admin?] _]
+    (or can-edit-application? opinto-ohjaaja-or-admin?)))
+
+(re-frame/reg-sub
   :application/review-field-editable?
   (fn [_ _]
     [(re-frame/subscribe [:application/can-edit-application?])

--- a/src/cljs/ataru/virkailija/application/application_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/application_subs.cljs
@@ -886,12 +886,20 @@
     (get-in db [:editor :user-info :superuser?])))
 
 (re-frame/reg-sub
-  :application/single-email-sending-enabled?
+  :application/single-information-request-allowed?
   (fn [_ _]
     [(re-frame/subscribe [:application/can-edit-application?])
-      re-frame/subscribe [:editor/opinto-ohjaaja-or-admin?]])
+     (re-frame/subscribe [:editor/opinto-ohjaaja-or-admin?])])
   (fn [[can-edit-application? opinto-ohjaaja-or-admin?] _]
     (or can-edit-application? opinto-ohjaaja-or-admin?)))
+
+(re-frame/reg-sub
+ :application/mass-information-request-allowed?
+ (fn [_ _]
+   [(re-frame/subscribe [:editor/opinto-ohjaaja-or-admin?])
+    (re-frame/subscribe [:editor/editor-rights-for-selected-organization?])])
+ (fn [[opinto-ohjaaja-or-admin? editor-rights-for-selected-organization?] _]
+   (or opinto-ohjaaja-or-admin? editor-rights-for-selected-organization?)))
 
 (re-frame/reg-sub
   :application/review-field-editable?

--- a/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
+++ b/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
@@ -11,7 +11,7 @@
         subject            (subscribe [:state-query [:application :single-information-request :subject]])
         message            (subscribe [:state-query [:application :single-information-request :message]])
         form-status        (subscribe [:application/single-information-request-form-status])
-        enabled?           (subscribe [:application/can-edit-application?])
+        enabled?           (subscribe [:application/single-email-sending-enabled?])
         button-enabled?    (subscribe [:application/single-information-request-button-enabled?])]
     (fn []
       [:span.application-handling__single-information-request-container

--- a/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
+++ b/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
@@ -11,11 +11,13 @@
         subject            (subscribe [:state-query [:application :single-information-request :subject]])
         message            (subscribe [:state-query [:application :single-information-request :message]])
         form-status        (subscribe [:application/single-information-request-form-status])
+        disabled?          (subscribe [:application/can-edit-application?])
         button-enabled?    (subscribe [:application/single-information-request-button-enabled?])]
     (fn []
       [:span.application-handling__single-information-request-container
        [:a.application-handling__send-message-button.application-handling__button
-        {:on-click #(dispatch [:application/set-single-information-request-popup-visibility true])}
+        {:on-click (when (not disabled?) #(dispatch [:application/set-single-information-request-popup-visibility true]))
+         :class (when disabled? "application-handling__button--disabled")}
         @(subscribe [:editor/virkailija-translation :send-email-to-applicant])]
        (when @visible?
          [:div.application-handling__popup.application-handling__-information-request-popup

--- a/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
+++ b/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
@@ -11,13 +11,13 @@
         subject            (subscribe [:state-query [:application :single-information-request :subject]])
         message            (subscribe [:state-query [:application :single-information-request :message]])
         form-status        (subscribe [:application/single-information-request-form-status])
-        enabled?           (subscribe [:application/single-email-sending-enabled?])
+        allowed?           (subscribe [:application/single-information-request-allowed?])
         button-enabled?    (subscribe [:application/single-information-request-button-enabled?])]
     (fn []
       [:span.application-handling__single-information-request-container
        [:a.application-handling__send-message-button.application-handling__button
-        {:on-click (when enabled? #(dispatch [:application/set-single-information-request-popup-visibility true]))
-         :class (when (not enabled?) "application-handling__button--disabled")}
+        {:on-click (when @allowed? #(dispatch [:application/set-single-information-request-popup-visibility true]))
+         :class (when (not @allowed?) "application-handling__button--disabled")}
         @(subscribe [:editor/virkailija-translation :send-email-to-applicant])]
        (when @visible?
          [:div.application-handling__popup.application-handling__-information-request-popup

--- a/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
+++ b/src/cljs/ataru/virkailija/application/information_request/virkailija_information_request_view.cljs
@@ -11,13 +11,13 @@
         subject            (subscribe [:state-query [:application :single-information-request :subject]])
         message            (subscribe [:state-query [:application :single-information-request :message]])
         form-status        (subscribe [:application/single-information-request-form-status])
-        disabled?          (subscribe [:application/can-edit-application?])
+        enabled?           (subscribe [:application/can-edit-application?])
         button-enabled?    (subscribe [:application/single-information-request-button-enabled?])]
     (fn []
       [:span.application-handling__single-information-request-container
        [:a.application-handling__send-message-button.application-handling__button
-        {:on-click (when (not disabled?) #(dispatch [:application/set-single-information-request-popup-visibility true]))
-         :class (when disabled? "application-handling__button--disabled")}
+        {:on-click (when enabled? #(dispatch [:application/set-single-information-request-popup-visibility true]))
+         :class (when (not enabled?) "application-handling__button--disabled")}
         @(subscribe [:editor/virkailija-translation :send-email-to-applicant])]
        (when @visible?
          [:div.application-handling__popup.application-handling__-information-request-popup

--- a/src/cljs/ataru/virkailija/application/mass_information_request/virkailija_mass_information_request_view.cljs
+++ b/src/cljs/ataru/virkailija/application/mass_information_request/virkailija_mass_information_request_view.cljs
@@ -12,11 +12,13 @@
         message            (subscribe [:state-query [:application :mass-information-request :message]])
         form-status        (subscribe [:application/mass-information-request-form-status])
         applications-count (subscribe [:application/loaded-applications-count])
+        allowed?           (subscribe [:application/mass-information-request-allowed?])
         button-enabled?    (subscribe [:application/mass-information-request-button-enabled?])]
     (fn [application-information-request-contains-modification-link]
       [:span.application-handling__mass-information-request-container
        [:a.application-handling__mass-information-request-link.editor-form__control-button.editor-form__control-button--enabled.editor-form__control-button--variable-width
-        {:on-click #(dispatch [:application/set-mass-information-request-popup-visibility true])}
+        {:on-click (when @allowed? #(dispatch [:application/set-mass-information-request-popup-visibility true]))
+         :class (when (not @allowed?) "application-handling__button--disabled")}
         @(subscribe [:editor/virkailija-translation :mass-information-request])]
        (when @visible?
          [:div.application-handling__popup.application-handling__mass-information-request-popup

--- a/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_view.cljs
+++ b/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_view.cljs
@@ -70,6 +70,7 @@
         review-state-counts        (subscribe [:state-query [:application :review-state-counts]])
         loading?                   (subscribe [:application/fetching-applications?])
         tutu-form-visible?         (subscribe [:tutu-payment/tutu-form-selected?])
+        allowed?                   (subscribe [:application/mass-information-request-allowed?])
         processing-states          (if @tutu-form-visible?
                                        review-states/application-hakukohde-processing-states
                                        review-states/application-hakukohde-processing-states-normal)
@@ -81,7 +82,8 @@
       (let [from-states (merge all-states @review-state-counts)]
         [:span.application-handling__mass-edit-review-states-container
          [:a.application-handling__mass-edit-review-states-link.editor-form__control-button.editor-form__control-button--enabled.editor-form__control-button--variable-width
-          {:on-click #(dispatch [:application/set-mass-update-popup-visibility true])}
+          {:on-click (when @allowed? #(dispatch [:application/set-mass-update-popup-visibility true]))
+           :class (when (not @allowed?) "application-handling__button--disabled")}
           @(subscribe [:editor/virkailija-translation :mass-edit])]
          (when @visible?
            [:div.application-handling__mass-edit-review-states-popup.application-handling__popup

--- a/src/cljs/ataru/virkailija/editor/subs.cljs
+++ b/src/cljs/ataru/virkailija/editor/subs.cljs
@@ -577,7 +577,7 @@
  :editor/editor-rights-for-any-organization?
  (fn [db _]
    (let [user-info (-> db :editor :user-info)]
-     (some (fn [org] (some #(= "form-edit" %) (:rights org))) (:organizations user-info)))))
+     (some (fn [org] (some #(= "edit-applications" %) (:rights org))) (:organizations user-info)))))
 
 (re-frame/reg-sub
   :editor/all-organizations-have-only-opinto-ohjaaja-rights?

--- a/src/cljs/ataru/virkailija/editor/subs.cljs
+++ b/src/cljs/ataru/virkailija/editor/subs.cljs
@@ -574,7 +574,7 @@
     (or opinto-ohjaaja? superuser?)))
 
 (re-frame/reg-sub
- :editor/editor-rights-for-any-organization?
+ :editor/edit-rights-for-any-organization?
  (fn [db _]
    (let [user-info (-> db :editor :user-info)]
      (some (fn [org] (some #(= "edit-applications" %) (:rights org))) (:organizations user-info)))))

--- a/src/cljs/ataru/virkailija/editor/subs.cljs
+++ b/src/cljs/ataru/virkailija/editor/subs.cljs
@@ -574,10 +574,10 @@
     (or opinto-ohjaaja? superuser?)))
 
 (re-frame/reg-sub
- :editor/editor-rights-for-selected-organization?
+ :editor/editor-rights-for-any-organization?
  (fn [db _]
-   (let [selected-organization-rights (-> db :editor :user-info :selected-organization :rights)]
-     (contains? (set selected-organization-rights) "form-edit"))))
+   (let [user-info (-> db :editor :user-info)]
+     (some (fn [org] (some #(= "form-edit" %) (:rights org))) (:organizations user-info)))))
 
 (re-frame/reg-sub
   :editor/all-organizations-have-only-opinto-ohjaaja-rights?

--- a/src/cljs/ataru/virkailija/editor/subs.cljs
+++ b/src/cljs/ataru/virkailija/editor/subs.cljs
@@ -574,6 +574,12 @@
     (or opinto-ohjaaja? superuser?)))
 
 (re-frame/reg-sub
+ :editor/editor-rights-for-selected-organization?
+ (fn [db _]
+   (let [selected-organization-rights (-> db :editor :user-info :selected-organization :rights)]
+     (contains? (set selected-organization-rights) "form-edit"))))
+
+(re-frame/reg-sub
   :editor/all-organizations-have-only-opinto-ohjaaja-rights?
   (fn [db _]
     (let [user-info (-> db :editor :user-info)]


### PR DESCRIPTION
Ataru backend already silently fails to send messages to applicants if the user is not authorized to do so. Disable the relevant buttons in frontend when the user doesn't have any opo / editor / superuser rights, so the user won't even try to. 

Figuring out the exact rights especially for mass e-mails would require some help from the backend (new endpoint that matches the backend validations, possible performance issues because its always possible to filter application-by-application), so let's use somewhat more lax validations so that in some cases a user _may_ see enabled buttons even if they aren't allowed to complete the operation on the backend side.