### PR TITLE
OY-4800 Use 1st of June of application year as lähtökoulu cutoff date in yhteishaku

### DIFF
--- a/spec/ataru/suoritus/suoritus_service_spec.clj
+++ b/spec/ataru/suoritus/suoritus_service_spec.clj
@@ -72,7 +72,7 @@
                     (spec)))
 
           (it "returns most recently started student class data filtered by luokkatasot when no cutoff date specified"
-              (let [data (suoritus-service/opiskelija service test-henkilo-oid [test-year] test-luokkatasot nil)]
+              (let [data (suoritus-service/opiskelijan-luokkatieto service test-henkilo-oid [test-year] test-luokkatasot nil)]
                 (should= {:oppilaitos-oid "1.1.111.111.111.111"
                           :luokka "TELMA"
                           :luokkataso "TELMA"
@@ -81,7 +81,7 @@
                          data)))
 
           (it "returns student class data that is ongoing on cutoff date"
-              (let [data (suoritus-service/opiskelija service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2023-03-02T21:00:00.000Z"))]
+              (let [data (suoritus-service/opiskelijan-luokkatieto service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2023-03-02T21:00:00.000Z"))]
                 (should= {:oppilaitos-oid "1.2.222.222.222.222"
                           :luokka "9E"
                           :luokkataso "9"
@@ -92,7 +92,7 @@
           (it "returns latest ongoing student class data by start date on cutoff date"
               (with-redefs [suoritus-client/opiskelijat (stub :opiskelijat
                                                               {:return test-client-response-overlapping})]
-                (let [data (suoritus-service/opiskelija service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2023-03-02T21:00:00.000Z"))]
+                (let [data (suoritus-service/opiskelijan-luokkatieto service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2023-03-02T21:00:00.000Z"))]
                   (should= {:oppilaitos-oid "1.4.444.444.444.444"
                             :luokka "TELMA"
                             :luokkataso "TELMA"
@@ -101,6 +101,6 @@
                            data))))
 
           (it "doesn't return student class data if nothing was ongoing on cutoff date"
-              (let [data (suoritus-service/opiskelija service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2019-08-02T21:00:00.000Z"))]
+              (let [data (suoritus-service/opiskelijan-luokkatieto service test-henkilo-oid [test-year] test-luokkatasot (str->timestamp "2019-08-02T21:00:00.000Z"))]
                 (should= nil
                          data))))

--- a/spec/ataru/virkailija/virkailija_application_service_spec.clj
+++ b/spec/ataru/virkailija/virkailija_application_service_spec.clj
@@ -1,0 +1,41 @@
+(ns ataru.virkailija.virkailija-application-service-spec
+  (:require [ataru.virkailija.virkailija-application-service :as application-service]
+            [clj-time.coerce :as coerce]
+            [speclj.core :refer [describe it should= should-be-nil tags]]))
+
+(defn str->timestamp [str] (coerce/to-timestamp (coerce/from-string str)))
+
+(def yhteishaku-tarjonta
+  {:tarjonta
+   {:hakukohteet                      []
+    :haku-oid                         "haku-oid"
+    :hakuaika                         {:start (str->timestamp "2023-03-02T00:00:00.000Z")
+                                       :end   (str->timestamp "2023-05-05T00:00:00.000Z")}
+    :kohdejoukko-uri                  "haunkohdejoukko_11#1"
+    :yhteishaku                       true}})
+
+(def non-yhteishaku-tarjonta
+  {:tarjonta
+   {:hakukohteet                      []
+    :haku-oid                         "haku-oid"
+    :hakuaika                         {:start (str->timestamp "2023-03-02T00:00:00.000Z")
+                                       :end   (str->timestamp "2023-05-05T00:00:00.000Z")}
+    :kohdejoukko-uri                  "haunkohdejoukko_13#1"
+    :yhteishaku                       false}})
+
+(describe "get-lahtokoulu-cutoff-timestamp"
+          (tags :unit)
+
+          (it "should return haku end timestamp for non-yhteishaku"
+              (should=
+                (str->timestamp "2023-05-05T00:00:00.000Z")
+                (application-service/get-lahtokoulu-cutoff-timestamp 2023 non-yhteishaku-tarjonta)))
+
+          (it "should return timestamp for 1st of June on haku year for yhteishaku"
+              (should=
+                (str->timestamp "2016-06-01T00:00:00.000Z")
+                (application-service/get-lahtokoulu-cutoff-timestamp 2016 yhteishaku-tarjonta)))
+
+          (it "should return nil, eg. no cutoff, when tarjonta data is completely missing"
+              (should-be-nil
+                (application-service/get-lahtokoulu-cutoff-timestamp 2016 {}))))

--- a/src/clj/ataru/odw/odw_service.clj
+++ b/src/clj/ataru/odw/odw_service.clj
@@ -118,7 +118,7 @@
                                                pohjakoulutus (:POHJAKOULUTUS koosteData)
                                                opetuskieli (:perusopetuksen_kieli koosteData)
                                                suoritusvuosi (:pohjakoulutus_vuosi koosteData)
-                                               luokkatieto (suoritus-service/opiskelija suoritus-service person-oid (vector application-year) (suoritus-filter/luokkatasot-for-suoritus-filter) nil)
+                                               luokkatieto (suoritus-service/opiskelijan-luokkatieto suoritus-service person-oid (vector application-year) (suoritus-filter/luokkatasot-for-suoritus-filter) nil)
                                                lahtoluokka (:luokka luokkatieto)
                                                luokkataso (:luokkataso luokkatieto)
                                                lahtokoulu-oid (:oppilaitos-oid luokkatieto)]

--- a/src/clj/ataru/suoritus/suoritus_service.clj
+++ b/src/clj/ataru/suoritus/suoritus_service.clj
@@ -20,7 +20,7 @@
   (oppilaitoksen-opiskelijat [this oppilaitos-oid vuosi luokkatasot])
   (oppilaitoksen-opiskelijat-useammalle-vuodelle [this oppilaitos-oid vuodet luokkatasot])
   (oppilaitoksen-luokat [this oppilaitos-oid vuosi luokkatasot])
-  (opiskelija [this henkilo-oid vuodet luokkatasot cutoff-timestamp]))
+  (opiskelijan-luokkatieto [this henkilo-oid vuodet luokkatasot cutoff-timestamp]))
 
 (defrecord HttpSuoritusService [suoritusrekisteri-cas-client oppilaitoksen-opiskelijat-cache oppilaitoksen-luokat-cache]
   component/Lifecycle
@@ -43,7 +43,7 @@
     (let [luokkatasot-str (string/join "," luokkatasot)
           cache-key (str oppilaitos-oid "#" vuosi "#" luokkatasot-str)]
       (cache/get-from oppilaitoksen-luokat-cache cache-key)))
-  (opiskelija [_ henkilo-oid vuodet luokkatasot cutoff-timestamp]
+  (opiskelijan-luokkatieto [_ henkilo-oid vuodet luokkatasot cutoff-timestamp]
               ; If there's a cutoff timestamp given, only consider luokka data still ongoing on that date.
               (let [cutoff-fn (fn [opiskelija]
                                 (let [start-date (coerce/from-string (:alkupaiva opiskelija))

--- a/src/clj/ataru/virkailija/virkailija_application_service.clj
+++ b/src/clj/ataru/virkailija/virkailija_application_service.clj
@@ -47,7 +47,7 @@
         cutoff-timestamp (get-lahtokoulu-cutoff-timestamp hakuvuosi tarjonta-info)
         linked-oids (get (person-service/linked-oids person-service [henkilo-oid]) henkilo-oid)
         aliases     (conj (:linked-oids linked-oids) (:master-oid linked-oids))
-        opiskelijat (map #(suoritus-service/opiskelija suoritus-service % [hakuvuosi] luokkatasot cutoff-timestamp)
+        opiskelijat (map #(suoritus-service/opiskelijan-luokkatieto suoritus-service % [hakuvuosi] luokkatasot cutoff-timestamp)
                          aliases)]
     (when-let [opiskelija (last (sort-by :alkupaiva opiskelijat))]
       (let [[organization] (organization-service/get-organizations-for-oids

--- a/src/clj/ataru/virkailija/virkailija_application_service.clj
+++ b/src/clj/ataru/virkailija/virkailija_application_service.clj
@@ -20,14 +20,14 @@
 
 ; In case of peruskoulun jälkeisen koulutuksen yhteishaku, it's specified
 ; that lähtökoulu information should be based on whatever school the student
-; was in on 1th of June of the application year. In other applications,
+; was in up to 1st of June of the application year. In other applications,
 ; we use application end date.
-(defn- get-lahtokoulu-cutoff-timestamp
+(defn get-lahtokoulu-cutoff-timestamp
   [hakuvuosi tarjonta-info]
   (let [haku-end (get-in tarjonta-info [:tarjonta :hakuaika :end])
-        lahtokoulu-yhteishaku-cutoff-date (time/date-time hakuvuosi 1 6)]
-    (if (haku/toisen-asteen-yhteishaku? tarjonta-info)
-      (coerce/to-long lahtokoulu-yhteishaku-cutoff-date)
+        lahtokoulu-yhteishaku-cutoff-date (time/date-time hakuvuosi 6 1)]
+    (if (haku/toisen-asteen-yhteishaku? (:tarjonta tarjonta-info))
+      (coerce/to-timestamp lahtokoulu-yhteishaku-cutoff-date)
       haku-end)))
 
 (defn get-opiskelija

--- a/src/clj/ataru/virkailija/virkailija_application_service.clj
+++ b/src/clj/ataru/virkailija/virkailija_application_service.clj
@@ -30,7 +30,7 @@
       (coerce/to-timestamp lahtokoulu-yhteishaku-cutoff-date)
       haku-end)))
 
-(defn get-opiskelija
+(defn get-opiskelijan-luokkatieto
   [henkilo-oid haku-oid hakemus-datetime koodisto-cache tarjonta-service
    organization-service ohjausparametrit-service person-service suoritus-service]
   (let [hakuvuosi   (->> hakemus-datetime

--- a/src/clj/ataru/virkailija/virkailija_application_service.clj
+++ b/src/clj/ataru/virkailija/virkailija_application_service.clj
@@ -1,14 +1,59 @@
-(ns ataru.virkailija.virkailija-application-service 
+(ns ataru.virkailija.virkailija-application-service
   (:require [ataru.applications.application-store :as application-store]
+            [ataru.applications.suoritus-filter :as suoritus-filter]
             [ataru.applications.synthetic-application-util :as synthetic-application-util]
             [ataru.hakija.hakija-form-service :as hakija-form-service]
             [ataru.hakija.validator :as validator]
             [ataru.log.audit-log :as audit-log]
+            [ataru.organization-service.organization-service :as organization-service]
+            [ataru.person-service.person-service :as person-service]
+            [ataru.suoritus.suoritus-service :as suoritus-service]
             [ataru.tarjonta-service.tarjonta-parser :as tarjonta-parser]
+            [ataru.tarjonta.haku :as haku]
             [ataru.util :as util]
+            [clj-time.core :as time]
+            [clj-time.coerce :as coerce]
+            [clj-time.format :as format]
             [taoensso.timbre :as log]
             [ataru.person-service.person-integration :as person-integration]
             [ataru.ohjausparametrit.ohjausparametrit-protocol :as ohjausparametrit]))
+
+; In case of peruskoulun jälkeisen koulutuksen yhteishaku, it's specified
+; that lähtökoulu information should be based on whatever school the student
+; was in on 1th of June of the application year. In other applications,
+; we use application end date.
+(defn- get-lahtokoulu-cutoff-timestamp
+  [hakuvuosi tarjonta-info]
+  (let [haku-end (get-in tarjonta-info [:tarjonta :hakuaika :end])
+        lahtokoulu-yhteishaku-cutoff-date (time/date-time hakuvuosi 1 6)]
+    (if (haku/toisen-asteen-yhteishaku? tarjonta-info)
+      (coerce/to-long lahtokoulu-yhteishaku-cutoff-date)
+      haku-end)))
+
+(defn get-opiskelija
+  [henkilo-oid haku-oid hakemus-datetime koodisto-cache tarjonta-service
+   organization-service ohjausparametrit-service person-service suoritus-service]
+  (let [hakuvuosi   (->> hakemus-datetime
+                         (format/parse (:date-time format/formatters))
+                         (suoritus-filter/year-for-suoritus-filter))
+        luokkatasot (suoritus-filter/luokkatasot-for-suoritus-filter)
+        tarjonta-info (when haku-oid
+                        (tarjonta-parser/parse-tarjonta-info-by-haku
+                          koodisto-cache
+                          tarjonta-service
+                          organization-service
+                          ohjausparametrit-service
+                          haku-oid))
+        cutoff-timestamp (get-lahtokoulu-cutoff-timestamp hakuvuosi tarjonta-info)
+        linked-oids (get (person-service/linked-oids person-service [henkilo-oid]) henkilo-oid)
+        aliases     (conj (:linked-oids linked-oids) (:master-oid linked-oids))
+        opiskelijat (map #(suoritus-service/opiskelija suoritus-service % [hakuvuosi] luokkatasot cutoff-timestamp)
+                         aliases)]
+    (when-let [opiskelija (last (sort-by :alkupaiva opiskelijat))]
+      (let [[organization] (organization-service/get-organizations-for-oids
+                             organization-service [(:oppilaitos-oid opiskelija)])]
+        {:oppilaitos-name (:name organization)
+         :luokka          (:luokka opiskelija)}))))
 
 (defn- uses-synthetic-applications?
   [ohjausparametrit-service haku-oid]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -498,14 +498,15 @@
         :path-params [henkilo-oid :- String]
         :query-params [haku-oid :- String
                        hakemus-datetime :- String]
-        :summary "Returns opiskelija information from suoritusrekisteri"
-        :return ataru-schema/OpiskelijaResponse
-        (let [opiskelija (virkailija-application-service/get-opiskelija henkilo-oid haku-oid hakemus-datetime
-                                                       koodisto-cache tarjonta-service organization-service
-                                                       ohjausparametrit-service person-service suoritus-service)]
-          (if opiskelija
-            (response/ok opiskelija)
-            (response/not-found {:error (str "Opiskelija information not found for henkilo-oid " henkilo-oid)}))))
+        :summary "Returns opiskelijan luokkatieto information from suoritusrekisteri"
+        :return ataru-schema/OpiskelijaLuokkatietoResponse
+        (let [luokkatieto (virkailija-application-service/get-opiskelijan-luokkatieto
+                            henkilo-oid haku-oid hakemus-datetime
+                            koodisto-cache tarjonta-service organization-service
+                            ohjausparametrit-service person-service suoritus-service)]
+          (if luokkatieto
+            (response/ok luokkatieto)
+            (response/not-found {:error (str "Opiskelijan luokkatieto information not found for henkilo-oid " henkilo-oid)}))))
 
       (api/GET "/virkailija-settings" {session :session}
         :return ataru-schema/VirkailijaSettings

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -84,11 +84,8 @@
             [ataru.suoritus.suoritus-service :as suoritus-service]
             [clj-time.core :as time]
             [ataru.applications.suoritus-filter :as suoritus-filter]
-            [ataru.person-service.person-service :as person-service]
             [ataru.valintalaskentakoostepalvelu.pohjakoulutus-toinen-aste :as pohjakoulutus-toinen-aste]
-            [ataru.tarjonta-service.tarjonta-parser :as tarjonta-parser]
             [cuerdas.core :as str]
-            [clj-time.format :as f]
             [ataru.virkailija.virkailija-application-service :as virkailija-application-service])
   (:import java.util.Locale
            java.time.ZonedDateTime
@@ -503,26 +500,11 @@
                        hakemus-datetime :- String]
         :summary "Returns opiskelija information from suoritusrekisteri"
         :return ataru-schema/OpiskelijaResponse
-        (let [hakuvuosi   (->> hakemus-datetime
-                               (f/parse (:date-time f/formatters))
-                               (suoritus-filter/year-for-suoritus-filter))
-              luokkatasot (suoritus-filter/luokkatasot-for-suoritus-filter)
-              tarjonta-info (when haku-oid
-                              (tarjonta-parser/parse-tarjonta-info-by-haku
-                               koodisto-cache
-                               tarjonta-service
-                               organization-service
-                               ohjausparametrit-service
-                               haku-oid))
-              haku-end    (get-in tarjonta-info [:tarjonta :hakuaika :end])
-              linked-oids (get (person-service/linked-oids person-service [henkilo-oid]) henkilo-oid)
-              aliases     (conj (:linked-oids linked-oids) (:master-oid linked-oids))
-              opiskelijat (map #(suoritus-service/opiskelija suoritus-service % [hakuvuosi] luokkatasot haku-end) aliases)]
-          (if-let [opiskelija (last (sort-by :alkupaiva opiskelijat))]
-            (let [[organization] (organization-service/get-organizations-for-oids organization-service [(:oppilaitos-oid opiskelija)])]
-              (response/ok
-                {:oppilaitos-name (:name organization)
-                 :luokka          (:luokka opiskelija)}))
+        (let [opiskelija (virkailija-application-service/get-opiskelija henkilo-oid haku-oid hakemus-datetime
+                                                       koodisto-cache tarjonta-service organization-service
+                                                       ohjausparametrit-service person-service suoritus-service)]
+          (if opiskelija
+            (response/ok opiskelija)
             (response/not-found {:error (str "Opiskelija information not found for henkilo-oid " henkilo-oid)}))))
 
       (api/GET "/virkailija-settings" {session :session}

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -921,7 +921,7 @@
    :yo-amm-autom-hakukelpoisuus                                s/Bool
    s/Any                                                       s/Any})
 
-(s/defschema OpiskelijaResponse
+(s/defschema OpiskelijaLuokkatietoResponse
   {:oppilaitos-name localized-schema/LocalizedStringOptional
    :luokka s/Str})
 


### PR DESCRIPTION
Spec: in case of peruskoulun jälkeisen koulutuksen yhteishaku, lähtökoulu cutoff date should be 1st of June of the application year. Otherwise the end of the application period.

+ Moved the logic from routes to service.
+ Renamed suoritus-service.opiskelija to opiskelijan-luokkatieto to better match data that is returned.