### PR TITLE
OY-4565 Do lahtokoulu filtering based on cutoff date

### DIFF
--- a/spec/ataru/suoritus/suoritus_service_spec.clj
+++ b/spec/ataru/suoritus/suoritus_service_spec.clj
@@ -1,0 +1,106 @@
+(ns ataru.suoritus.suoritus-service-spec
+  (:require [speclj.core :refer :all]
+            [ataru.suoritus.suoritus-service :as suoritus-service]
+            [ataru.suoritus.suoritus-client :as suoritus-client]
+            [ataru.applications.suoritus-filter :as suoritus-filter]
+            [clj-time.coerce :as coerce]))
+
+(def service (suoritus-service/map->HttpSuoritusService {}))
+
+(def test-henkilo-oid "1.123.123.123")
+(def test-luokkatasot (suoritus-filter/luokkatasot-for-suoritus-filter))
+(def test-year "2023")
+
+(defn str->timestamp [str] (coerce/to-timestamp (coerce/from-string str)))
+
+(def test-client-response
+  [{:id "6d5f828d-355c-4c37-b719-ef5e4c6f6dde",
+    :oppilaitosOid "1.1.111.111.111.111",
+    :luokkataso "TELMA",
+    :luokka "TELMA",
+    :henkiloOid "1.123.123.123",
+    :alkuPaiva "2023-08-02T21:00:00.000Z",
+    :loppuPaiva "2024-06-02T21:00:00.000Z",
+    :source "koski",
+    :core {:oppilaitosOid "1.1.111.111.111.111",
+           :luokkataso "TELMA",
+           :henkiloOid "1.123.123.123"}}
+   {:id "cd9edf5c-c411-4610-8dfe-7cc1a753896d",
+    :oppilaitosOid "1.2.222.222.222.222",
+    :luokkataso "9",
+    :luokka "9E",
+    :henkiloOid "1.123.123.123",
+    :alkuPaiva "2020-08-11T21:00:00.000Z",
+    :loppuPaiva "2023-06-02T21:00:00.000Z",
+    :source "koski",
+    :core {:oppilaitosOid "1.2.222.222.222.222",
+           :luokkataso "9",
+           :henkiloOid "1.123.123.123"}}
+   {:id "abcddf6c-b311-4110-1234-8cc1a753896d",
+    :oppilaitosOid "1.3.333.333.333.333",
+    :luokkataso "FOO",
+    :luokka "FOO",
+    :henkiloOid "1.123.123.123",
+    :alkuPaiva "2020-01-11T21:00:00.000Z",
+    :loppuPaiva "2025-06-02T21:00:00.000Z",
+    :source "koski",
+    :core {:oppilaitosOid "1.3.333.333.333.333",
+           :luokkataso "FOO",
+           :henkiloOid "1.123.123.123"}}])
+
+(def test-client-response-overlapping
+  (conj test-client-response
+        {:id "aaaaaaaa-355c-cccc-b719-ef5e4c6f6dde",
+         :oppilaitosOid "1.4.444.444.444.444",
+         :luokkataso "TELMA",
+         :luokka "TELMA",
+         :henkiloOid "1.123.123.123",
+         :alkuPaiva "2022-08-03T21:00:00.000Z",
+         :loppuPaiva "2024-06-02T21:00:00.000Z",
+         :source "koski",
+         :core {:oppilaitosOid "1.4.444.444.444.444",
+                :luokkataso "TELMA",
+                :henkiloOid "1.123.123.123"}}))
+
+(describe "suoritus-service"
+          (tags :unit :suoritus)
+          (with-stubs)
+
+          (around [spec]
+                  (with-redefs [suoritus-client/opiskelijat (stub :opiskelijat
+                                                                  {:return test-client-response})]
+                    (spec)))
+
+          (it "returns most recently started student class data filtered by luokkatasot when no cutoff date specified"
+              (let [data (suoritus-service/opiskelija service test-henkilo-oid [test-year] test-luokkatasot nil)]
+                (should= {:oppilaitos-oid "1.1.111.111.111.111"
+                          :luokka "TELMA"
+                          :luokkataso "TELMA"
+                          :alkupaiva "2023-08-02T21:00:00.000Z"
+                          :loppupaiva "2024-06-02T21:00:00.000Z"}
+                         data)))
+
+          (it "returns student class data that is ongoing on cutoff date"
+              (let [data (suoritus-service/opiskelija service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2023-03-02T21:00:00.000Z"))]
+                (should= {:oppilaitos-oid "1.2.222.222.222.222"
+                          :luokka "9E"
+                          :luokkataso "9"
+                          :alkupaiva "2020-08-11T21:00:00.000Z"
+                          :loppupaiva "2023-06-02T21:00:00.000Z"}
+                         data)))
+
+          (it "returns latest ongoing student class data by start date on cutoff date"
+              (with-redefs [suoritus-client/opiskelijat (stub :opiskelijat
+                                                              {:return test-client-response-overlapping})]
+                (let [data (suoritus-service/opiskelija service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2023-03-02T21:00:00.000Z"))]
+                  (should= {:oppilaitos-oid "1.4.444.444.444.444"
+                            :luokka "TELMA"
+                            :luokkataso "TELMA"
+                            :alkupaiva "2022-08-03T21:00:00.000Z"
+                            :loppupaiva "2024-06-02T21:00:00.000Z"}
+                           data))))
+
+          (it "doesn't return student class data if nothing was ongoing on cutoff date"
+              (let [data (suoritus-service/opiskelija service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2019-08-02T21:00:00.000Z"))]
+                (should= nil
+                         data))))

--- a/src/clj/ataru/odw/odw_service.clj
+++ b/src/clj/ataru/odw/odw_service.clj
@@ -118,7 +118,7 @@
                                                pohjakoulutus (:POHJAKOULUTUS koosteData)
                                                opetuskieli (:perusopetuksen_kieli koosteData)
                                                suoritusvuosi (:pohjakoulutus_vuosi koosteData)
-                                               luokkatieto (suoritus-service/opiskelija suoritus-service person-oid (vector application-year) (suoritus-filter/luokkatasot-for-suoritus-filter))
+                                               luokkatieto (suoritus-service/opiskelija suoritus-service person-oid (vector application-year) (suoritus-filter/luokkatasot-for-suoritus-filter) nil)
                                                lahtoluokka (:luokka luokkatieto)
                                                luokkataso (:luokkataso luokkatieto)
                                                lahtokoulu-oid (:oppilaitos-oid luokkatieto)]

--- a/src/clj/ataru/suoritus/suoritus_service.clj
+++ b/src/clj/ataru/suoritus/suoritus_service.clj
@@ -20,7 +20,7 @@
   (oppilaitoksen-opiskelijat [this oppilaitos-oid vuosi luokkatasot])
   (oppilaitoksen-opiskelijat-useammalle-vuodelle [this oppilaitos-oid vuodet luokkatasot])
   (oppilaitoksen-luokat [this oppilaitos-oid vuosi luokkatasot])
-  (opiskelija [this henkilo-oid vuodet luokkatasot cutoff-date]))
+  (opiskelija [this henkilo-oid vuodet luokkatasot cutoff-timestamp]))
 
 (defrecord HttpSuoritusService [suoritusrekisteri-cas-client oppilaitoksen-opiskelijat-cache oppilaitoksen-luokat-cache]
   component/Lifecycle

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -86,6 +86,7 @@
             [ataru.applications.suoritus-filter :as suoritus-filter]
             [ataru.person-service.person-service :as person-service]
             [ataru.valintalaskentakoostepalvelu.pohjakoulutus-toinen-aste :as pohjakoulutus-toinen-aste]
+            [ataru.tarjonta-service.tarjonta-parser :as tarjonta-parser]
             [cuerdas.core :as str]
             [clj-time.format :as f]
             [ataru.virkailija.virkailija-application-service :as virkailija-application-service])
@@ -506,9 +507,17 @@
                                (f/parse (:date-time f/formatters))
                                (suoritus-filter/year-for-suoritus-filter))
               luokkatasot (suoritus-filter/luokkatasot-for-suoritus-filter)
+              tarjonta-info (when haku-oid
+                              (tarjonta-parser/parse-tarjonta-info-by-haku
+                               koodisto-cache
+                               tarjonta-service
+                               organization-service
+                               ohjausparametrit-service
+                               haku-oid))
+              haku-end    (get-in tarjonta-info [:tarjonta :hakuaika :end])
               linked-oids (get (person-service/linked-oids person-service [henkilo-oid]) henkilo-oid)
               aliases     (conj (:linked-oids linked-oids) (:master-oid linked-oids))
-              opiskelijat (map #(suoritus-service/opiskelija suoritus-service % [hakuvuosi] luokkatasot) aliases)]
+              opiskelijat (map #(suoritus-service/opiskelija suoritus-service % [hakuvuosi] luokkatasot haku-end) aliases)]
           (if-let [opiskelija (last (sort-by :alkupaiva opiskelijat))]
             (let [[organization] (organization-service/get-organizations-for-oids organization-service [(:oppilaitos-oid opiskelija)])]
               (response/ok


### PR DESCRIPTION
Lähtökoulu data shown on the application view was based on most recent lähtökoulu and hence could change after application time was over. 

After this change, the visible lähtökoulu is the (most recent) one that was valid on the application end date.

There are no changes in the application access control in this PR - as it was a bit more complex than imagined, it was split to another ticket so we can do some planning beforehand.