### PR TITLE
OY-4756 do nil-padding for all form fields in sanitization phase

### DIFF
--- a/src/cljs/ataru/application_common/application_field_common.cljs
+++ b/src/cljs/ataru/application_common/application_field_common.cljs
@@ -252,14 +252,14 @@
                                 (filterv allowed-values values)))
         keep-allowed-question-group-values (fn [allowed-values values]
                                              (mapv (partial keep-allowed-values allowed-values) values))
-        is-field-with-allowed-values (fn [descriptor] (and (not-empty (:options descriptor))
+        is-options-type-field? (fn [descriptor] (and (not-empty (:options descriptor))
                                                            (#{"dropdown" "multipleChoice" "singleChoice"} (:fieldType descriptor))))
-        is-question-group-value (fn [value] (or (vector? (first value)) (nil? (first value))))]
+        is-question-group-value? (fn [value] (or (vector? (first value)) (nil? (first value))))]
     ; Fields with allowed options get filtered and nil padded
-    (if (is-field-with-allowed-values field-descriptor)
+    (if (is-options-type-field? field-descriptor)
       (let [allowed-values (set (map :value (:options field-descriptor)))]
         (if (vector? value)
-          (if (is-question-group-value value)
+          (if (is-question-group-value? value)
             (pad (or question-group-highest-dimension 0)
                  (keep-allowed-question-group-values allowed-values value)
                  nil)
@@ -268,6 +268,6 @@
       ; Other "freeform" fields just get nil padded when necessary
       (if (and (= "formField" (:fieldClass field-descriptor))
                (vector? value)
-               (is-question-group-value value))
+               (is-question-group-value? value))
         (pad (or question-group-highest-dimension 0) value nil)
         value))))

--- a/src/cljs/ataru/hakija/application.cljs
+++ b/src/cljs/ataru/hakija/application.cljs
@@ -135,9 +135,8 @@
             (let [required? (some #(contains? required-validators %)
                                   (:validators field))]
               [(keyword id) {:valid  (not required?)
-                             :value  [[nil]]
-                             :values [[{:value nil
-                                        :valid (not required?)}]]
+                             :value  [nil]
+                             :values [nil]
                              :label  label}])
 
             [{:id         id

--- a/test/cljs/unit/ataru/application_common/application_field_common_test.cljs
+++ b/test/cljs/unit/ataru/application_common/application_field_common_test.cljs
@@ -1,0 +1,101 @@
+(ns ataru.application-common.application-field-common-test
+  (:require [cljs.test :refer-macros [deftest is testing are]]
+            [ataru.application-common.application-field-common :as common]))
+
+(defn build-question-with-options
+  [field-type]
+  {:id         "c8558a1f-86e9-4d76-83eb-a0d7e1fd44b0",
+   :params     {},
+   :options
+   [{:label {:fi "Ensimmäinen vaihtoehto", :sv ""}, :value "eka"}
+    {:label {:fi "Toinen vaihtoehto", :sv ""}, :value "toka"}
+    {:label {:fi "Kolmas vaihtoehto", :sv ""}, :value "kolmas"}
+    {:label {:fi "", :sv ""}, :value ""}],
+   :fieldType  field-type,
+   :fieldClass "formField"})
+
+(def text-field-question
+  {:id         "047da62c-9afe-4e28-bfe8-5b50b21b4277",
+   :params     {},
+   :fieldType  "textField",
+   :fieldClass "formField"})
+
+(deftest multiple-choice-values
+  (testing "multiple choice values"
+    (testing "are kept as is when matching an allowed value"
+      (are [field-type]
+           (let [field-descriptor (build-question-with-options field-type)
+                 answer-value     "toka"
+                 sanitized-value  (common/sanitize-value field-descriptor answer-value nil)]
+             (is (= sanitized-value answer-value)))
+        "dropdown"
+        "multipleChoice"
+        "singleChoice"))
+    (testing "are filtered out when a single value does not match allowed"
+      (are [field-type]
+           (let [field-descriptor (build-question-with-options field-type)
+                 answer-value     "neljäs"
+                 sanitized-value  (common/sanitize-value field-descriptor answer-value nil)]
+             (is (= sanitized-value nil)))
+        "dropdown"
+        "multipleChoice"
+        "singleChoice"))
+    (testing "are left untouched when no padding or filtering is needed"
+      (are [field-type]
+           (let [field-descriptor (build-question-with-options field-type)
+                 answer-value     ["toka" "kolmas" "eka"]
+                 sanitized-value  (common/sanitize-value field-descriptor answer-value nil)]
+             (is (= sanitized-value answer-value)))
+        "dropdown"
+        "multipleChoice"
+        "singleChoice"))
+    (testing "are filtered by options"
+      (are [field-type]
+           (let [field-descriptor (build-question-with-options field-type)
+                 answer-value     ["toka" "kolmas" "neljäs"]
+                 sanitized-value  (common/sanitize-value field-descriptor answer-value nil)]
+             (is (= sanitized-value ["toka" "kolmas"])))
+        "dropdown"
+        "multipleChoice"
+        "singleChoice"))
+    (testing "are filtered by inside question group answers"
+      (are [field-type]
+           (let [field-descriptor (build-question-with-options field-type)
+                 answer-value     [["toka"] ["kolmas"] ["neljäs"]]
+                 sanitized-value  (common/sanitize-value field-descriptor answer-value 3)]
+             (is (= sanitized-value [["toka"] ["kolmas"] []])))
+        "dropdown"
+        "multipleChoice"
+        "singleChoice"))
+    (testing "are nil padded as question group"
+      (are [field-type]
+           (let [field-descriptor (build-question-with-options field-type)
+                 answer-value     [["toka"] ["kolmas"]]
+                 sanitized-value  (common/sanitize-value field-descriptor answer-value 4)]
+             (is (= sanitized-value [["toka"] ["kolmas"] nil nil])))
+        "dropdown"
+        "multipleChoice"
+        "singleChoice"))
+    (testing "are filtered and nil padded"
+      (are [field-type]
+           (let [field-descriptor (build-question-with-options field-type)
+                 answer-value     [["toka"] ["kolmas"] ["foo"]]
+                 sanitized-value  (common/sanitize-value field-descriptor answer-value 4)]
+             (is (= sanitized-value [["toka"] ["kolmas"] [] nil])))
+        "dropdown"
+        "multipleChoice"
+        "singleChoice"))))
+
+(deftest text-field-values
+  (testing "text field values"
+    (testing "are not filtered"
+      (let [field-descriptor text-field-question
+            answer-value     [["foo"] ["bar"] ["baz"]]
+            sanitized-value  (common/sanitize-value field-descriptor answer-value 3)]
+        (is (= sanitized-value answer-value))))
+    (testing "are nil padded to question group maximum dimension"
+      (let [field-descriptor text-field-question
+            answer-value     [["foo"] ["bar"] ["baz"]]
+            sanitized-value  (common/sanitize-value field-descriptor answer-value 5)]
+        (is (= sanitized-value [["foo"] ["bar"] ["baz"] nil nil]))))))
+  

--- a/test/cljs/unit/ataru/hakija/application_test.cljs
+++ b/test/cljs/unit/ataru/hakija/application_test.cljs
@@ -114,6 +114,17 @@
                                             :default-option "suomi"}
                           :metadata metadata}]})
 
+(def flat-form-with-question-group
+  [{:id          "G__2",
+    :label       {:fi "kenttä1", :sv ""},
+    :params      {:size "S" :question-group-id "1234"},
+    :validators  ["required"]
+    :fieldType   "singleChoice",
+    :options     [{:value "0",},
+                  {:value "1",}],
+    :fieldClass  "formField"
+    :metadata    metadata}])
+
 (deftest flattens-correctly
   (let [expected [{:id         "G__1",
                    :label      {:fi "osio1", :sv "Avsnitt namn"},
@@ -217,6 +228,15 @@
                     :valid  true
                     :label  {:fi "ulkokenttä", :sv ""}}}
            initial-answers))))
+
+(deftest correct-initial-value-for-single-choice-question-group-field
+  (let [initial-answers (create-initial-answers flat-form-with-question-group nil nil)]
+    (is (=
+          {:G__2 {:valid false,
+                  :value [nil],
+                  :values [nil],
+                  :label {:fi "kenttä1", :sv ""}}}
+          initial-answers))))
 
 (defn check-language-and-validity [initial-answers, lang, valid]
   (is (= {:language {:value  lang

--- a/test/cljs/unit/ataru/unit_runner.cljs
+++ b/test/cljs/unit/ataru/unit_runner.cljs
@@ -19,6 +19,7 @@
             [ataru.collections-test]
             [ataru.hakija.handlers-util-test]
             [ataru.application-common.hakukohde-specific-questions-test]
+            [ataru.application-common.application-field-common-test]
             [ataru.hakija.form-tools-test]
             [ataru.liitteet-test]))
 
@@ -41,5 +42,6 @@
            'ataru.collections-test
            'ataru.hakija.handlers-util-test
            'ataru.application-common.hakukohde-specific-questions-test
+           'ataru.application-common.application-field-common-test
            'ataru.hakija.form-tools-test
            'ataru.liitteet-test)


### PR DESCRIPTION
Previously only question group fields with allowed option values (eg. dropdowns, single selects, multiselects) were nil-padded in sanitization phase. Do the same nil padding for other formFields (eg. text fields) as well.

Also fixes a related issue where empty singleChoice fields were not initialized correctly (= in the same way as completely empty form) on form modification.