### PR TITLE
OK-529 dynamically add hakemusmaksu to form data when editing / filling

### DIFF
--- a/spec/ataru/forms/form_payment_info_spec.clj
+++ b/spec/ataru/forms/form_payment_info_spec.clj
@@ -74,77 +74,87 @@
           (describe "with old tarjonta-service (basic sanity checks)"
                     (it "returns existing payment info when no haku given"
                         (let [tarjonta-service (mts/->MockTarjontaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-non-kk-form-with-existing-payment-info nil)]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-non-kk-form-with-existing-payment-info nil)
+                              payment-info (:properties form-with-payment-info)]
                           (should= test-payment-info payment-info)))
 
                     (it "sets payment info dynamically if higher education"
                         (let [tarjonta-service (mts/->MockTarjontaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-kk-form
-                                             (tarjonta-service/get-haku tarjonta-service
-                                                                        "payment-info-test-kk-haku"))]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-kk-form
+                                                       (tarjonta-service/get-haku tarjonta-service
+                                                                                  "payment-info-test-kk-haku"))
+                              payment-info (:properties form-with-payment-info)]
                           (should= expected-payment-info payment-info)))
 
                     (it "doesn't set payment info dynamically if not higher education"
                         (let [tarjonta-service (mts/->MockTarjontaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-non-kk-form
-                                             (tarjonta-service/get-haku tarjonta-service
-                                                                        "payment-info-test-non-kk-haku"))]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-non-kk-form
+                                                       (tarjonta-service/get-haku tarjonta-service
+                                                                                  "payment-info-test-non-kk-haku"))
+                              payment-info (:properties form-with-payment-info)]
                           (should-be empty? payment-info))))
 
           (describe "with kouta tarjonta-service"
                     (it "returns existing payment info when no haku given"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-non-kk-form-with-existing-payment-info nil)]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-non-kk-form-with-existing-payment-info nil)
+                              payment-info (:properties form-with-payment-info)]
                           (should= test-payment-info payment-info)))
 
                     (it "returns existing payment info when hakemusmaksu criteria is not met"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-non-kk-form-with-existing-payment-info
-                                             (tarjonta-service/get-haku tarjonta-service
-                                                                        "payment-info-test-non-kk-haku"))]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-non-kk-form-with-existing-payment-info
+                                                       (tarjonta-service/get-haku tarjonta-service
+                                                                                  "payment-info-test-non-kk-haku"))
+                              payment-info (:properties form-with-payment-info)]
                           (should= test-payment-info payment-info)))
 
                     (it "sets payment info dynamically if higher education"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-kk-form
-                                             (tarjonta-service/get-haku tarjonta-service
-                                                                        "payment-info-test-kk-haku"))]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-kk-form
+                                                       (tarjonta-service/get-haku tarjonta-service
+                                                                                  "payment-info-test-kk-haku"))
+                              payment-info (:properties form-with-payment-info)]
                           (should= expected-payment-info payment-info)))
 
                     (it "doesn't set payment info dynamically if not higher education"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-non-kk-form
-                                             (tarjonta-service/get-haku tarjonta-service
-                                                                        "payment-info-test-non-kk-haku"))]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-non-kk-form
+                                                       (tarjonta-service/get-haku tarjonta-service
+                                                                                  "payment-info-test-non-kk-haku"))
+                              payment-info (:properties form-with-payment-info)]
                           (should-be empty? payment-info)))
 
                     (it "doesn't set payment info dynamically if not tutkintoon johtava"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-kk-no-tutkinto-form
-                                             (tarjonta-service/get-haku tarjonta-service
-                                                                        "payment-info-test-kk-no-tutkinto-haku"))]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-kk-no-tutkinto-form
+                                                       (tarjonta-service/get-haku tarjonta-service
+                                                                                  "payment-info-test-kk-no-tutkinto-haku"))
+                              payment-info (:properties form-with-payment-info)]
                           (should-be empty? payment-info)))
 
                     (it "doesn't set payment info dynamically if non-siirtohaku"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-kk-jatko-form
-                                             (tarjonta-service/get-haku tarjonta-service
-                                                                        "payment-info-test-kk-jatko-haku"))]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-kk-jatko-form
+                                                       (tarjonta-service/get-haku tarjonta-service
+                                                                                  "payment-info-test-kk-jatko-haku"))
+                              payment-info (:properties form-with-payment-info)]
                           (should-be empty? payment-info)))
 
                     (it "overrides payment info on the form when hakemusmaksu criteria is met"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              payment-info (payment-info/get-payment-info
-                                             tarjonta-service test-kk-form-with-existing-payment-info
-                                             (tarjonta-service/get-haku tarjonta-service
-                                                                        "payment-info-test-kk-haku"))]
+                              form-with-payment-info (payment-info/get-form-with-payment-info
+                                                       tarjonta-service test-kk-form-with-existing-payment-info
+                                                       (tarjonta-service/get-haku tarjonta-service
+                                                                                  "payment-info-test-kk-haku"))
+                              payment-info (:properties form-with-payment-info)]
                           (should= expected-payment-info payment-info)))))

--- a/spec/ataru/forms/form_payment_info_spec.clj
+++ b/spec/ataru/forms/form_payment_info_spec.clj
@@ -35,6 +35,39 @@
 (def test-non-kk-form-with-existing-payment-info
   (merge test-non-kk-form {:properties test-payment-info}))
 
+(describe "add-admission-payment-info-for-haku"
+          (tags :unit)
+
+          (it "sets payment needed as true with higher education"
+              (let [tarjonta-service (mts/->MockTarjontaKoutaService)
+                    haku {:name { :fi "Testihaku 1"}
+                          :oid "payment-info-test-kk-haku"
+                          :kohdejoukko-uri "haunkohdejoukko_12#1"
+                          :hakukohteet ["payment-info-test-kk-hakukohde"] }
+                    haku-with-payment-flag (payment-info/add-admission-payment-info-for-haku
+                                             tarjonta-service haku)]
+                (should= true(:admission-payment-required? haku-with-payment-flag))))
+
+          (it "sets payment needed as false for non higher education"
+              (let [tarjonta-service (mts/->MockTarjontaKoutaService)
+                    haku {:name { :fi "Testihaku 2" }
+                          :oid "payment-info-test-non-kk-haku"
+                          :kohdejoukko-uri "haunkohdejoukko_11#1"
+                          :hakukohteet ["payment-info-test-non-kk-hakukohde"] }
+                    haku-with-payment-flag (payment-info/add-admission-payment-info-for-haku
+                                             tarjonta-service haku)]
+                (should= false (:admission-payment-required? haku-with-payment-flag))))
+
+          (it "sets payment needed as false for unknown haku"
+              (let [tarjonta-service (mts/->MockTarjontaKoutaService)
+                    haku {:name { :fi "Testihaku 2" }
+                          :oid "payment-info-test-unknown-haku"
+                          :kohdejoukko-uri "haunkohdejoukko_12#1"
+                          :hakukohteet ["payment-info-test-unknown-hakukohde"] }
+                    haku-with-payment-flag (payment-info/add-admission-payment-info-for-haku
+                                             tarjonta-service haku)]
+                (should= false (:admission-payment-required? haku-with-payment-flag)))))
+
 (describe "get-payment-info"
           (tags :unit)
 

--- a/spec/ataru/forms/form_payment_info_spec.clj
+++ b/spec/ataru/forms/form_payment_info_spec.clj
@@ -6,7 +6,7 @@
     [ataru.tarjonta-service.mock-tarjonta-service :as mts]))
 
 (def expected-payment-info
-  {:payment-type :payment-type-kk,
+  {:payment-type "payment-type-kk",
    :processing-fee (str payment-info/kk-processing-fee),
    :decision-fee nil})
 
@@ -68,21 +68,22 @@
                                              tarjonta-service haku)]
                 (should= false (:admission-payment-required? haku-with-payment-flag)))))
 
-(describe "get-payment-info"
+(describe "populate-form-with-payment-info"
           (tags :unit)
 
           (describe "with old tarjonta-service (basic sanity checks)"
                     (it "returns existing payment info when no haku given"
                         (let [tarjonta-service (mts/->MockTarjontaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-non-kk-form-with-existing-payment-info nil)
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-non-kk-form-with-existing-payment-info tarjonta-service nil)
                               payment-info (:properties form-with-payment-info)]
                           (should= test-payment-info payment-info)))
 
                     (it "sets payment info dynamically if higher education"
                         (let [tarjonta-service (mts/->MockTarjontaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-kk-form
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-kk-form
+                                                       tarjonta-service
                                                        (tarjonta-service/get-haku tarjonta-service
                                                                                   "payment-info-test-kk-haku"))
                               payment-info (:properties form-with-payment-info)]
@@ -90,8 +91,9 @@
 
                     (it "doesn't set payment info dynamically if not higher education"
                         (let [tarjonta-service (mts/->MockTarjontaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-non-kk-form
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-non-kk-form
+                                                       tarjonta-service
                                                        (tarjonta-service/get-haku tarjonta-service
                                                                                   "payment-info-test-non-kk-haku"))
                               payment-info (:properties form-with-payment-info)]
@@ -100,15 +102,18 @@
           (describe "with kouta tarjonta-service"
                     (it "returns existing payment info when no haku given"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-non-kk-form-with-existing-payment-info nil)
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-non-kk-form-with-existing-payment-info
+                                                       tarjonta-service
+                                                       nil)
                               payment-info (:properties form-with-payment-info)]
                           (should= test-payment-info payment-info)))
 
                     (it "returns existing payment info when hakemusmaksu criteria is not met"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-non-kk-form-with-existing-payment-info
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-non-kk-form-with-existing-payment-info
+                                                       tarjonta-service
                                                        (tarjonta-service/get-haku tarjonta-service
                                                                                   "payment-info-test-non-kk-haku"))
                               payment-info (:properties form-with-payment-info)]
@@ -116,8 +121,9 @@
 
                     (it "sets payment info dynamically if higher education"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-kk-form
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-kk-form
+                                                       tarjonta-service
                                                        (tarjonta-service/get-haku tarjonta-service
                                                                                   "payment-info-test-kk-haku"))
                               payment-info (:properties form-with-payment-info)]
@@ -125,8 +131,9 @@
 
                     (it "doesn't set payment info dynamically if not higher education"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-non-kk-form
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-non-kk-form
+                                                       tarjonta-service
                                                        (tarjonta-service/get-haku tarjonta-service
                                                                                   "payment-info-test-non-kk-haku"))
                               payment-info (:properties form-with-payment-info)]
@@ -134,8 +141,9 @@
 
                     (it "doesn't set payment info dynamically if not tutkintoon johtava"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-kk-no-tutkinto-form
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-kk-no-tutkinto-form
+                                                       tarjonta-service
                                                        (tarjonta-service/get-haku tarjonta-service
                                                                                   "payment-info-test-kk-no-tutkinto-haku"))
                               payment-info (:properties form-with-payment-info)]
@@ -143,8 +151,9 @@
 
                     (it "doesn't set payment info dynamically if non-siirtohaku"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-kk-jatko-form
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-kk-jatko-form
+                                                       tarjonta-service
                                                        (tarjonta-service/get-haku tarjonta-service
                                                                                   "payment-info-test-kk-jatko-haku"))
                               payment-info (:properties form-with-payment-info)]
@@ -152,8 +161,9 @@
 
                     (it "overrides payment info on the form when hakemusmaksu criteria is met"
                         (let [tarjonta-service (mts/->MockTarjontaKoutaService)
-                              form-with-payment-info (payment-info/get-form-with-payment-info
-                                                       tarjonta-service test-kk-form-with-existing-payment-info
+                              form-with-payment-info (payment-info/populate-form-with-payment-info
+                                                       test-kk-form-with-existing-payment-info
+                                                       tarjonta-service
                                                        (tarjonta-service/get-haku tarjonta-service
                                                                                   "payment-info-test-kk-haku"))
                               payment-info (:properties form-with-payment-info)]

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -295,6 +295,26 @@
           (should= (map :id (filter cannot-view? fields))
                    [])))))
 
+  (it "should get form with dynamic kk payment info as hakija"
+      (with-redefs [hakuaika/hakukohteen-hakuaika hakuaika-ongoing]
+        (with-haku-form-response "1.2.246.562.29.65950024186" [:hakija :with-henkilo] resp
+           (should= 200 (:status resp))
+           (let [properties (->> resp :body :properties)]
+             (should-not (empty? properties))
+             (should= "payment-type-kk" (:payment-type properties))
+             (should= "100.00" (:processing-fee properties))
+             (should= nil (:decision-fee properties))))))
+
+  (it "should get form with dynamic kk payment info as virkailija without henkilo"
+      (with-redefs [hakuaika/hakukohteen-hakuaika hakuaika-ongoing]
+        (with-haku-form-response "1.2.246.562.29.65950024186" [:virkailija] resp
+           (should= 200 (:status resp))
+           (let [properties (->> resp :body :properties)]
+             (should-not (empty? properties))
+             (should= "payment-type-kk" (:payment-type properties))
+             (should= "100.00" (:processing-fee properties))
+             (should= nil (:decision-fee properties))))))
+
   (it "should get application with hakuaika ended"
     (with-redefs [hakuaika/hakukohteen-hakuaika hakuaika-ended-within-grace-period]
       (with-haku-form-response "1.2.246.562.29.65950024186" [:hakija :with-henkilo] resp

--- a/spec/ataru/virkailija/virkailija_routes_spec.clj
+++ b/spec/ataru/virkailija/virkailija_routes_spec.clj
@@ -617,8 +617,7 @@
           (it "should return admission-payment-required? false for non higher education admission"
               (let [resp (get-haku "payment-info-test-non-kk-form")
                     status (:status resp)
-                    body (:body resp)
-                    _ (println "BODY" body)]
+                    body (:body resp)]
                 (should= 200 status)
                 (should= 1 (count body))
                 (should= false (:admission-payment-required? (first body))))))

--- a/src/clj/ataru/forms/form_payment_info.clj
+++ b/src/clj/ataru/forms/form_payment_info.clj
@@ -118,13 +118,12 @@
              (str "Hakemusmaksua ei voi asettaa manuaalisesti: " [payment-type processing-fee decision-fee])))
     (add-payment-info-to-form form payment-type processing-fee decision-fee)))
 
-(defn get-payment-info
-  "Gets payment info for form. Should be always used to get payment info rather than querying
+(defn get-form-with-payment-info
+  "Adds payment info for form. Should be always used to get payment info rather than querying
    properties directly, because type and fees may be set and overridden dynamically."
   [tarjonta-service form haku]
-  (let [form-with-possible-kk-fees (add-payment-info-if-higher-education tarjonta-service form haku)
-        properties (:properties form-with-possible-kk-fees)]
-    (select-keys properties [:payment-type :processing-fee :decision-fee])))
+  (let [form-with-possible-kk-fees (add-payment-info-if-higher-education tarjonta-service form haku)]
+    form-with-possible-kk-fees))
 
 (defn add-admission-payment-info-for-haku
   "Adds info about admission payment requirement to a haku object"

--- a/src/clj/ataru/forms/form_payment_info.clj
+++ b/src/clj/ataru/forms/form_payment_info.clj
@@ -21,15 +21,15 @@
   [tarjonta-service haku]
   (let [hakukohteet (tarjonta/get-hakukohteet tarjonta-service (:hakukohteet haku))]
     (and
-      haku
-      hakukohteet
+      (boolean haku)
+      (boolean hakukohteet)
       ; Kohdejoukko must be korkeakoulutus
       (str/starts-with? (:kohdejoukko-uri haku) "haunkohdejoukko_12#")
       ; "Kohdejoukon tarkenne must be empty or siirtohaku
       (or (nil? (:kohdejoukon-tarkenne-uri haku))
           (str/starts-with? (:kohdejoukon-tarkenne-uri haku) "haunkohdejoukontarkenne_1#"))
       ; Must be tutkintoon johtava
-      (some true? (map #(:tutkintoon-johtava? %) hakukohteet)))))
+      (boolean (some true? (map #(:tutkintoon-johtava? %) hakukohteet))))))
 
 (defn- valid-fees?
   [payment-type processing-fee decision-fee]
@@ -125,3 +125,9 @@
   (let [form-with-possible-kk-fees (add-payment-info-if-higher-education tarjonta-service form haku)
         properties (:properties form-with-possible-kk-fees)]
     (select-keys properties [:payment-type :processing-fee :decision-fee])))
+
+(defn add-admission-payment-info-for-haku
+  "Adds info about admission payment requirement to a haku object"
+  [tarjonta-service haku]
+  (let [admission-payment-required? (requires-higher-education-application-fee? tarjonta-service haku)]
+    (assoc haku :admission-payment-required? admission-payment-required?)))

--- a/src/clj/ataru/hakija/hakija_form_service.clj
+++ b/src/clj/ataru/hakija/hakija_form_service.clj
@@ -1,6 +1,7 @@
 (ns ataru.hakija.hakija-form-service
   (:require [ataru.cache.cache-service :as cache]
             [ataru.forms.form-store :as form-store]
+            [ataru.forms.form-payment-info :as payment-info]
             [ataru.koodisto.koodisto :as koodisto]
             [ataru.forms.hakukohderyhmat :as hakukohderyhmat]
             [ataru.hakija.person-info-fields :refer [viewing-forbidden-person-info-field-ids
@@ -318,6 +319,7 @@
           (merge tarjonta-info)
           (assoc? :priorisoivat-hakukohderyhmat priorisoivat)
           (assoc? :rajaavat-hakukohderyhmat rajaavat)
+          (payment-info/populate-form-with-payment-info tarjonta-service (:tarjonta tarjonta-info))
           (populate-hakukohde-answer-options tarjonta-info)
           (populate-can-submit-multiple-applications tarjonta-info))
       (log/warn "Form (id: " id ", haku-oid: " haku-oid ", hakukohteet: " hakukohteet ") cannot be fetched. Possible reason can be missing hakukohteet."))))

--- a/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
@@ -118,12 +118,14 @@
    :1.2.246.562.29.65950024186               (merge
                                                base-haku
                                                {:oid              "1.2.246.562.29.65950024186"
+                                                :kohdejoukkoUri              "haunkohdejoukko_12#1"
+                                                :kohdejoukonTarkenne         "haunkohdejoukontarkenne_1#1"
                                                 :usePriority      true
                                                 :ataruLomakeAvain "41101b4f-1762-49af-9db0-e3603adae3ae"
                                                 :hakukohdeOids    ["1.2.246.562.20.49028196523"
                                                                    "1.2.246.562.20.49028196524"
                                                                    "1.2.246.562.20.49028196525"
-                                                                   "1.2.246.562.20.49028196526"]})
+                                                                   "1.2.246.562.20.11111111111"]})
    :1.2.246.562.29.65950024187               (merge
                                                base-haku
                                                {:oid              "1.2.246.562.29.65950024187"
@@ -338,7 +340,12 @@
    :payment-info-test-non-kk-hakukohde     (merge
                                              base-hakukohde
                                              {:oid          "payment-info-test-kk-hakukohde"
-                                              :tutkintoonJohtava true})})
+                                              :tutkintoonJohtava true})
+
+   :1.2.246.562.20.11111111111 (merge
+                                 base-hakukohde
+                                 {:oid          "1.2.246.562.20.11111111111"
+                                  :tutkintoonJohtava true})})
 
 (def koulutus
   {:1.2.246.562.17.74335799461 {:oid                  "1.2.246.562.17.74335799461"

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -21,6 +21,7 @@
             [ataru.forms.form-access-control :as access-controlled-form]
             [ataru.forms.form-store :as form-store]
             [ataru.forms.hakukohderyhmat :as hakukohderyhmat]
+            [ataru.forms.form-payment-info :as form-payment-info]
             [ataru.haku.haku-service :as haku-service]
             [ataru.information-request.information-request-service :as information-request]
             [ataru.koodisto.koodisto :as koodisto]
@@ -277,6 +278,7 @@
       (ok (->> (form-store/fetch-by-key key)
                (koodisto/populate-form-koodisto-fields koodisto-cache))))
 
+    ; TODO MAKSUT: do we need to also insert hakemusmaksu data here?
     (api/GET "/forms/latest-by-haku/:haku-oid" []
       :path-params [haku-oid :- s/Str]
       :return ataru-schema/FormWithContent
@@ -1155,9 +1157,13 @@
       (api/GET "/haku" []
         :query-params [form-key :- (api/describe s/Str "Form key")]
         :return [ataru-schema/Haku]
-        (-> (tarjonta/hakus-by-form-key tarjonta-service form-key)
+        (let [hakus (tarjonta/hakus-by-form-key tarjonta-service form-key)
+              hakus-with-payment-flag (map
+                                        #(form-payment-info/add-admission-payment-info-for-haku tarjonta-service %)
+                                        hakus)]
+        (-> hakus-with-payment-flag
             response/ok
-            (header "Cache-Control" "public, max-age=300")))
+            (header "Cache-Control" "public, max-age=300"))))
       (api/GET "/haku/:oid" []
         :path-params [oid :- (api/describe s/Str "Haku OID")]
         :return ataru-schema/Haku

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -278,7 +278,7 @@
       (ok (->> (form-store/fetch-by-key key)
                (koodisto/populate-form-koodisto-fields koodisto-cache))))
 
-    ; TODO MAKSUT: do we need to also insert hakemusmaksu data here?
+    ; TODO: do we need to also insert hakemusmaksu data here? Only used for virkailija hakemus browsing.
     (api/GET "/forms/latest-by-haku/:haku-oid" []
       :path-params [haku-oid :- s/Str]
       :return ataru-schema/FormWithContent

--- a/src/cljc/ataru/schema/form_element_schema.cljc
+++ b/src/cljc/ataru/schema/form_element_schema.cljc
@@ -22,5 +22,8 @@
                                                         (s/optional-key :allow-hakeminen-tunnistautuneena) s/Bool
                                                         (s/optional-key :demo-validity-start)              (s/maybe s/Str)
                                                         (s/optional-key :demo-validity-end)                (s/maybe s/Str)
-                                                        (s/optional-key :closed)                           s/Bool}
+                                                        (s/optional-key :closed)                           s/Bool
+                                                        (s/optional-key :payment-type)                     s/Str
+                                                        (s/optional-key :processing-fee)                   (s/maybe s/Str)
+                                                        (s/optional-key :decision-fee)                     (s/maybe s/Str)}
                    (s/optional-key :demo-allowed)      s/Bool})

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -293,7 +293,8 @@
    (s/optional-key :ataru-form-key)            s/Str
    (s/optional-key :max-hakukohteet)           s/Int
    (s/optional-key :valinnat-estetty-time-window) (s/maybe {:dateStart (s/maybe s/Int)
-                                                            :dateEnd   (s/maybe s/Int)})})
+                                                            :dateEnd   (s/maybe s/Int)})
+   (s/optional-key :admission-payment-required?) s/Bool})
 
 (s/defschema Hakukohderyhma
   {:oid             s/Str


### PR DESCRIPTION
Hakemusmaksu is dynamically determined by haku & hakukohde properties, so add it to form and haku on the fly whenever needed.

Built on top of OK-485 which has the base functionality, see separate PR.