### PR TITLE
OY-4699 API and functionality for updating all form koodisto values

### DIFF
--- a/spec/ataru/fixtures/form.clj
+++ b/spec/ataru/fixtures/form.clj
@@ -275,3 +275,57 @@
                  :metadata   metadata
                  :fieldType  "attachment"
                  :label      {:fi "Liite ilman vastausta"}}]})
+
+(def form-with-koodisto-source
+  {:id 981230123
+   :name {:fi "Test fixture for options vs koodisto"}
+   :key "koodisto-test-form"
+   :created-by       "1.2.246.562.11.11111111111"
+   :organization-oid "1.2.246.562.10.0439845"
+   :created-time     "2016-07-28T09:58:34.217+03:00"
+   :locked           nil
+   :locked-by        nil
+   :content [{:id "kysymys_1",
+              :options [{:value "2"},
+                        {:value "1"},
+                        {:value "4"},
+                        {:value "3"},
+                        {:value "5"}],
+              :metadata metadata,
+              :fieldType "dropdown",
+              :fieldClass "formField",
+              :validators ["required"],
+              :koodisto-source {:uri "kktutkinnot",
+                                :title "Kk-tutkinnot",
+                                :version 1,
+                                :allow-invalid? false}}]})
+
+(def form-test-followup-value
+  {:value "3"
+   :label {:fi "" :sv ""}
+   :followups [(assoc (component/text-field metadata)
+                      :id "text")]})
+
+(def form-with-koodisto-source-and-followup
+  {:id 981230123
+   :name {:fi "Test fixture for options vs koodisto"}
+   :key "koodisto-test-form"
+   :created-by       "1.2.246.562.11.11111111111"
+   :organization-oid "1.2.246.562.10.0439845"
+   :created-time     "2016-07-28T09:58:34.217+03:00"
+   :locked           nil
+   :locked-by        nil
+   :content [{:id "kysymys_1",
+              :options [{:value "2" :label {:fi "" :sv ""}},
+                        {:value "1" :label {:fi "" :sv ""}},
+                        {:value "4" :label {:fi "" :sv ""}},
+                        form-test-followup-value,
+                        {:value "5" :label {:fi "" :sv ""}}],
+              :metadata metadata,
+              :fieldType "dropdown",
+              :fieldClass "formField",
+              :validators ["required"],
+              :koodisto-source {:uri "kktutkinnot",
+                                :title "Kk-tutkinnot",
+                                :version 1,
+                                :allow-invalid? false}}]})

--- a/src/clj/ataru/forms/form_access_control.clj
+++ b/src/clj/ataru/forms/form_access_control.clj
@@ -9,6 +9,7 @@
     [ataru.organization-service.session-organizations :as session-orgs]
     [ataru.middleware.user-feedback :refer [user-feedback-exception]]
     [ataru.tarjonta.haku :as haku]
+    [ataru.koodisto.koodisto :as koodisto]
     [taoensso.timbre :as log]))
 
 (defn- form-allowed-by-id?
@@ -100,14 +101,18 @@
 (defn post-form [form session tarjonta-service organization-service audit-logger]
   (let [organization-oids (map :oid (get-organizations-with-edit-rights session))
         first-org-oid     (first organization-oids)
-        form-with-org     (assoc form :organization-oid (or (:organization-oid form) first-org-oid))]
+        form-with-org     (assoc form :organization-oid (or (:organization-oid form) first-org-oid))
+        key               (:key form)]
+    (log/info "Checking form field ID duplicates with form key" key)
     (check-form-field-id-duplicates form)
+    (log/info "Checking form edit authorization with form key" key)
     (check-edit-authorization
      form-with-org
      session
      tarjonta-service
      organization-service
      (fn []
+       (log/info "Creating or updating form with key" key)
        (form-store/create-form-or-increment-version!
         (assoc
          form-with-org
@@ -149,6 +154,16 @@
       (let [coerced-form (form-schema/form-coercer latest-version)
             updated-form (form-diff/apply-operations coerced-form operations)]
         (post-form updated-form session tarjonta-service organization-service audit-logger)))))
+
+(defn refresh-form-codes
+  [form-key session tarjonta-service organization-service koodisto-cache audit-logger]
+  (log/info "Requested to refresh codes for form, key" form-key)
+  (let [form (form-store/fetch-by-key form-key)
+        has-applications? (form-store/form-has-applications form-key)
+        updated-form (koodisto/populate-form-koodisto-fields koodisto-cache form true)]
+    (when has-applications? (throw (user-feedback-exception (str "Lomakkeella " (:key form) " on hakemuksia."))))
+    (log/info "Saving form with refreshed code values, key" form-key)
+    (post-form updated-form session tarjonta-service organization-service audit-logger)))
 
 (defn delete-form [form-id session tarjonta-service organization-service audit-logger]
   (let [form (form-store/fetch-latest-version form-id)]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -293,6 +293,11 @@
       :summary "Toggle form locked state"
       (ok (access-controlled-form/update-form-lock id operation session tarjonta-service organization-service audit-logger)))
 
+    (api/PUT "/forms/:form-key/refresh-codes" {session :session}
+      :summary "Update all code values on form to latest ones from koodisto service"
+      :path-params [form-key :- s/Str]
+      (ok (access-controlled-form/refresh-form-codes form-key session tarjonta-service organization-service koodisto-cache audit-logger)))
+
     (api/DELETE "/forms/:id" {session :session}
       :path-params [id :- Long]
       :summary "Mark form as deleted"

--- a/src/cljc/ataru/component_data/value_transformers.cljc
+++ b/src/cljc/ataru/component_data/value_transformers.cljc
@@ -22,28 +22,47 @@
                                    (Integer/valueOf year)]
                             :cljs [day month year])))))
 
-(defn update-options-while-keeping-existing-followups [newest-options existing-options]
-  (let [options (if (empty? existing-options)
-                  newest-options
-                  (let [existing-values (set (map :value existing-options))
-                        options-that-didnt-exist-before (filter #(not (contains? existing-values (:value %))) newest-options)]
-                    (vec (concat options-that-didnt-exist-before
-                                 (map (fn [existing-option]
-                                        (if-let [new-option (first (filter #(= (:value %) (:value existing-option)) newest-options))]
-                                          (assoc existing-option :label (:label new-option))
-                                          existing-option))
-                                      existing-options)))))
-        identical (fn [{:keys [value]}]
-                    (keep-indexed (fn [index option]
-                                    (when (= value (:value option))
-                                      [index option]))
-                                  options))
-        remove-hidden? (fn [{:keys [hidden] :as koodi}]
-                         (if (or (nil? koodi) hidden)
-                           true
-                           false))]
-    (vec (remove remove-hidden? (map-indexed (fn [index option]
-                                               (let [last-option (first (last (identical option)))]
-                                                 (when (= index last-option)
-                                                   option)))
-                                             options)))))
+(defn merge-options-keeping-existing
+  [newest-options existing-options]
+  (let [existing-values (set (map :value existing-options))
+        options-that-didnt-exist-before (filter #(not (contains? existing-values (:value %))) newest-options)]
+    (vec (concat options-that-didnt-exist-before
+                 (map (fn [existing-option]
+                        (if-let [new-option (first (filter #(= (:value %) (:value existing-option)) newest-options))]
+                          (assoc existing-option :label (:label new-option))
+                          existing-option))
+                      existing-options)))))
+
+; Returns the set of new options with possible old followups added.
+(defn merge-options-removing-existing
+  [newest-options existing-options]
+  (vec (map (fn [new-option]
+              (let [existing-option (first (filter #(= (:value %) (:value new-option)) existing-options))]
+                (if (and existing-option (:followups existing-option))
+                  (assoc new-option :followups (:followups existing-option))
+                  new-option)))
+            newest-options)))
+
+(defn update-options-while-keeping-existing-followups
+  ([newest-options existing-options remove-existing]
+   (let [options (if (empty? existing-options)
+                   newest-options
+                   (if remove-existing
+                     (merge-options-removing-existing newest-options existing-options)
+                     (merge-options-keeping-existing newest-options existing-options)))
+         identical (fn [{:keys [value]}]
+                     (keep-indexed (fn [index option]
+                                     (when (= value (:value option))
+                                       [index option]))
+                                   options))
+         remove-hidden? (fn [{:keys [hidden] :as koodi}]
+                          (if (or (nil? koodi) hidden)
+                            true
+                            false))]
+     (vec (remove remove-hidden? (map-indexed (fn [index option]
+                                                (let [last-option (first (last (identical option)))]
+                                                  (when (= index last-option)
+                                                    option)))
+                                              options)))))
+  ([newest-options existing-options]
+   (update-options-while-keeping-existing-followups newest-options existing-options false)))


### PR DESCRIPTION
API and service code to update all code sets to latest ones in a single form - creating a new version of the form with same key. 

Adds and removes values if necessary, updates labels. Fails in case any followups would be erased accidentally.