### PR TITLE
OY-4718 hide empty application changes from the change UI

### DIFF
--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -190,15 +190,16 @@
 
 (defn keep-non-empty-changes
   [changes]
-  (let [is-non-empty-value? (fn [value] (and (some? value)
-                                             (or (number? value) (seq value))))
-        keep-if-non-empty-change (fn [[id change]]
-                                   (when (or (is-non-empty-value? (:new change))
-                                             (is-non-empty-value? (:old change)))
-                                     [id change]))]
-    (->> changes
-         (map keep-if-non-empty-change)
-         (remove nil?)
-         (into {}))))
+  (when (some? changes)
+    (let [is-non-empty-value? (fn [value] (and (some? value)
+                                               (or (number? value) (seq value))))
+          keep-if-non-empty-change (fn [[id change]]
+                                     (when (or (is-non-empty-value? (:new change))
+                                               (is-non-empty-value? (:old change)))
+                                       [id change]))]
+      (->> changes
+           (map keep-if-non-empty-change)
+           (remove nil?)
+           (into {})))))
 
 (defn classes [& cs] (string/join " " (vec cs)))

--- a/src/cljs/ataru/cljs_util.cljs
+++ b/src/cljs/ataru/cljs_util.cljs
@@ -188,4 +188,17 @@
     value
     (.toLocaleString (js/Number value) "fi")))
 
+(defn keep-non-empty-changes
+  [changes]
+  (let [is-non-empty-value? (fn [value] (and (some? value)
+                                             (or (number? value) (seq value))))
+        keep-if-non-empty-change (fn [[id change]]
+                                   (when (or (is-non-empty-value? (:new change))
+                                             (is-non-empty-value? (:old change)))
+                                     [id change]))]
+    (->> changes
+         (map keep-if-non-empty-change)
+         (remove nil?)
+         (into {}))))
+
 (defn classes [& cs] (string/join " " (vec cs)))

--- a/src/cljs/ataru/virkailija/application/application_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/application_subs.cljs
@@ -851,10 +851,11 @@
 (defn- modify-event-changes
   [events change-history event-id]
   (let [modify-events (filter util/modify-event? events)]
-    (some (fn [[event changes]]
-            (when (= event-id (:id event))
-              changes))
-          (map vector modify-events change-history))))
+    (util/keep-non-empty-changes
+     (some (fn [[event changes]]
+             (when (= event-id (:id event))
+               changes))
+           (map vector modify-events change-history)))))
 
 (defn- replace-change-value-with-label
   [change field lang]

--- a/test/cljs/unit/ataru/cljs_util_test.cljs
+++ b/test/cljs/unit/ataru/cljs_util_test.cljs
@@ -15,3 +15,15 @@
 (deftest generates-rfc-4122-version-4-uuids
   (let [uuid (util/new-uuid)]
     (is (re-matches #"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89ab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$" uuid))))
+
+(deftest keeps-non-empty-event-changes
+  (let [changes {:1 {:old "" :new nil}
+                 :2 {:old ["1"] :new []}
+                 :3 {:old nil :new nil}
+                 :4 {:old nil :new []}
+                 :5 {:old [] :new "1"}
+                 :6 {:old 1 :new nil}
+                 :7 {:old [nil "1"] :new []}}
+        non-empty-changes (util/keep-non-empty-changes changes)]
+    (is (= non-empty-changes
+           (select-keys changes [:2 :5 :6 :7])))))


### PR DESCRIPTION
Changes like [] -> nil or "" -> [] were shown in the virkailija application changeset UI. Hide those.

There are probably more changes that should be hidden as well (eg. empty arrays of empty strings / arrays etc.), but let's start carefully.