### PR TITLE
OY-4756 Pad app-db question group answers with nils when loading existing application

### DIFF
--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -252,8 +252,9 @@
                             (filterv allowed-values values)))
         sanitize-question-group-values (fn [allowed-values values]
                                          (mapv (partial sanitize-values allowed-values) values))]
-    (if (and (not-empty (:options field-descriptor))
-             (#{"dropdown" "multipleChoice" "singleChoice"} (:fieldType field-descriptor)))
+    (if (or (and (not-empty (:options field-descriptor))
+              (#{"dropdown" "multipleChoice" "singleChoice"} (:fieldType field-descriptor)))
+            (< 1 question-group-highest-dimension))
       (let [allowed-values (set (map :value (:options field-descriptor)))]
         (if (vector? value)
           (if (or (vector? (first value)) (nil? (first value)))

--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -252,9 +252,8 @@
                             (filterv allowed-values values)))
         sanitize-question-group-values (fn [allowed-values values]
                                          (mapv (partial sanitize-values allowed-values) values))]
-    (if (or (and (not-empty (:options field-descriptor))
-              (#{"dropdown" "multipleChoice" "singleChoice"} (:fieldType field-descriptor)))
-            (< 1 question-group-highest-dimension))
+    (if (and (not-empty (:options field-descriptor))
+             (#{"dropdown" "multipleChoice" "singleChoice"} (:fieldType field-descriptor)))
       (let [allowed-values (set (map :value (:options field-descriptor)))]
         (if (vector? value)
           (if (or (vector? (first value)) (nil? (first value)))

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -466,6 +466,7 @@
   (if (empty? answers)
     db
     (let [question-group-form-fields (->> flat-form-content
+                                          (filter #(= :formField (keyword (:fieldClass %))))
                                           (filter #(some? (get-in % [:params :question-group-id])))
                                           (filter #(not (contains? (set person-info-fields/person-info-field-ids) (keyword (:id %))))))
           question-group-field-ids (set (->> question-group-form-fields
@@ -565,7 +566,7 @@
         (populate-hakukohde-answers-if-necessary)
         (set-have-finnish-ssn flat-form-content)
         (original-values->answers)
-        ;(reinitialize-question-group-empty-answers submitted-answers flat-form-content)
+        (reinitialize-question-group-empty-answers submitted-answers flat-form-content)
         (rules/run-all-rules flat-form-content)
         (set-question-group-row-amounts))))
 

--- a/src/cljs/ataru/hakija/application_handlers.cljs
+++ b/src/cljs/ataru/hakija/application_handlers.cljs
@@ -2,7 +2,7 @@
   (:require [ataru.config :as config]
             [clojure.string :as string]
             [re-frame.core :refer [reg-event-db reg-event-fx dispatch subscribe after inject-cofx]]
-            [ataru.application-common.application-field-common :refer [sanitize-value]]
+            [ataru.application-common.application-field-common :refer [sanitize-value pad]]
             [schema.core :as s]
             [ataru.application.option-visibility :as option-visibility]
             [ataru.feature-config :as fc]
@@ -460,6 +460,62 @@
                         (assoc answers answer-key (assoc answer :original-value (:value answer))))
                       {})))
 
+(defn- reinitialize-question-group-empty-answers [db answers flat-form-content]
+  (prn "reinitialize-question-group-empty-answers")
+  (prn (get-in db [:application :answers :c98313ba-bdd8-4d67-b6aa-5951b269300b]))
+  (if (empty? answers)
+    db
+    (let [question-group-form-fields (->> flat-form-content
+                                          (filter #(some? (get-in % [:params :question-group-id])))
+                                          (filter #(not (contains? (set person-info-fields/person-info-field-ids) (keyword (:id %))))))
+          question-group-field-ids (set (->> question-group-form-fields
+                                             (map #(keyword (:id %)))))
+          question-group-answers-with-values (->> answers
+                                                  (filter #(contains? question-group-field-ids (keyword (:key %)))))
+          answers-with-values-ids (set (->> question-group-answers-with-values
+                                       (map #(keyword (:key %)))))
+          question-group-answers-without-values (->> question-group-form-fields
+                                                     (map #(get-in db [:application :answers (keyword (:id %))]))
+                                                     (remove nil?)
+                                                     (remove #(contains? answers-with-values-ids (keyword (:id %)))))
+          ;_ (prn question-group-field-ids)
+          ;_ (prn question-group-answers)
+          _ (prn question-group-answers-with-values)
+          map-to-question-group (fn [answer]
+                                   (let [question-group-id (get-in
+                                                             (->> question-group-form-fields
+                                                                (filter #(= (:key answer) (:id %)))
+                                                                first
+                                                                ) [:params :question-group-id])
+                                         amount (count (:value answer))]
+                                     [question-group-id amount]))
+          question-group-ids-with-amounts (into {}
+                                                (->> question-group-answers-with-values
+                                                     (map map-to-question-group)
+                                                     (filter #(> (last %) 1))
+                                                     distinct))
+          _ (prn question-group-ids-with-amounts)
+          map-matching-amount-if-found (fn [answer]
+                                (let [matching-field (->> question-group-form-fields
+                                                          (filter #(= (:id %) (:id answer)))
+                                                          first)
+                                      _ (prn "map-matching-amount")
+                                      _ (prn matching-field)
+                                      amount (->> (get-in matching-field [:params :question-group-id])
+                                                  keyword
+                                                  (get question-group-ids-with-amounts))
+                                      _ (prn amount)
+                                      padded-value (pad amount (:value answer) nil)
+                                      padded-values (pad amount (:values answer) nil)]
+                                  (when amount
+                                    (update-in answer :value padded-value :values padded-values))))
+          updated-answers (->> question-group-answers-without-values
+                               (map map-matching-amount-if-found)
+                               (remove nil?))
+          _ (prn updated-answers)]
+      (update-in db [:application :answers] merge updated-answers)
+    )))
+
 (defn- merge-submitted-answers [db submitted-answers flat-form-content]
   (let [form-fields-by-id (autil/group-by-first (comp keyword :id) flat-form-content)]
     (-> (reduce (fn [db answer]
@@ -504,6 +560,7 @@
         (populate-hakukohde-answers-if-necessary)
         (set-have-finnish-ssn flat-form-content)
         (original-values->answers)
+        (reinitialize-question-group-empty-answers submitted-answers flat-form-content)
         (rules/run-all-rules flat-form-content)
         (set-question-group-row-amounts))))
 
@@ -581,7 +638,8 @@
         questions-with-duplicates  (handlers-util/duplicate-questions-for-hakukohteet-during-form-load (get-in form [:tarjonta :hakukohteet]) hakukohde-oids-to-duplicate questions)
         flat-form-content          (autil/flatten-form-fields questions-with-duplicates)
         selected-language          (:selected-language form)
-        initial-answers            (create-initial-answers flat-form-content preselected-hakukohde-oids selected-language)]
+        initial-answers            (create-initial-answers flat-form-content preselected-hakukohde-oids selected-language)
+        _ (prn "HERERERERE")]
     (-> db
         (update :form (fn [{:keys [selected-language]}]
                         (cond-> form
@@ -702,6 +760,7 @@
         [secret-kwd secret-val]           (if-not (clojure.string/blank? secret)
                                             [:secret secret]
                                             [:virkailija-secret virkailija-secret])]
+    (prn "handle-get-application")
     (util/set-query-param "application-key" (:key application))
     {:db       (-> db
                    (assoc-in [:application :application-identifier] (:application-identifier application))
@@ -862,6 +921,9 @@
 
 (defn- set-repeatable-field-values
   [db id group-idx data-idx value]
+  (prn "set-repatable-field-value")
+  (when (= id :45ec0320-cd32-4968-a86e-f26f62feb37b)
+    (prn group-idx value (some? group-idx)))
   (cond (some? group-idx)
         (let [data-idx (or data-idx 0)]
           (-> db

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -236,13 +236,13 @@
           {:tab-index    "1"
            :on-click     #(reset! hidden? true)
            :data-test-id "send-feedback-button"
-           :autofocus ""}
+           :auto-focus ""}
           (translations/get-hakija-translation :ht-katso-hakemustasi lang)]
          [:button.application__overlay-button.application__overlay-button
           {:tab-index    "2"
            :on-click     #(dispatch [:application/redirect-to-logout (name lang)])
            :data-test-id "logout-button"
-           :autofocus ""}
+           :auto-focus ""}
           [:i.material-icons-outlined.logout
            {:title (translations/get-hakija-translation :ht-kirjaudu-ulos lang)} "logout"]
           (translations/get-hakija-translation :ht-kirjaudu-ulos lang)]]]])))
@@ -275,7 +275,7 @@
          {:tab-index    "1"
           :on-click     #(reset! hidden? true)
           :data-test-id "send-feedback-button"
-          :autofocus ""}
+          :auto-focus ""}
          (translations/get-hakija-translation :application-submitted-ok lang)]]])))
 
 (defn- submit-notification-payment

--- a/src/cljs/ataru/hakija/handlers_util.cljs
+++ b/src/cljs/ataru/hakija/handlers_util.cljs
@@ -156,9 +156,9 @@
                                                      (map (partial pad-to-matching-length-if-necessary
                                                                    question-group-field-group-ids question-group-max-dimensions))
                                                      (remove nil?))]
-      (-> (reduce (fn [db answer]
+      (reduce (fn [db answer]
                     (assoc-in db 
                               [:application :answers (:key answer)]
                               (dissoc answer :key)))
                   db
-                  answers-to-update)))))
+                  answers-to-update))))

--- a/test/cljs/unit/ataru/hakija/handlers_util_test.cljs
+++ b/test/cljs/unit/ataru/hakija/handlers_util_test.cljs
@@ -119,3 +119,132 @@
         questions [{:id "q1"} {:id "q2" :original-question "q1" :validators ["required"]}]
         result (util/fill-missing-answer-for-hakukohde answers questions)]
     (is (= false (:valid (:q2 result))))))
+
+(def test-flat-form
+  [{:params {:size "M"},
+    :rules {},
+    :validators ["required"],
+    :fieldClass "formField",
+    :cannot-edit true,
+    :label {:fi "Sukunimi", :sv "Efternamn", :en "Surname/Family name"},
+    :id "last-name",
+    :cannot-view false,
+    :metadata {:created-by {:name "system", :oid "system", :date "1970-01-01T00:00:00Z"}}}
+   {:label {:fi "Kysymysryhmä", :sv ""},
+    :fieldClass "questionGroup",
+    :id "04bf89e0-2fec-4f7a-941c-40c91f8f593a",
+    :params {}, :metadata {:created-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:19:15Z"},
+                           :modified-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:19:37Z"}},
+    :fieldType "fieldset"}
+   {:children-of "04bf89e0-2fec-4f7a-941c-40c91f8f593a",
+    :params {:repeatable true, :question-group-id :04bf89e0-2fec-4f7a-941c-40c91f8f593a},
+    :fieldClass "formField",
+    :cannot-edit false,
+    :label {:fi "Vapaamuotoinen vastaus", :sv ""},
+    :id "2c97597f-2e52-43b0-a0a2-b8b022e572af",
+    :cannot-view false,
+    :metadata {:created-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:19:42Z"},
+               :modified-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:19:47Z"}},
+    :fieldType "textField"}
+   {:label {:fi "Infoteksti"},
+    :text {:fi "Tässä infotekstiä"},
+    :fieldClass "infoElement",
+    :id "efeb883a-8dfd-4933-b1c1-5751b7147eda",
+    :params {:question-group-id :04bf89e0-2fec-4f7a-941c-40c91f8f593a},
+    :metadata {:created-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:21:45Z"},
+               :modified-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:21:49Z"}},
+    :fieldType "p", :children-of "04bf89e0-2fec-4f7a-941c-40c91f8f593a"}
+   {:children-of "04bf89e0-2fec-4f7a-941c-40c91f8f593a",
+    :params {:max-value "2024", :numeric true, :min-value "1900", :question-group-id :04bf89e0-2fec-4f7a-941c-40c91f8f593a},
+    :validators ["numeric"],
+    :fieldClass "formField",
+    :cannot-edit false,
+    :label {:fi "Vapaamuotoinen vastaus 2", :sv ""}, :id "51207053-6674-47d1-b88e-c0f8ab5cee92",
+    :cannot-view false,
+    :options [{:label {:fi "", :sv ""}, :value "0", :condition {:comparison-operator "<", :answer-compared-to 2020}}],
+    :metadata {:created-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:25:56Z"},
+               :modified-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:26:27Z"}},
+    :fieldType "textField"}
+   {:params {:question-group-id :04bf89e0-2fec-4f7a-941c-40c91f8f593a},
+    :option-value "0", :fieldClass "formField", :cannot-edit false,
+    :label {:fi "Lisäkysymys kun yli 2020", :sv ""},
+    :id "ce039866-a75c-4641-b444-0218e7421ad0",
+    :cannot-view false,
+    :followup-of "51207053-6674-47d1-b88e-c0f8ab5cee92",
+    :metadata {:created-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:26:36Z"},
+               :modified-by {:name "Virkailija", :oid "1.2.246.562.24.76008520040", :date "2024-03-27T11:26:40Z"}},
+    :fieldType "textField"}])
+
+(defn test-answers
+  [add-remaining-answer]
+  (let [answers [{:duplikoitu-followup-hakukohde-oid nil,
+                  :key "last-name", :value "Henkilö",
+                  :duplikoitu-kysymys-hakukohde-oid nil,
+                  :original-question nil,
+                  :fieldType "textField",
+                  :original-followup nil}
+                 {:duplikoitu-followup-hakukohde-oid nil,
+                  :key "2c97597f-2e52-43b0-a0a2-b8b022e572af",
+                  :value [["Vastaan tähän jotain" "Tähän vielä toinen kohta"] ["Tähänkin vastaus"]],
+                  :duplikoitu-kysymys-hakukohde-oid nil,
+                  :original-question nil,
+                  :fieldType "textField",
+                  :original-followup nil}
+                 {:duplikoitu-followup-hakukohde-oid nil,
+                  :key "51207053-6674-47d1-b88e-c0f8ab5cee92",
+                  :value [["2000"] ["2023"]],
+                  :duplikoitu-kysymys-hakukohde-oid nil,
+                  :original-question nil,
+                  :fieldType "textField",
+                  :original-followup nil}]]
+    (if add-remaining-answer
+      (conj answers {:duplikoitu-followup-hakukohde-oid nil,
+                     :key "ce039866-a75c-4641-b444-0218e7421ad0",
+                     :value [["foo"] ["bar"]],
+                     :duplikoitu-kysymys-hakukohde-oid nil,
+                     :original-question nil,
+                     :fieldType "textField",
+                     :original-followup nil})
+      answers)))
+
+(defn test-app-db-answers
+  [add-remaining-answer]
+  (let [answers {:last-name
+                 {:valid true, :label {:fi "Sukunimi", :sv "Efternamn", :en "Surname/Family name"},
+                  :value "Henkilö", :values {:value "Henkilö", :valid true}, :original-value "Henkilö"}
+                 :51207053-6674-47d1-b88e-c0f8ab5cee92
+                 {:valid true, :label {:fi "Vapaamuotoinen vastaus 2", :sv ""}, :value [["2000"] ["2023"]],
+                  :values [[{:valid true, :value "2000"}] [{:valid true, :value "2023"}]], :original-value [["2000"] ["2023"]]},
+                 :2c97597f-2e52-43b0-a0a2-b8b022e572af
+                 {:valid true, :label {:fi "Vapaamuotoinen vastaus", :sv ""}, :value [["Vastaan tähän jotain" "Tähän vielä toinen kohta"] ["Tähänkin vastaus"]],
+                  :values [[{:valid true, :value "Vastaan tähän jotain"} {:valid true, :value "Tähän vielä toinen kohta"}] [{:valid true, :value "Tähänkin vastaus"}]],
+                  :original-value [["Vastaan tähän jotain" "Tähän vielä toinen kohta"] ["Tähänkin vastaus"]]}
+                 :ce039866-a75c-4641-b444-0218e7421ad0
+                 {:valid true, :label {:fi "Lisäkysymys kun yli 2020", :sv ""},
+                  :value [[""]],
+                  :values [[{:valid false, :value ""}]],
+                  :original-value [["Vastaus"] nil]}}]
+    (if add-remaining-answer
+      (merge answers {:ce039866-a75c-4641-b444-0218e7421ad0
+                      {:valid true, :label {:fi "Lisäkysymys kun yli 2020", :sv ""},
+                       :value [["foo"] ["bar"]],
+                       :values [[{:valid true, :value "foo"}] [{:valid true, :value "bar"}]],
+                       :original-value [["Vastaus"] nil]}})
+      answers)))
+
+(deftest reinitializes-values-without-changes-when-all-answers-present
+  (let [answers (test-answers true)
+        db-answers (test-app-db-answers true)
+        pre-db {:application {:answers db-answers}}
+        post-db (util/reinitialize-question-group-empty-answers pre-db answers test-flat-form)]
+    (is (= pre-db post-db))))
+
+(deftest reinitializes-values-with-question-group-nil-padding-on-missing-answers
+  (let [answers (test-answers false)
+        db-answers (test-app-db-answers false)
+        pre-db {:application {:answers db-answers}}
+        post-db (util/reinitialize-question-group-empty-answers pre-db answers test-flat-form)
+        post-db-answers (get-in post-db [:application :answers])]
+    (is (not (= pre-db post-db)))
+    (is (= (get-in post-db-answers [:ce039866-a75c-4641-b444-0218e7421ad0 :value]) [[""] nil]))
+    (is (= (get-in post-db-answers [:ce039866-a75c-4641-b444-0218e7421ad0 :values]) [[{:valid false, :value ""}] nil]))))


### PR DESCRIPTION
Answers to question group's questions get padded with nil values in frontend's app-db whenever there are multiple "answer sets", but some of them don't include answers to every question. This happens because the backend validator requires all question group's answers to have the same dimension / length.

When loading an existing application for modification, nil padding did not happen to empty answers (eg. don't explicitly come from the saved application) that belong to question group that has more than one answer set.

After this PR, any problematic answers should be checked and nil padded in app-db.