### PR TITLE
OY-4627 use application language in error message when application inactivated

### DIFF
--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -689,9 +689,9 @@
                                      (conj :with-henkilo))
         secret-expired?            (when (nil? application)
                                      (application-store/application-exists-with-secret? secret))
-        lang-override              (when secret-expired? (application-store/get-application-language-by-secret secret))
         application-in-processing? (util/application-in-processing? (:application-hakukohde-reviews application))
         inactivated?               (is-inactivated? application)
+        lang-override              (when (or secret-expired? inactivated?) (application-store/get-application-language-by-secret secret))
         field-deadlines            (or (some->> application
                                                 :key
                                                 field-deadline/get-field-deadlines
@@ -725,15 +725,15 @@
         filtered-person (if (= actor-role :virkailija)
                           new-person
                           (dissoc new-person :ssn :birth-date))
-        full-application           (merge (some-> application
-                                                  (remove-unviewable-answers form)
-                                                  (attachments-metadata->answers liiteri-cas-client)
-                                                  (dissoc :person-oid :application-hakukohde-reviews)
-                                                  (assoc :cannot-edit-because-in-processing (and
-                                                                                             (not= actor-role :virkailija)
-                                                                                             (in-processing-state? application form))))
-                                          (when (some? (:key application))
-                                            {:application-identifier (application-service/mask-application-key (:key application))}))]
+        full-application (merge (some-> application
+                                        (remove-unviewable-answers form)
+                                        (attachments-metadata->answers liiteri-cas-client)
+                                        (dissoc :person-oid :application-hakukohde-reviews)
+                                        (assoc :cannot-edit-because-in-processing (and
+                                                                                   (not= actor-role :virkailija)
+                                                                                   (in-processing-state? application form))))
+                                (when (some? (:key application))
+                                  {:application-identifier (application-service/mask-application-key (:key application))}))]
     [(when full-application
        {:application full-application
         :person      filtered-person

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -67,7 +67,8 @@
                                                                      secret
                                                                      liiteri-cas-client)]
     (cond inactivated?
-          (response/bad-request {:code :inactivated :error "Inactivated"})
+          (let [lang (application-store/get-application-language-by-secret secret)]
+            (response/bad-request {:code :inactivated :error "Inactivated" :lang lang}))
 
           (some? application-form-and-person)
           (let [application (:application application-form-and-person)]

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -67,8 +67,7 @@
                                                                      secret
                                                                      liiteri-cas-client)]
     (cond inactivated?
-          (let [lang (application-store/get-application-language-by-secret secret)]
-            (response/bad-request {:code :inactivated :error "Inactivated" :lang lang}))
+          (response/bad-request {:code :inactivated :error "Inactivated" :lang lang-override})
 
           (some? application-form-and-person)
           (let [application (:application application-form-and-person)]

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -261,6 +261,7 @@
 (defn response->error-message [db response]
   (assoc db :error {:code    (keyword (get-in response [:body :code] "internal-server-error"))
                     :message "Tapahtui virhe"
+                    :lang    (keyword (get-in response [:body :lang]))
                     :detail  (str response)}))
 
 (reg-event-fx

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -499,14 +499,16 @@
 
 (defn error-display []
   (let [error-code (subscribe [:state-query [:error :code]])
-        lang       (subscribe [:application/form-language])]
+        error-lang (subscribe [:state-query [:error :lang]])
+        form-lang  (subscribe [:application/form-language])]
     (fn [] (when-let [error-code @error-code]
              [:div.application__message-display
               {:class (if (some #(= error-code %) [:inactivated :network-offline])
                         "application__message-display--warning"
                         "application__message-display--error")}
               [:div.application__message-display--exclamation [:i.zmdi.zmdi-alert-triangle]]
-              [:div.application__message-display--details (translations/get-hakija-translation error-code @lang)]]))))
+              (let [lang (or @error-lang @form-lang)]
+                [:div.application__message-display--details (translations/get-hakija-translation error-code lang)])]))))
 
 (defn ht-error-display []
   (let [error-code (subscribe [:state-query [:oppija-session :error]])


### PR DESCRIPTION
The application doesn't get passed to frontend in case it's inactivated, so error message localization based on application language doesn't happen. 

When application has been inactivated, return the application language separately with the error, and use it for the error message in the frontend.