### PR TITLE
OY-4733 saavutettavuuskorjaus

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -1814,6 +1814,10 @@ th.application__readonly-adjacent--header {
   border-right: 12px solid transparent;
   border-bottom: 12px solid @primary-green-700;
 
+  &:focus {
+    box-shadow: 0px 0px 0px 3px @primary-green-900;
+  }
+
   &:hover {
     opacity: 0.5;
   }
@@ -1837,6 +1841,10 @@ th.application__readonly-adjacent--header {
   border-left: 12px solid transparent;
   border-right: 12px solid transparent;
   border-top: 12px solid @primary-green-700;
+
+  &:focus {
+    box-shadow: 0px 0px 0px 3px @primary-green-900;
+  }
 
   &:hover {
     opacity: 0.5;

--- a/src/cljs/ataru/hakija/application_hakukohde_component.cljs
+++ b/src/cljs/ataru/hakija/application_hakukohde_component.cljs
@@ -43,20 +43,28 @@
 
 (defn- selected-hakukohde-increase-priority
   [hakukohde-oid priority-number disabled?]
-  (let [increase-disabled? (= priority-number 1)]
+  (let [increase-disabled? (= priority-number 1)
+        lang @(subscribe [:application/form-language])]
     [:span.application__selected-hakukohde-row--priority-increase
      {:disabled (when disabled? "disabled")
+      :tab-index 0
+      :role "button"
       :class    (when increase-disabled? "disabled")
+      :aria-label (translations/get-hakija-translation :increase-priority lang)
       :on-click (when-not increase-disabled?
                   #(dispatch [:application/change-hakukohde-priority hakukohde-oid -1]))}]))
 
 (defn- selected-hakukohde-decrease-priority
   [hakukohde-oid priority-number disabled?]
   (let [selected-hakukohteet @(subscribe [:application/selected-hakukohteet])
-        decrease-disabled?   (= priority-number (count selected-hakukohteet))]
-    [:span.application__selected-hakukohde-row--priority-decrease
+        decrease-disabled?   (= priority-number (count selected-hakukohteet))
+        lang @(subscribe [:application/form-language])]
+  [:span.application__selected-hakukohde-row--priority-decrease
      {:disabled (when disabled? "disabled")
+      :tab-index 0
+      :role "button"
       :class    (when decrease-disabled? "disabled")
+      :aria-label (translations/get-hakija-translation :decrease-priority lang)
       :on-click (when-not decrease-disabled?
                   #(dispatch [:application/change-hakukohde-priority hakukohde-oid 1]))}]))
 

--- a/src/cljs/ataru/hakija/application_hakukohde_component.cljs
+++ b/src/cljs/ataru/hakija/application_hakukohde_component.cljs
@@ -37,6 +37,7 @@
     [:button.application__selected-hakukohde-row--remove
      {:data-hakukohde-oid hakukohde-oid
       :disabled           disabled?
+      :tab-index          (when (not disabled?) 0)
       :on-click           (when (not disabled?)
                             hakukohde-remove-event-handler)}
      (translations/get-hakija-translation :remove lang)]))
@@ -44,29 +45,33 @@
 (defn- selected-hakukohde-increase-priority
   [hakukohde-oid priority-number disabled?]
   (let [increase-disabled? (= priority-number 1)
-        lang @(subscribe [:application/form-language])]
+        lang               @(subscribe [:application/form-language])]
     [:span.application__selected-hakukohde-row--priority-increase
-     {:disabled (when disabled? "disabled")
-      :tab-index 0
-      :role "button"
-      :class    (when increase-disabled? "disabled")
-      :aria-label (translations/get-hakija-translation :increase-priority lang)
-      :on-click (when-not increase-disabled?
-                  #(dispatch [:application/change-hakukohde-priority hakukohde-oid -1]))}]))
+     (if increase-disabled?
+       {:class "disabled"}
+       {:disabled   (when disabled? "disabled")
+        :tab-index  0
+        :role       "button"
+        :aria-label (translations/get-hakija-translation :increase-priority lang)
+        :on-key-up #(when (a11y/is-enter-or-space? %)
+                     (dispatch [:application/change-hakukohde-priority hakukohde-oid -1]))
+        :on-click   #(dispatch [:application/change-hakukohde-priority hakukohde-oid -1])})]))
 
 (defn- selected-hakukohde-decrease-priority
   [hakukohde-oid priority-number disabled?]
   (let [selected-hakukohteet @(subscribe [:application/selected-hakukohteet])
         decrease-disabled?   (= priority-number (count selected-hakukohteet))
-        lang @(subscribe [:application/form-language])]
-  [:span.application__selected-hakukohde-row--priority-decrease
-     {:disabled (when disabled? "disabled")
-      :tab-index 0
-      :role "button"
-      :class    (when decrease-disabled? "disabled")
-      :aria-label (translations/get-hakija-translation :decrease-priority lang)
-      :on-click (when-not decrease-disabled?
-                  #(dispatch [:application/change-hakukohde-priority hakukohde-oid 1]))}]))
+        lang                 @(subscribe [:application/form-language])]
+    [:span.application__selected-hakukohde-row--priority-decrease
+     (if decrease-disabled?
+       {:class "disabled"}
+       {:disabled   (when disabled? "disabled")
+        :tab-index  0
+        :role       "button"
+        :aria-label (translations/get-hakija-translation :decrease-priority lang)
+        :on-key-up #(when (a11y/is-enter-or-space? %)
+                     (dispatch [:application/change-hakukohde-priority hakukohde-oid 1]))
+        :on-click   #(dispatch [:application/change-hakukohde-priority hakukohde-oid 1])})]))
 
 (defn- prioritize-hakukohde-buttons
   [hakukohde-oid disabled?]

--- a/src/cljs/ataru/hakija/application_hakukohde_component.cljs
+++ b/src/cljs/ataru/hakija/application_hakukohde_component.cljs
@@ -224,7 +224,9 @@
         (when @(subscribe [:application/show-more-hakukohdes?])
           [:div.application__show_more_hakukohdes_container
            [:span.application__show_more_hakukohdes
-            {:on-click #(dispatch [:application/show-more-hakukohdes])}
+            {:tab-index 0
+             :role "button"
+             :on-click #(dispatch [:application/show-more-hakukohdes])}
             (translations/get-hakija-translation :show-more @lang)]])]])))
 
 (defn- hakukohde-selection-header


### PR DESCRIPTION
Vastaava korjaus kuin 2. asteen hakukohdevalintaan, lisätty focus-tyylimääre, tabindex ja ruudunlukijateksti hakukohteiden järjestyksen vaihtoon (vrt https://github.com/Opetushallitus/ataru/pull/1479/files#diff-e91b5fdb0d7b9735f53d4a6b2cd8c7604b446211bfcdb0111d5f1d9f1c597a36)