### PR TITLE
OY-4635 Add session and request data to has-applied application log

### DIFF
--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -433,11 +433,14 @@
       :summary "Get cached koulutustyypit from koodisto"
       (let [codes (koodisto/get-koulutustyypit koodisto-cache)]
         (response/ok codes)))
-    (api/POST "/has-applied" []
+    (api/POST "/has-applied" [:as request]
       :summary "Check if a person has already applied"
       :body [has-applied-params ataru-schema/HasAppliedParams]
-      (let [{:keys [haku-oid ssn email eidas-id]} has-applied-params]
-        (log/info "Checking has-applied" has-applied-params)
+      (let [{:keys [haku-oid ssn email eidas-id]} has-applied-params
+            session (:session request)
+            oppija-session-from-db (some-> (get-in request [:cookies "oppija-session" :value])
+                                           (oss/read-session))]
+        (log/info "Checking has-applied" has-applied-params session oppija-session-from-db)
         (cond (some? ssn)
               (response/ok (application-store/has-ssn-applied haku-oid ssn))
               (some? eidas-id)

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -440,7 +440,7 @@
             session (:session request)
             oppija-session-from-db (some-> (get-in request [:cookies "oppija-session" :value])
                                            (oss/read-session))]
-        (log/info "Checking has-applied" has-applied-params session oppija-session-from-db)
+        (log/info "Checking has-applied" has-applied-params "session" session "logged-in" (boolean (:logged-in oppija-session-from-db)))
         (cond (some? ssn)
               (response/ok (application-store/has-ssn-applied haku-oid ssn))
               (some? eidas-id)


### PR DESCRIPTION
Spec: api/has-applied call should log the user / session identification data (eg. IP, browser, ...) to application logs for troubleshooting reasons.