### PR TITLE
OY-4772 Filter out nil attachments in question groups, assume that th…

### DIFF
--- a/src/clj/ataru/email/application_email.clj
+++ b/src/clj/ataru/email/application_email.clj
@@ -217,7 +217,8 @@
                                               (filter #(or (not (contains? answers-by-key (keyword %)))
                                                            (or (empty? (:value ((keyword %) answers-by-key)))
                                                                (and (coll? (:value ((keyword %) answers-by-key)))
-                                                                    (boolean (not-empty (filter empty? (:value ((keyword %) answers-by-key)))))))))
+                                                                    (boolean (not-empty (filter (fn [value] (and (some? value)
+                                                                                                                 (empty? value))) (:value ((keyword %) answers-by-key)))))))))
                                               set)
          attachments-without-answer      (->> flat-form-fields
                                               (filter #(and (contains? attachment-keys-without-answers (:id %))


### PR DESCRIPTION
…ey are not really missing.

A preferable state would be that a missing attachment would be represented by an empty array [], and unneeded attachments (inside a question group) would be nil-values.
This needs to be confirmed, though.