### PR TITLE
OY-4700 Remove markdown support from information request mail content

### DIFF
--- a/src/clj/ataru/email/application_email.clj
+++ b/src/clj/ataru/email/application_email.clj
@@ -82,6 +82,11 @@
   (when content
     (.sanitize html-policy (markdown->html content))))
 
+(defn ->safe-html-without-markdown-conversion
+  [content]
+  (when content
+    (.sanitize html-policy content)))
+
 (defn- hakukohde-names [tarjonta-info lang application]
   (when (:haku application)
     (let [tarjonta-hakukohteet (util/group-by-first :oid (:hakukohteet tarjonta-info))

--- a/src/clj/ataru/email/application_email_jobs.clj
+++ b/src/clj/ataru/email/application_email_jobs.clj
@@ -13,6 +13,10 @@
   [content]
   (application-email/->safe-html content))
 
+(defn ->safe-html-without-markdown-conversion
+  [content]
+  (application-email/->safe-html-without-markdown-conversion content))
+
 (defn get-email-templates
   [form-key form-allows-ht?]
   (application-email/get-email-templates form-key form-allows-ht?))

--- a/src/clj/ataru/information_request/information_request_service.clj
+++ b/src/clj/ataru/information_request/information_request_service.clj
@@ -5,7 +5,7 @@
             [ataru.translations.translation-util :as translations]
             [ataru.util :as u]
             [ataru.email.email-util :as email-util]
-            [ataru.email.application-email-jobs :refer [->safe-html]]
+            [ataru.email.application-email-jobs :refer [->safe-html ->safe-html-without-markdown-conversion]]
             [ataru.information-request.information-request-job :as information-request-job]
             [ataru.information-request.information-request-store :as information-request-store]
             [ataru.tutkintojen-tunnustaminen :as tutkintojen-tunnustaminen]
@@ -25,6 +25,7 @@
        (filter (comp (partial = answer-key-str) :key))
        (map :value)
        (first)))
+
 (defn- initial-state [connection information-request guardian?]
   (let [add-update-link? (:add-update-link information-request)]
     (when add-update-link?
@@ -46,7 +47,7 @@
           translations     (translations/get-translations lang)
           {:keys [application-url application-url-text oma-opintopolku-link]} (email-util/get-application-url-and-text form application lang)
           body             (selmer/render-file (information-request-email-template-filename lang)
-                                               (merge {:message (->safe-html (:message information-request))}
+                                               (merge {:message (->safe-html-without-markdown-conversion (:message information-request))}
                                                       (if (or guardian? (not add-update-link?))
                                                         {}
                                                         {:application-url application-url

--- a/src/clj/ataru/information_request/information_request_service.clj
+++ b/src/clj/ataru/information_request/information_request_service.clj
@@ -47,6 +47,8 @@
           translations     (translations/get-translations lang)
           {:keys [application-url application-url-text oma-opintopolku-link]} (email-util/get-application-url-and-text form application lang)
           body             (selmer/render-file (information-request-email-template-filename lang)
+                                               ; Message body text coming from virkailija UI has never "officially" supported Markdown and 
+                                               ; there have been issues with accidental styling - so just sanitize instead of parsing md style.
                                                (merge {:message (->safe-html-without-markdown-conversion (:message information-request))}
                                                       (if (or guardian? (not add-update-link?))
                                                         {}


### PR DESCRIPTION
Copy-pasting content from eg. word processing apps occasionally caused accidental and malformed Markdown in information requests - and it isn't even advertised anywhere in the UI that Markdown ought to be supported. So revert to plain text (still sanitized and embbeded to HTML template) in information request message content.