### PR TITLE
OK-556 payment state logic for hakemusmaksu

### DIFF
--- a/.clj-kondo/babashka/sci/config.edn
+++ b/.clj-kondo/babashka/sci/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:macroexpand {sci.core/copy-ns sci.core/copy-ns}}}

--- a/.clj-kondo/babashka/sci/sci/core.clj
+++ b/.clj-kondo/babashka/sci/sci/core.clj
@@ -1,0 +1,9 @@
+(ns sci.core)
+
+(defmacro copy-ns
+  ([ns-sym sci-ns]
+   `(copy-ns ~ns-sym ~sci-ns nil))
+  ([ns-sym sci-ns opts]
+   `[(quote ~ns-sym)
+     ~sci-ns
+     (quote ~opts)]))

--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -1307,3 +1307,19 @@ cross join unnest(la.hakukohde) with ordinality as u(hakukohde_oid, idx)
 where la.haku = :haku_oid
 and u.idx = 1) as ensisijaiset
 group by hakukohde_oid;
+
+--name: yesql-get-latest-applications-for-kk-payment-processing
+SELECT
+  la.key,
+  la.submitted,
+  la.haku,
+  la.hakukohde,
+  la.person_oid AS "person-oid",
+  (SELECT content
+   FROM answers_as_content
+   WHERE application_id = la.id) AS content
+FROM latest_applications AS la
+LEFT JOIN application_reviews AS ar ON ar.application_key = la.key
+WHERE la.haku in (:haku_oids) AND
+      la.person_oid in (:person_oids) AND
+      ar.state <> 'inactivated';

--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -17,6 +17,14 @@
    :person-oid "1.2.3.4.5.303"
    :answers    [{:key "vapautus_hakemusmaksusta" :value "0" :fieldType "dropdown"}]})
 
+(def application-without-hakemusmaksu-exemption
+  {:form       909909,
+   :lang       "fi"
+   :haku       "payment-info-test-kk-haku"
+   :id         1
+   :person-oid "1.2.3.4.5.303"
+   :answers    [{:key "foo" :value "1" :fieldType "dropdown"}]})
+
 (def application-with-koodisto-form
   {:form       981230123,
    :lang       "fi"

--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -13,7 +13,7 @@
   {:form       909909,
    :lang       "fi"
    :haku       "payment-info-test-kk-haku"
-   :id         1
+   :id         543210
    :person-oid "1.2.3.4.5.303"
    :answers    [{:key "vapautus_hakemusmaksusta" :value "0" :fieldType "dropdown"}]})
 
@@ -21,7 +21,7 @@
   {:form       909909,
    :lang       "fi"
    :haku       "payment-info-test-kk-haku"
-   :id         1
+   :id         543211
    :person-oid "1.2.3.4.5.303"
    :answers    [{:key "foo" :value "1" :fieldType "dropdown"}]})
 

--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -9,6 +9,14 @@
                              :date "2018-03-22T07:55:08Z"
                              :name "Teppo Testinen"}})
 
+(def application-with-hakemusmaksu-exemption
+  {:form       909909,
+   :lang       "fi"
+   :haku       "payment-info-test-kk-haku"
+   :id         1
+   :person-oid "1.2.3.4.5.303"
+   :answers    [{:key "vapautus_hakemusmaksusta" :value "0" :fieldType "dropdown"}]})
+
 (def application-with-koodisto-form
   {:form       981230123,
    :lang       "fi"

--- a/spec/ataru/fixtures/db/unit_test_db.clj
+++ b/spec/ataru/fixtures/db/unit_test_db.clj
@@ -7,6 +7,18 @@
             [ataru.db.db :as ataru-db]
             [ataru.log.audit-log :as audit-log]))
 
+; Make linter happy again
+(declare yesql-delete-fixture-application-review!)
+(declare yesql-delete-fixture-application-events!)
+(declare yesql-delete-fixture-application-secrets!)
+(declare yesql-delete-fixture-application-answers!)
+(declare yesql-delete-fixture-application-multi-answers!)
+(declare yesql-delete-fixture-application-group-answers!)
+(declare yesql-delete-fixture-application!)
+(declare yesql-delete-fixture-form!)
+(declare yesql-delete-fixture-forms-with-key!)
+(declare yesql-set-form-id!)
+
 (defqueries "sql/dev-form-queries.sql")
 
 (defn- nuke-old-fixture-data [form-id]
@@ -32,11 +44,11 @@
     form))
 
 (defn init-db-application-fixture
-  [form-fixture application-fixture application-reviews-fixture]
+  [form-fixture application-fixture application-hakukohde-reviews-fixture application-reviews-fixture]
   (when (or (nil? (:id form-fixture)) (not= (:id form-fixture) (:form application-fixture)))
     (throw (Exception. (str "Incorrect fixture data, application should refer the given form"))))
   (let [audit-logger       (audit-log/new-dummy-audit-logger)
-        form-id            (init-db-form-fixture form-fixture)
+        _                  (init-db-form-fixture form-fixture)
         application-id     (-> (application-store/add-application
                                application-fixture
                                (:hakukohde application-fixture)
@@ -46,17 +58,25 @@
                                nil)
                                :id)
         stored-application (application-store/get-application application-id)]
-    (doseq [{hakukohde :hakukohde review-requirement :review-requirement review-state :review-state} application-reviews-fixture]
+    (doseq [{hakukohde :hakukohde review-requirement :review-requirement review-state :review-state}
+            application-hakukohde-reviews-fixture]
       (application-store/save-application-hakukohde-review
-       (:key stored-application) hakukohde review-requirement review-state {} audit-logger))))
+       (:key stored-application) hakukohde review-requirement review-state {} audit-logger))
+    (doseq [review application-reviews-fixture]
+      (application-store/save-application-review
+        (merge review {:application-key (:key stored-application)}) {} audit-logger))))
 
 (defn init-db-fixture
   ([form-fixture]
     (nuke-old-fixture-data (:id form-fixture))
     (init-db-form-fixture form-fixture))
-  ([form-fixture application-fixture application-reviews-fixture]
+  ([form-fixture application-fixture application-hakukohde-reviews-fixture]
     (nuke-old-fixture-data (:id form-fixture))
-    (init-db-application-fixture form-fixture application-fixture application-reviews-fixture)))
+    (init-db-application-fixture form-fixture application-fixture application-hakukohde-reviews-fixture nil))
+  ([form-fixture application-fixture application-hakukohde-reviews-fixture application-reviews-fixture]
+   (nuke-old-fixture-data (:id form-fixture))
+   (init-db-application-fixture form-fixture application-fixture
+                                application-hakukohde-reviews-fixture application-reviews-fixture)))
 
 (defn init-oppija-session-to-db
   [ticket data]

--- a/spec/ataru/fixtures/form.clj
+++ b/spec/ataru/fixtures/form.clj
@@ -345,3 +345,8 @@
 (def payment-properties-test-form
   (merge minimal-form
          {:key "payment-properties-test-form"}))
+
+(def payment-exemption-test-form
+  (merge minimal-form
+         {:id  909909
+          :key "payment-exemption-test-form"}))

--- a/spec/ataru/forms/form_payment_info_spec.clj
+++ b/spec/ataru/forms/form_payment_info_spec.clj
@@ -2,6 +2,7 @@
   (:require
     [ataru.forms.form-payment-info :as payment-info]
     [ataru.tarjonta-service.tarjonta-protocol :as tarjonta-service]
+    [clj-time.core :as t]
     [speclj.core :refer [describe it should= should-be tags]]
     [ataru.tarjonta-service.mock-tarjonta-service :as mts]))
 
@@ -43,17 +44,25 @@
                     haku {:name { :fi "Testihaku 1"}
                           :oid "payment-info-test-kk-haku"
                           :kohdejoukko-uri "haunkohdejoukko_12#1"
-                          :hakukohteet ["payment-info-test-kk-hakukohde"] }
+                          :hakukohteet ["payment-info-test-kk-hakukohde"]
+                          :hakuajat [{:start (t/date-time 2025 10 14)
+                                      :end   (t/date-time 2025 10 15)}]
+                          :alkamiskausi "kausi_s#1"
+                          :alkamisvuosi 2025}
                     haku-with-payment-flag (payment-info/add-admission-payment-info-for-haku
                                              tarjonta-service haku)]
-                (should= true(:admission-payment-required? haku-with-payment-flag))))
+                (should= true (:admission-payment-required? haku-with-payment-flag))))
 
           (it "sets payment needed as false for non higher education"
               (let [tarjonta-service (mts/->MockTarjontaKoutaService)
                     haku {:name { :fi "Testihaku 2" }
                           :oid "payment-info-test-non-kk-haku"
                           :kohdejoukko-uri "haunkohdejoukko_11#1"
-                          :hakukohteet ["payment-info-test-non-kk-hakukohde"] }
+                          :hakukohteet ["payment-info-test-non-kk-hakukohde"]
+                          :hakuajat [{:start (t/date-time 2025 10 14)
+                                      :end   (t/date-time 2025 10 15)}]
+                          :alkamiskausi "kausi_s#1"
+                          :alkamisvuosi 2025}
                     haku-with-payment-flag (payment-info/add-admission-payment-info-for-haku
                                              tarjonta-service haku)]
                 (should= false (:admission-payment-required? haku-with-payment-flag))))
@@ -63,7 +72,39 @@
                     haku {:name { :fi "Testihaku 2" }
                           :oid "payment-info-test-unknown-haku"
                           :kohdejoukko-uri "haunkohdejoukko_12#1"
-                          :hakukohteet ["payment-info-test-unknown-hakukohde"] }
+                          :hakukohteet ["payment-info-test-unknown-hakukohde"]
+                          :hakuajat [{:start (t/date-time 2025 10 14)
+                                      :end   (t/date-time 2025 10 15)}]
+                          :alkamiskausi "kausi_s#1"
+                          :alkamisvuosi 2025}
+                    haku-with-payment-flag (payment-info/add-admission-payment-info-for-haku
+                                             tarjonta-service haku)]
+                (should= false (:admission-payment-required? haku-with-payment-flag))))
+
+          (it "sets payment needed as false with higher education haku starting before 2025"
+              (let [tarjonta-service (mts/->MockTarjontaKoutaService)
+                    haku {:name { :fi "Testihaku 1"}
+                          :oid "payment-info-test-kk-haku"
+                          :kohdejoukko-uri "haunkohdejoukko_12#1"
+                          :hakukohteet ["payment-info-test-kk-hakukohde"]
+                          :hakuajat [{:start (t/date-time 2024 10 14)
+                                      :end   (t/date-time 2025 10 15)}]
+                          :alkamiskausi "kausi_s#1"
+                          :alkamisvuosi 2025}
+                    haku-with-payment-flag (payment-info/add-admission-payment-info-for-haku
+                                             tarjonta-service haku)]
+                (should= false (:admission-payment-required? haku-with-payment-flag))))
+
+          (it "sets payment needed as false with higher education studies starting before fall 2025"
+              (let [tarjonta-service (mts/->MockTarjontaKoutaService)
+                    haku {:name { :fi "Testihaku 1"}
+                          :oid "payment-info-test-kk-haku"
+                          :kohdejoukko-uri "haunkohdejoukko_12#1"
+                          :hakukohteet ["payment-info-test-kk-hakukohde"]
+                          :hakuajat [{:start (t/date-time 2025 10 14)
+                                      :end   (t/date-time 2025 10 15)}]
+                          :alkamiskausi "kausi_k#1"
+                          :alkamisvuosi 2025}
                     haku-with-payment-flag (payment-info/add-admission-payment-info-for-haku
                                              tarjonta-service haku)]
                 (should= false (:admission-payment-required? haku-with-payment-flag)))))

--- a/spec/ataru/kk_application_payment/fixtures.clj
+++ b/spec/ataru/kk_application_payment/fixtures.clj
@@ -1,0 +1,26 @@
+(ns ataru.kk-application-payment.fixtures)
+
+(def koodisto-valtioryhmat-response
+  [{:uri "valtioryhmat_1"
+    :version 1
+    :value "EU"
+    :label {}
+    :valid { :start "2015-09-03T00:00:00+03:00" }
+    :within [{:uri "maatjavaltiot2_246"
+              :version 1
+              :value "246"}
+             {:uri "maatjavaltiot2_250"
+              :version 1
+              :value "250"}
+             {:uri "maatjavaltiot2_233"
+              :version 1
+              :value "233"}
+             {:uri "maatjavaltiot2_056"
+              :version 1
+              :value "056"}]}
+   {:uri "valtioryhmat_2"
+    :version 1
+    :value "ETA"
+    :label {}
+    :valid { :start "2015-09-03T00:00:00+03:00" }
+    :within {}}])

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -3,7 +3,8 @@
             [ataru.fixtures.form :as form-fixtures]
             [ataru.koodisto.koodisto :as koodisto]
             [ataru.person-service.person-service :as person-service]
-            [speclj.core :refer [describe tags it should-throw should= should-be-nil should-not-be-nil before-all around]]
+            [speclj.core :refer [describe tags it should-throw should= should-be-nil should-not-be-nil
+                                 before-all around]]
             [ataru.kk-application-payment.kk-application-payment :as payment]
             [clojure.java.jdbc :as jdbc]
             [ataru.db.db :as db]
@@ -56,9 +57,6 @@
 (describe "update-payment-status"
           (tags :unit :kk-application-payment)
 
-          (before-all
-            (delete-states-and-events!))
-
           (around [spec]
                   (with-redefs [koodisto/get-koodisto-options (fn [_ uri _ _]
                                                                 (case uri
@@ -66,59 +64,98 @@
                                                                   fixtures/koodisto-valtioryhmat-response))]
                     (spec)))
 
-          (it "should throw an error when EU country codes could not be read"
-              (with-redefs [koodisto/get-koodisto-options (constantly [])]
-                (should-throw
-                  (payment/update-payment-status fake-person-service fake-tarjonta-service
-                                                 fake-koodisto-cache fake-haku-cache
-                                                 "1.1.1" term-fall year-ok nil))))
+          (describe "without exemption"
+                    (before-all
+                      (delete-states-and-events!))
 
-          (it "should return existing paid (terminal) state without state changes"
-              (let [oid "1.2.3.4.5.6"
-                    linked-oid (str oid "2")                ; See FakePersonService
-                    _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
-                    _ (payment/update-payment-status fake-person-service fake-tarjonta-service
-                                                     fake-koodisto-cache fake-haku-cache
-                                                     linked-oid term-fall year-ok nil)
-                    state (first (payment/get-payment-states [linked-oid] term-fall year-ok))]
-                (should-not-be-nil state)
-                (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
-                                           :start_year year-ok, :state state-paid} state)))
+                    (it "should return nil without any updates when the person has no applications"
+                        (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                      application-fixtures/application-without-hakemusmaksu-exemption
+                                                      nil)
+                        (let [oid "1.2.3.4.5.1234"                       ; Should have no applications
+                              id (payment/update-payment-status fake-person-service fake-tarjonta-service
+                                                               fake-koodisto-cache fake-haku-cache
+                                                               oid term-fall year-ok nil)
+                              state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                          (should-be-nil state)
+                          (should-be-nil id)))
 
-          (it "should set payment status for eu citizen as not required"
-              (let [oid "1.2.3.4.5.7"                       ; FakePersonService returns Finnish nationality by default
-                    _ (payment/update-payment-status fake-person-service fake-tarjonta-service
-                                                     fake-koodisto-cache fake-haku-cache
-                                                     oid term-fall year-ok nil)
-                    state (first (payment/get-payment-states [oid] term-fall year-ok))]
-                (should-not-be-nil state)
-                (should-be-matching-state {:person_oid oid, :start_term term-fall,
-                                           :start_year year-ok, :state state-not-required} state)))
+                    (it "should throw an error when EU country codes could not be read"
+                        (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                      (merge
+                                                        application-fixtures/application-without-hakemusmaksu-exemption
+                                                        {:person-oid "1.1.1"}) nil)
+                        (with-redefs [koodisto/get-koodisto-options (constantly [])]
+                          (should-throw
+                            (payment/update-payment-status fake-person-service fake-tarjonta-service
+                                                           fake-koodisto-cache fake-haku-cache
+                                                           "1.1.1" term-fall year-ok nil))))
 
-          (it "should set payment status for non eu citizen without exemption as required"
-              (with-redefs [payment/exempt-via-applications? (constantly false)]
-                (let [oid "1.2.3.4.5.303"                       ; FakePersonService returns non-EU nationality for this one
-                      _ (payment/update-payment-status fake-person-service fake-tarjonta-service
-                                                       fake-koodisto-cache fake-haku-cache
-                                                       oid term-fall year-ok nil)
-                      state (first (payment/get-payment-states [oid] term-fall year-ok))]
-                  (should-not-be-nil state)
-                  (should-be-matching-state {:person_oid oid, :start_term term-fall,
-                                             :start_year year-ok, :state state-pending} state))))
+                    (it "should return existing paid (terminal) state without state changes"
+                        (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                      (merge
+                                                        application-fixtures/application-without-hakemusmaksu-exemption
+                                                        {:person-oid "1.2.3.4.5.62"}) nil)
+                        (let [oid "1.2.3.4.5.6"
+                              linked-oid (str oid "2")                ; See FakePersonService
+                              _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
+                              id (payment/update-payment-status fake-person-service fake-tarjonta-service
+                                                                fake-koodisto-cache fake-haku-cache
+                                                                linked-oid term-fall year-ok nil)
+                              state (first (payment/get-payment-states [linked-oid] term-fall year-ok))]
+                          (should-not-be-nil id)
+                          (should-not-be-nil state)
+                          (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
+                                                     :start_year year-ok, :state state-paid} state)))
 
-          (it "should set payment status for non eu citizen with exemption as not required"
-              (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
-                                            application-fixtures/application-with-hakemusmaksu-exemption
-                                            nil
-                                            [{:state "active"}])
-              (let [oid "1.2.3.4.5.303"                       ; FakePersonService returns non-EU nationality for this one
-                    _ (payment/update-payment-status fake-person-service fake-tarjonta-service
-                                                     fake-koodisto-cache fake-haku-cache
-                                                     oid term-fall year-ok nil)
-                    state (first (payment/get-payment-states [oid] term-fall year-ok))]
-                (should-not-be-nil state)
-                (should-be-matching-state {:person_oid oid, :start_term term-fall,
-                                           :start_year year-ok, :state state-not-required} state))))
+                    (it "should set payment status for eu citizen as not required"
+                        (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                      (merge
+                                                        application-fixtures/application-without-hakemusmaksu-exemption
+                                                        {:person-oid "1.2.3.4.5.7"}) nil)
+                        (let [oid "1.2.3.4.5.7"                       ; FakePersonService returns Finnish nationality by default
+                              id (payment/update-payment-status fake-person-service fake-tarjonta-service
+                                                                fake-koodisto-cache fake-haku-cache
+                                                                oid term-fall year-ok nil)
+                              state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                          (should-not-be-nil id)
+                          (should-not-be-nil state)
+                          (should-be-matching-state {:person_oid oid, :start_term term-fall,
+                                                     :start_year year-ok, :state state-not-required} state)))
+
+                    (it "should set payment status for non eu citizen without exemption as required"
+                        (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                      application-fixtures/application-without-hakemusmaksu-exemption
+                                                      nil)
+                        (with-redefs [payment/exemption-in-application? (constantly false)]
+                          (let [oid "1.2.3.4.5.303"                       ; FakePersonService returns non-EU nationality for this one
+                                id (payment/update-payment-status fake-person-service fake-tarjonta-service
+                                                                  fake-koodisto-cache fake-haku-cache
+                                                                  oid term-fall year-ok nil)
+                                state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                            (should-not-be-nil id)
+                            (should-not-be-nil state)
+                            (should-be-matching-state {:person_oid oid, :start_term term-fall,
+                                                       :start_year year-ok, :state state-pending} state)))))
+
+          (describe "with exemption"
+                    (before-all
+                      (delete-states-and-events!))
+
+                    (it "should set payment status for non eu citizen with exemption as not required"
+                        (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                      application-fixtures/application-with-hakemusmaksu-exemption
+                                                      nil
+                                                      [{:state "active"}])
+                        (let [oid "1.2.3.4.5.303"                       ; FakePersonService returns non-EU nationality for this one
+                              id (payment/update-payment-status fake-person-service fake-tarjonta-service
+                                                                fake-koodisto-cache fake-haku-cache
+                                                                oid term-fall year-ok nil)
+                              state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                          (should-not-be-nil id)
+                          (should-not-be-nil state)
+                          (should-be-matching-state {:person_oid oid, :start_term term-fall,
+                                                     :start_year year-ok, :state state-not-required} state)))))
 
 (describe "resolve-payment-status"
           (tags :unit :kk-application-payment)
@@ -137,7 +174,7 @@
                     state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
                 (should-be-matching-state {:person_oid oid, :start_term term-fall,
                                            :start_year year-ok, :state state-pending}
-                  state)))
+                                          state)))
 
           (it "should resolve a simple single state for linked oid"
               (let [oid "1.2.3.4.5.8"
@@ -156,7 +193,7 @@
                     state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
                 (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
                                            :start_year year-ok, :state state-paid}
-                  state)))
+                                          state)))
 
           (it "should resolve a possible not required state with linked oids, conflicting states and no paid state"
               (let [oid "1.2.3.4.5.10"

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -1,23 +1,167 @@
 (ns ataru.kk-application-payment.kk-application-payment-spec
-  (:require [speclj.core :refer [describe tags it should-throw should= before-all]]
+  (:require [ataru.koodisto.koodisto :as koodisto]
+            [ataru.person-service.person-service :as person-service]
+            [speclj.core :refer [describe tags it should-throw should= should-be-nil should-not-be-nil before-all around]]
             [ataru.kk-application-payment.kk-application-payment :as payment]
             [clojure.java.jdbc :as jdbc]
-            [ataru.db.db :as db]))
+            [ataru.db.db :as db]
+            [ataru.cache.cache-service :as cache-service]
+            [ataru.kk-application-payment.fixtures :as fixtures]))
+
+(def fake-person-service (person-service/->FakePersonService))
+
+(def fake-koodisto-cache (reify cache-service/Cache
+                           (get-from [_ _])
+                           (get-many-from [_ _])
+                           (remove-from [_ _])
+                           (clear-all [_])))
 
 (defn- delete-states-and-events! []
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
                             (jdbc/delete! conn :kk_application_payment_events [])
                             (jdbc/delete! conn :kk_application_payment_states [])))
 
-(def test-term-spring "kausi_k")
-(def test-term-fall "kausi_s")
-(def test-term-error "kausi_a")
-(def test-year-ok 2025)
-(def test-year-error 2024)
-(def test-state-pending "payment-pending")
-(def test-state-not-required "payment-not-required")
-(def test-state-paid "payment-paid")
-(def test-event-updated "state-updated")
+(def term-spring "kausi_k")
+(def term-fall "kausi_s")
+(def term-error "kausi_a")
+(def year-ok 2025)
+(def year-error 2024)
+(def state-pending "payment-pending")
+(def state-not-required "payment-not-required")
+(def state-paid "payment-paid")
+(def event-updated "state-updated")
+
+(defn- should-be-matching-state
+  [example state]
+  (should= example (dissoc state :id :created_time :modified_time)))
+
+(defn- should-be-matching-event
+  [example event]
+  (should= example (dissoc event :id :created_time)))
+
+(declare spec)
+
+(describe "update-payment-status"
+          (tags :unit :kk-application-payment)
+
+          (before-all
+            (delete-states-and-events!))
+
+          (around [spec]
+                  (with-redefs [koodisto/get-koodisto-options (fn [_ uri _ _]
+                                                                (case uri
+                                                                  "valtioryhmat"
+                                                                  fixtures/koodisto-valtioryhmat-response))]
+                    (spec)))
+
+          (it "should throw an error when EU country codes could not be read"
+              (with-redefs [koodisto/get-koodisto-options (constantly [])]
+                (should-throw
+                  (payment/update-payment-status fake-person-service fake-koodisto-cache
+                                                 "1.1.1" term-fall year-ok nil))))
+
+          (it "should return existing paid (terminal) state without state changes"
+              (let [oid "1.2.3.4.5.6"
+                    linked-oid (str oid "2")                ; See FakePersonService
+                    _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
+                    _ (payment/update-payment-status fake-person-service fake-koodisto-cache
+                                                            linked-oid term-fall year-ok nil)
+                    state (first (payment/get-payment-states [linked-oid] term-fall year-ok))]
+                (should-not-be-nil state)
+                (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
+                                           :start_year year-ok, :state state-paid} state)))
+
+          (it "should set payment status for eu citizen as not required"
+              (let [oid "1.2.3.4.5.7"                       ; FakePersonService returns Finnish nationality by default
+                    _ (payment/update-payment-status fake-person-service fake-koodisto-cache
+                                                     oid term-fall year-ok nil)
+                    state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                (should-not-be-nil state)
+                (should-be-matching-state {:person_oid oid, :start_term term-fall,
+                                           :start_year year-ok, :state state-not-required} state)))
+
+          (it "should set payment status for non eu citizen without exemption as required"
+              (with-redefs [payment/exempt-via-applications? (constantly false)]
+                (let [oid "1.2.3.4.5.303"                       ; FakePersonService returns non-EU nationality for this one
+                      _ (payment/update-payment-status fake-person-service fake-koodisto-cache
+                                                       oid term-fall year-ok nil)
+                      state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                  (should-not-be-nil state)
+                  (should-be-matching-state {:person_oid oid, :start_term term-fall,
+                                             :start_year year-ok, :state state-pending} state))))
+
+          (it "should set payment status for non eu citizen with exemption as not required"))
+
+(describe "resolve-payment-status"
+          (tags :unit :kk-application-payment)
+
+          (before-all
+            (delete-states-and-events!))
+
+          (it "should return nil when no states found"
+              (let [oid "1.2.3.4.5.6"
+                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
+                (should-be-nil state)))
+
+          (it "should return a simple single state when no states for linked oids"
+              (let [oid "1.2.3.4.5.7"
+                    _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
+                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
+                (should-be-matching-state {:person_oid oid, :start_term term-fall,
+                                           :start_year year-ok, :state state-pending}
+                  state)))
+
+          (it "should resolve a simple single state for linked oid"
+              (let [oid "1.2.3.4.5.8"
+                    linked-oid (str oid "2")                ; See FakePersonService
+                    _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
+                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
+                (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
+                                           :start_year year-ok, :state state-paid}
+                                          state)))
+
+          (it "should resolve a possible paid state with linked oids and conflicting states"
+              (let [oid "1.2.3.4.5.9"
+                    linked-oid (str oid "2")                ; See FakePersonService
+                    _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
+                    _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
+                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
+                (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
+                                           :start_year year-ok, :state state-paid}
+                  state)))
+
+          (it "should resolve a possible not required state with linked oids, conflicting states and no paid state"
+              (let [oid "1.2.3.4.5.10"
+                    linked-oid (str oid "2")                ; See FakePersonService
+                    _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
+                    _ (payment/set-application-fee-not-required linked-oid term-fall year-ok nil nil)
+                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
+                (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
+                                           :start_year year-ok, :state state-not-required}
+                                          state)))
+
+          (it "should resolve a required state with linked oids whenever no paid or not required states found"
+              (let [oid "1.2.3.4.5.11"
+                    linked-oid (str oid "2")                ; See FakePersonService
+                    _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
+                    _ (payment/set-application-fee-required linked-oid term-fall year-ok nil nil)
+                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
+                (should-be-matching-state {:person_oid oid, :start_term term-fall,
+                                           :start_year year-ok, :state state-pending}
+                                          state))))
+
+(defn save-and-check-single-state-and-event
+  [oid term year state-func desired-state]
+  (let [state-id (state-func oid term-fall year-ok nil nil)
+        states   (payment/get-payment-states [oid] term year)
+        events   (payment/get-payment-events [state-id])
+        state    (first states)
+        event    (first events)]
+    (should= 1 (count states))
+    (should= 1 (count events))
+    (should-be-matching-state {:person_oid oid, :start_term term, :start_year year, :state desired-state} state)
+    (should-be-matching-event {:kk_application_payment_state_id state-id, :new_state desired-state,
+                               :event_type event-updated, :virkailija_oid nil, :message nil} event)))
 
 (describe "application payment states"
           (tags :unit :kk-application-payment)
@@ -28,64 +172,25 @@
           (describe "payment state validation"
                     (it "should not allow setting fee for spring 2025 (starts from fall 2025)"
                         (should-throw (payment/set-application-fee-required
-                                        "1.2.3.4.5.6" test-term-spring test-year-ok nil nil)))
+                                        "1.2.3.4.5.6" term-spring year-ok nil nil)))
 
                     (it "should not allow setting fee for year earlier than 2025"
                         (should-throw (payment/set-application-fee-required
-                                        "1.2.3.4.5.6" test-term-spring test-year-error nil nil)))
+                                        "1.2.3.4.5.6" term-spring year-error nil nil)))
 
                     (it "should not allow setting fee for invalid term"
                         (should-throw (payment/set-application-fee-required
-                                        "1.2.3.4.5.6" test-term-error test-year-ok nil nil))))
+                                        "1.2.3.4.5.6" term-error year-ok nil nil))))
 
           (describe "payment state setting"
                     (it "should set and get application fee required for a person with oid"
-                        (let [oid "1.2.3.4.5.6"
-                              state-id (payment/set-application-fee-required
-                                         oid test-term-fall test-year-ok nil nil)
-                              states (payment/get-payment-states [oid] test-term-fall test-year-ok)
-                              events (payment/get-payment-events [state-id])
-                              state (first states)
-                              event (first events)]
-                          (should= 1 (count states))
-                          (should= 1 (count events))
-                          (should= {:id state-id, :person_oid oid, :start_term test-term-fall,
-                                    :start_year test-year-ok, :state test-state-pending}
-                                   (dissoc state :created_time :modified_time))
-                          (should= {:kk_application_payment_state_id state-id, :new_state test-state-pending,
-                                    :event_type test-event-updated, :virkailija_oid nil, :message nil}
-                                   (dissoc event :id :created_time))))
+                        (save-and-check-single-state-and-event
+                          "1.2.3.4.5.6" term-fall year-ok payment/set-application-fee-required state-pending))
 
                     (it "should set and get application fee not required for a person with oid"
-                        (let [oid "1.2.3.4.5.7"
-                              state-id (payment/set-application-fee-not-required
-                                         oid test-term-fall test-year-ok nil nil)
-                              states (payment/get-payment-states [oid] test-term-fall test-year-ok)
-                              events (payment/get-payment-events [state-id])
-                              state (first states)
-                              event (first events)]
-                          (should= 1 (count states))
-                          (should= 1 (count events))
-                          (should= {:id state-id, :person_oid oid, :start_term test-term-fall,
-                                    :start_year test-year-ok, :state test-state-not-required}
-                                   (dissoc state :created_time :modified_time))
-                          (should= {:kk_application_payment_state_id state-id, :new_state test-state-not-required,
-                                    :event_type test-event-updated, :virkailija_oid nil, :message nil}
-                                   (dissoc event :id :created_time))))
+                        (save-and-check-single-state-and-event
+                          "1.2.3.4.5.7" term-fall year-ok payment/set-application-fee-not-required state-not-required))
 
                     (it "should set and get application fee paid for a person with oid"
-                        (let [oid "1.2.3.4.5.8"
-                              state-id (payment/set-application-fee-paid
-                                         oid test-term-fall test-year-ok nil nil)
-                              states (payment/get-payment-states [oid] test-term-fall test-year-ok)
-                              events (payment/get-payment-events [state-id])
-                              state (first states)
-                              event (first events)]
-                          (should= 1 (count states))
-                          (should= 1 (count events))
-                          (should= {:id state-id, :person_oid oid, :start_term test-term-fall,
-                                    :start_year test-year-ok, :state test-state-paid}
-                                   (dissoc state :created_time :modified_time))
-                          (should= {:kk_application_payment_state_id state-id, :new_state test-state-paid,
-                                    :event_type test-event-updated, :virkailija_oid nil, :message nil}
-                                   (dissoc event :id :created_time))))))
+                        (save-and-check-single-state-and-event
+                          "1.2.3.4.5.8" term-fall year-ok payment/set-application-fee-paid state-paid))))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -1675,3 +1675,8 @@
                                               %))
                                          application-keys)))]
     (remove nil? (vec (flatten not-deleted-keys)))))
+
+(defn get-latest-applications-for-kk-payment-processing
+  [person-oids haku-oids]
+  (exec-db :db queries/yesql-get-latest-applications-for-kk-payment-processing {:person_oids person-oids
+                                                                                :haku_oids (vec haku-oids)}))

--- a/src/clj/ataru/haku/haku_service.clj
+++ b/src/clj/ataru/haku/haku_service.clj
@@ -10,6 +10,7 @@
     [ataru.hakukohde.hakukohde-store :as hakukohde-store]
     [clj-time.core :as t]
     [clj-time.coerce :as c]
+    [clojure.string :as str]
     [taoensso.timbre :as log]
     [ataru.tarjonta.haku :as haku]
     [ataru.user-rights :as user-rights]
@@ -317,3 +318,13 @@
            :haut             haut
            :hakukohteet      hakukohteet-with-kevyt-valinta
            :hakukohderyhmat  hakukohderyhmat}))
+
+(defn get-haut-for-kk-application-payments
+  "Get hakus according to study start term and year. Only for internal use, does not do authorization."
+  [get-haut-cache tarjonta-service start-term start-year]
+  (->> (cache/get-from get-haut-cache :haut)
+       (map :haku)
+       distinct
+       (keep #(tarjonta/get-haku tarjonta-service %))
+       (filter #(and (= start-year (:alkamisvuosi %))
+                     (str/starts-with? (:alkamiskausi %) start-term)))))

--- a/src/clj/ataru/haku/haku_service.clj
+++ b/src/clj/ataru/haku/haku_service.clj
@@ -319,7 +319,7 @@
            :hakukohteet      hakukohteet-with-kevyt-valinta
            :hakukohderyhmat  hakukohderyhmat}))
 
-(defn get-haut-for-kk-application-payments
+(defn get-haut-for-start-term-and-year
   "Get hakus according to study start term and year. Only for internal use, does not do authorization."
   [get-haut-cache tarjonta-service start-term start-year]
   (->> (cache/get-from get-haut-cache :haut)

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -13,7 +13,7 @@
 
 (def exemption-form-field-name
   "Unique id / field name for form field that indicates exemption from application fee"
-  ; TODO: field name and format TBD
+  ; TODO: field name and format TBD -> OK-581
   :field-name-here)
 
 (def application-payment-start-year
@@ -78,7 +78,7 @@
   (set-payment-state person-oid term year "payment-paid" virkailija-oid message))
 
 ; TODO: where should we check this?
-(defn- haku-valid?
+(defn haku-valid?
   "Application payments are only collected for admissions starting on or after 1.1.2025"
   [haku]
   (when-let [hakuaika-start (some-> haku :hakuaika :start coerce/from-long)]
@@ -116,13 +116,13 @@
   [application]
   (let [answers (-> application :content :answers util/answers-by-key)]
     (when (contains? answers exemption-form-field-name)
-      ; TODO need to define field format before we can parse exemptions
+      ; TODO need to define field format before we can parse exemptions -> OK-581
       ())))
 
 (defn- exempt-via-applications?
   "Returns true if there is an exemption reason attached to one or more of the applications for the term.
    Also returns true, in case the person has no applications."
-  [person-oids term year]
+  [_ _ _]
   ; TODO get person's applications by starting term and year
   (let [applications ()]
     (some true? (map exemption-in-application? applications))))

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -13,11 +13,13 @@
             [clj-time.core :as time]))
 
 ; TODO: when the exact field is defined, make sure this is the final agreed id
+; TODO: -> before the main feature branch gets merged to master
 (def exemption-form-field-name
   "Unique id / field name for form field that indicates exemption from application fee"
   :vapautus_hakemusmaksusta)
 
 ; TODO: when the exact field is defined, check that these are correct
+; TODO: -> before the main feature branch gets merged to master
 (def exemption-field-ok-values
   "Any of these values should be considered as exemption to payment"
   #{"0" "1" "2" "3" "4" "5" "6"})

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -122,7 +122,7 @@
   "Infers and sets new payment status for person according to their personal data and applications for term.
   Does not poll payments, never updates status to paid. Returns state id."
   [person-service tarjonta-service koodisto-cache haku-cache person-oid term year virkailija-oid]
-  (let [hakus (haku-service/get-haut-for-kk-application-payments haku-cache tarjonta-service term year)
+  (let [hakus (haku-service/get-haut-for-start-term-and-year haku-cache tarjonta-service term year)
         valid-hakus (filter (partial haku-valid? tarjonta-service) hakus)
         valid-haku-oids (map :oid valid-hakus)
         linked-oids (get (person-service/linked-oids person-service [person-oid]) person-oid)

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -4,13 +4,25 @@
    NB! Semester is defined here by the start date of the actual first higher education semester,
    not the application date."
   (:require [ataru.kk-application-payment.kk-application-payment-store :as store]
-            [taoensso.timbre :as log]))
+            [ataru.koodisto.koodisto :as koodisto]
+            [ataru.person-service.person-service :as person-service]
+            [ataru.util :as util]
+            [taoensso.timbre :as log]
+            [clj-time.coerce :as coerce]
+            [clj-time.core :as time]))
 
-; TODO: application payments should be only charged for hakus starting on or after 1.1.2025 -> scoped to OK-556
+(def exemption-form-field-name
+  "Unique id / field name for form field that indicates exemption from application fee"
+  ; TODO: field name and format TBD
+  :field-name-here)
 
 (def application-payment-start-year
-  "Application payments are charged from studies starting on 2025 or later."
+  "Application payments are charged from studies starting in (Autumn) 2025 or later."
   2025)
+
+(def first-application-payment-hakuaika-start
+  "Application payments are only charged from admissions starting in 2025 or later"
+  (time/date-time 2025 1 1))
 
 (def valid-terms
   "Semesters / terms for kk application payments: one payment is required per starting term."
@@ -21,16 +33,13 @@
     :payment-pending
     :payment-paid})
 
-(def valid-event-types
-  #{:state-updated})
-
 (defn start-term-valid?
-  "Payments are only ever charged from Autumn 2025 onwards"
+  "Payments are only charged starting from term Autumn 2025"
   [term year]
   (let [term-kw  (keyword term)]
     (or
       (and (contains? valid-terms term-kw) (> year application-payment-start-year))
-      (and (= term-kw :kausi_s) (= year application-payment-start-year) ))))
+      (and (= term-kw :kausi_s) (= year application-payment-start-year)))))
 
 (defn- set-payment-state
   [person-oid term year new-state virkailija-oid message]
@@ -67,3 +76,83 @@
   "Sets kk processing fee paid for the target term."
   [person-oid term year virkailija-oid message]
   (set-payment-state person-oid term year "payment-paid" virkailija-oid message))
+
+; TODO: where should we check this?
+(defn- haku-valid?
+  "Application payments are only collected for admissions starting on or after 1.1.2025"
+  [haku]
+  (when-let [hakuaika-start (some-> haku :hakuaika :start coerce/from-long)]
+    (not (time/before? (coerce/from-long hakuaika-start)
+                       first-application-payment-hakuaika-start))))
+
+(defn- is-eu-citizen? [person-service koodisto-cache oid]
+  (let [person (person-service/get-person person-service oid)
+        eu-area (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+                     (filter #(= "EU" (:value %)))
+                     (first))
+        eu-country-codes (set (map :value (:within eu-area)))]
+    (if (> (count eu-country-codes) 0)
+      (some #(contains? eu-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person))
+      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid oid})))))
+
+(defn- resolve-actual-payment-state
+  "Resolves a single payment state from the states of possibly multiple aliases for single person.
+   Chooses on the benefit of the applicant in case of multiple conflicting states."
+  [states]
+  (when (not-empty states)
+    (let [state-set (->> states
+                         (map :state)
+                         (map keyword)
+                         set)
+          get-state-data (fn [field-name] (first
+                                            (filter #(= field-name (keyword (:state %))) states)))]
+      (cond
+        (= 1 (count state-set))                     (first states)
+        (contains? state-set :payment-paid)         (get-state-data :payment-paid)
+        (contains? state-set :payment-not-required) (get-state-data :payment-not-required)
+        :else                                       (get-state-data :payment-pending)))))
+
+(defn- exemption-in-application?
+  [application]
+  (let [answers (-> application :content :answers util/answers-by-key)]
+    (when (contains? answers exemption-form-field-name)
+      ; TODO need to define field format before we can parse exemptions
+      ())))
+
+(defn- exempt-via-applications?
+  "Returns true if there is an exemption reason attached to one or more of the applications for the term.
+   Also returns true, in case the person has no applications."
+  [person-oids term year]
+  ; TODO get person's applications by starting term and year
+  (let [applications ()]
+    (some true? (map exemption-in-application? applications))))
+
+(defn resolve-payment-status
+  "Determines a single payment status out of the statuses attached to possible aliases of the person.
+   Returns full state data."
+  [person-service person-oid term year]
+  (let [linked-oids (get (person-service/linked-oids person-service [person-oid]) person-oid)
+        aliases (into [] (conj (:linked-oids linked-oids) (:master-oid linked-oids) person-oid))]
+    (resolve-actual-payment-state (get-payment-states aliases term year))))
+
+(defn update-payment-status
+  "Infers and sets new payment status for person according to their personal data and applications for term.
+  Does not poll payments, never updates status to paid. Returns state id."
+  [person-service koodisto-cache person-oid term year virkailija-oid]
+  (let [linked-oids (get (person-service/linked-oids person-service [person-oid]) person-oid)
+        master-oid (:master-oid linked-oids)
+        aliases (into [] (conj (:linked-oids linked-oids) (:master-oid linked-oids) person-oid))
+        payment-state (resolve-actual-payment-state (get-payment-states aliases term year))]
+    (cond
+      ; Treat paid as terminal state that will not be modified automatically any more
+      (= (keyword (:state payment-state)) :payment-paid)
+      (:id payment-state)
+
+      (is-eu-citizen? person-service koodisto-cache master-oid)
+      (set-application-fee-not-required person-oid term year virkailija-oid nil)
+
+      (exempt-via-applications? aliases term year)
+      (set-application-fee-not-required person-oid term year virkailija-oid nil)
+
+      :else
+      (set-application-fee-required person-oid term year virkailija-oid nil))))

--- a/src/clj/ataru/kk_application_payment/utils.clj
+++ b/src/clj/ataru/kk_application_payment/utils.clj
@@ -1,14 +1,47 @@
 (ns ataru.kk-application-payment.utils
   (:require [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clj-time.core :as time]
+            [clj-time.coerce :as coerce]))
+
+(def application-payment-start-year
+  "Application payments are charged from studies starting in (Autumn) 2025 or later."
+  2025)
+
+(def valid-terms
+  "Semesters / terms for kk application payments: one payment is required per starting term."
+  #{:kausi_k :kausi_s})
+
+(defn start-term-valid?
+  "Payments are only charged starting from term Autumn 2025"
+  [term year]
+  (when (and term year)
+    ; Input term may be either non-versioned plain "kausi_s" or versioned "kausi_s#1", handle both
+    (let [term-kw (keyword (first (str/split term #"#")))]
+      (or
+        (and (contains? valid-terms term-kw) (> year application-payment-start-year))
+        (and (= term-kw :kausi_s) (= year application-payment-start-year))))))
+
+(def first-application-payment-hakuaika-start
+  "Application payments are only charged from admissions starting in 2025 or later"
+  (time/date-time 2025 1 1))
 
 (defn requires-higher-education-application-fee?
   "Returns true if application fee should be charged for given haku"
   [tarjonta-service haku hakukohde-oids]
-  (let [hakukohteet (tarjonta/get-hakukohteet
+  (let [hakuajat-start (if-let [hakuajat (:hakuajat haku)]
+                         (map :start hakuajat)
+                         ; Support old tarjonta, although we shouldn't have to handle these (?) some tests still use it.
+                         [(coerce/from-long (get-in haku [:hakuaika :start]))])
+        studies-start-term (:alkamiskausi haku)
+        studies-start-year (:alkamisvuosi haku)
+        hakukohteet (tarjonta/get-hakukohteet
                       tarjonta-service
                       (remove nil? hakukohde-oids))]
     (and
+      (boolean (start-term-valid? studies-start-term studies-start-year))
+      (boolean (some #(not (time/before? % first-application-payment-hakuaika-start))
+                     hakuajat-start))
       (boolean haku)
       (boolean hakukohteet)
       ; Kohdejoukko must be korkeakoulutus

--- a/src/clj/ataru/kk_application_payment/utils.clj
+++ b/src/clj/ataru/kk_application_payment/utils.clj
@@ -1,0 +1,21 @@
+(ns ataru.kk-application-payment.utils
+  (:require [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
+            [clojure.string :as str]))
+
+(defn requires-higher-education-application-fee?
+  "Returns true if application fee should be charged for given haku"
+  [tarjonta-service haku hakukohde-oids]
+  (let [hakukohteet (tarjonta/get-hakukohteet
+                      tarjonta-service
+                      (remove nil? hakukohde-oids))]
+    (and
+      (boolean haku)
+      (boolean hakukohteet)
+      ; Kohdejoukko must be korkeakoulutus
+      (and (string? (:kohdejoukko-uri haku))
+           (str/starts-with? (:kohdejoukko-uri haku) "haunkohdejoukko_12#"))
+      ; "Kohdejoukon tarkenne must be empty or siirtohaku
+      (or (nil? (:kohdejoukon-tarkenne-uri haku))
+          (str/starts-with? (:kohdejoukon-tarkenne-uri haku) "haunkohdejoukontarkenne_1#"))
+      ; Must be tutkintoon johtava
+      (boolean (some true? (map #(:tutkintoon-johtava? %) hakukohteet))))))

--- a/src/clj/ataru/koodisto/koodisto_db_cache.clj
+++ b/src/clj/ataru/koodisto/koodisto_db_cache.clj
@@ -100,6 +100,9 @@
   (let [[uri version] (str/split koodisto-uri #"#")]
     (condp = uri
 
+      "valtioryhmat" (add-within "maatjavaltiot2"
+                                 (get-koodisto uri version))
+
       "AmmatillisetOPSperustaiset" (get-vocational-degree-options version)
 
       "oppilaitostyyppi" (get-vocational-institutions version)

--- a/src/clj/ataru/person_service/person_service.clj
+++ b/src/clj/ataru/person_service/person_service.clj
@@ -145,6 +145,8 @@
                       :kutsumanimi "Ari"
                       :sukunimi    "Vatanen"
                       :hetu         "141196-933S"})
+      "1.2.3.4.5.303" (merge fake-onr-person
+                             {:kansalaisuus [{:kansalaisuusKoodi "784"}]})
       (merge fake-onr-person
              {:oidHenkilo oid})))
 

--- a/src/clj/ataru/tarjonta_service/kouta/kouta_client.clj
+++ b/src/clj/ataru/tarjonta_service/kouta/kouta_client.clj
@@ -47,6 +47,8 @@
     (merge
      {:can-submit-multiple-applications           (get ohjausparametrit :useitaHakemuksia false)
       :hakuajat                                   hakuajat
+      :alkamiskausi                               (:alkamiskausiKoodiUri haku)
+      :alkamisvuosi                               (:alkamisvuosi haku)
       :hakukohteet                                (mapv :oid hakukohteet)
       :hakutapa-uri                               (:hakutapaKoodiUri haku)
       :haun-tiedot-url                            (url-helper/resolve-url :kouta-app.haku (:oid haku))

--- a/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
@@ -1,5 +1,7 @@
 (ns ataru.tarjonta-service.mock-tarjonta-service
-  (:require [com.stuartsierra.component :as component]
+  (:require [clj-time.coerce :as coerce]
+            [clj-time.core :as t]
+            [com.stuartsierra.component :as component]
             [ataru.tarjonta-service.tarjonta-client :as tarjonta-client]
             [ataru.tarjonta-service.tarjonta-protocol :refer [TarjontaService]]
             [ataru.tarjonta-service.kouta.kouta-client :as kouta-client]))
@@ -14,7 +16,6 @@
    :maksumuuriKaytossa                                   false,
    :korkeakouluHaku                                      false,
    :tarjoajaOids                                         ["1.2.246.562.10.73539475928"],
-   :koulutuksenAlkamisVuosi                              2016,
    :sisaltyvatHaut                                       [],
    :hakutapaUri                                          "hakutapa_02#1",
    :tunnistusKaytossa                                    false,
@@ -37,6 +38,7 @@
    :modifiedBy                                           "1.2.246.562.24.70906349358",
    :koulutuksenAlkamiskausiUri                           "kausi_s#1",
    :hakukausiVuosi                                       2016,
+   :koulutuksenAlkamisVuosi                              2016,
    :hakuaikas                                            [{:hakuaikaId "10291885",
                                                            :alkuPvm    (- (System/currentTimeMillis)
                                                                           86400000),
@@ -125,7 +127,13 @@
                                                 :hakukohdeOids    ["1.2.246.562.20.49028196523"
                                                                    "1.2.246.562.20.49028196524"
                                                                    "1.2.246.562.20.49028196525"
-                                                                   "1.2.246.562.20.11111111111"]})
+                                                                   "1.2.246.562.20.11111111111"]
+                                                :hakukausiVuosi              2025
+                                                :koulutuksenAlkamisVuosi     2025
+                                                :hakuaikas                   [{:hakuaikaId "10291885",
+                                                                               :alkuPvm    (coerce/to-long (t/date-time 2025 1 1 8 0)),
+                                                                               :loppuPvm   (coerce/to-long (t/date-time 2025 2 8 0 0)),
+                                                                               :nimet      {:kieli_sv "", :kieli_fi "", :kieli_en ""}}]})
    :1.2.246.562.29.65950024187               (merge
                                                base-haku
                                                {:oid              "1.2.246.562.29.65950024187"
@@ -205,122 +213,134 @@
                                 {:oid                         "payment-info-test-kk-haku"
                                  :kohdejoukkoUri              "haunkohdejoukko_12#1"
                                  :kohdejoukonTarkenne         "haunkohdejoukontarkenne_1#1"
-                                 :hakukohdeOids               ["payment-info-test-kk-hakukohde"]})
+                                 :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
+                                 :hakukausiVuosi              2025,
+                                 :koulutuksenAlkamisVuosi     2025,
+                                 :hakuaikas                   [{:hakuaikaId "10291885",
+                                                                :alkuPvm    (coerce/to-long (t/date-time 2025 1 1 8 0)),
+                                                                :loppuPvm   (coerce/to-long (t/date-time 2025 2 8 0 0)),
+                                                                :nimet      {:kieli_sv "", :kieli_fi "", :kieli_en ""}}]})
 
-   :payment-info-test-non-kk-haku (merge
-                                    base-haku
-                                    {:oid                         "payment-info-test-non-kk-haku"
-                                     :kohdejoukkoUri              "haunkohdejoukko_11#1"
-                                     :kohdejoukonTarkenne         "haunkohdejoukontarkenne_1#1"
-                                     :hakukohdeOids               ["payment-info-test-non-kk-hakukohde"]})})
+   :payment-info-test-non-kk-haku            (merge
+                                               base-haku
+                                               {:oid                 "payment-info-test-non-kk-haku"
+                                                :kohdejoukkoUri      "haunkohdejoukko_11#1"
+                                                :kohdejoukonTarkenne "haunkohdejoukontarkenne_1#1"
+                                                :hakukohdeOids       ["payment-info-test-non-kk-hakukohde"]
+                                                :hakukausiVuosi              2025,
+                                                :koulutuksenAlkamisVuosi     2025,
+                                                :hakuaikas                   [{:hakuaikaId "10291885",
+                                                                               :alkuPvm    (coerce/to-long (t/date-time 2025 1 1 8 0)),
+                                                                               :loppuPvm   (coerce/to-long (t/date-time 2025 2 8 0 0)),
+                                                                               :nimet      {:kieli_sv "", :kieli_fi "", :kieli_en ""}}]})})
 
 (def hakukohde
-  {:1.2.246.562.20.49028196522           base-hakukohde
+  {:1.2.246.562.20.49028196522             base-hakukohde
 
-   :hakukohde.oid                        (merge base-hakukohde
-                                           {:oid     "hakukohde.oid"
-                                            :hakuOid "haku.oid"})
+   :hakukohde.oid                          (merge base-hakukohde
+                                                  {:oid     "hakukohde.oid"
+                                                   :hakuOid "haku.oid"})
 
-   :hakukohde_oid                        base-hakukohde
+   :hakukohde_oid                          base-hakukohde
 
-   :hakukohde-in-ryhma.oid               (merge base-hakukohde
-                                           {:oid            "hakukohde-in-ryhma.oid"
-                                            :ryhmaliitokset [{:ryhmaOid "1.2.246.562.28.00000000001"}]
-                                            :hakuOid        "haku.oid"})
-   :1.2.246.562.20.49028196523           (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain          "41101b4f-1762-49af-9db0-e3603adae3ae"
-                                            :oid                       "1.2.246.562.20.49028196523"
-                                            :hakuOid                   "1.2.246.562.29.65950024186"
-                                            :koulutukset               [{:oid "1.2.246.562.17.74335799462"}]
-                                            :josYoEiMuitaLiitepyyntoja true
-                                            :hakukohteenNimet
-                                                                       {:kieli_fi "Testihakukohde 1"
-                                                                        :kieli_sv "sv Testihakukohde 1"}})
-   :1.2.246.562.20.49028196524           (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain "41101b4f-1762-49af-9db0-e3603adae3ae"
-                                            :oid              "1.2.246.562.20.49028196524"
-                                            :hakuOid          "1.2.246.562.29.65950024186"
-                                            :koulutukset      [{:oid "1.2.246.562.17.74335799463"}]
-                                            :hakukohteenNimet
-                                                              {:kieli_fi "Testihakukohde 2"
-                                                               :kieli_sv "sv Testihakukohde 2"}})
+   :hakukohde-in-ryhma.oid                 (merge base-hakukohde
+                                                  {:oid            "hakukohde-in-ryhma.oid"
+                                                   :ryhmaliitokset [{:ryhmaOid "1.2.246.562.28.00000000001"}]
+                                                   :hakuOid        "haku.oid"})
+   :1.2.246.562.20.49028196523             (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain          "41101b4f-1762-49af-9db0-e3603adae3ae"
+                                              :oid                       "1.2.246.562.20.49028196523"
+                                              :hakuOid                   "1.2.246.562.29.65950024186"
+                                              :koulutukset               [{:oid "1.2.246.562.17.74335799462"}]
+                                              :josYoEiMuitaLiitepyyntoja true
+                                              :hakukohteenNimet
+                                              {:kieli_fi "Testihakukohde 1"
+                                               :kieli_sv "sv Testihakukohde 1"}})
+   :1.2.246.562.20.49028196524             (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain "41101b4f-1762-49af-9db0-e3603adae3ae"
+                                              :oid              "1.2.246.562.20.49028196524"
+                                              :hakuOid          "1.2.246.562.29.65950024186"
+                                              :koulutukset      [{:oid "1.2.246.562.17.74335799463"}]
+                                              :hakukohteenNimet
+                                              {:kieli_fi "Testihakukohde 2"
+                                               :kieli_sv "sv Testihakukohde 2"}})
 
-   :1.2.246.562.20.49028196525           (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain "41101b4f-1762-49af-9db0-e3603adae3ae"
-                                            :oid              "1.2.246.562.20.49028196525"
-                                            :hakuOid          "1.2.246.562.29.65950024186"
-                                            :koulutukset      [{:oid "1.2.246.562.17.74335799464"}]
-                                            :hakukohteenNimet
-                                                              {:kieli_fi "Testihakukohde 3"
-                                                               :kieli_sv "sv Testihakukohde 3"}})
-   :1.2.246.562.20.49028100001           (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain                     "hakija-hakukohteen-hakuaika-test-form"
-                                            :oid                                  "1.2.246.562.20.49028100001"
-                                            :hakuOid                              "1.2.246.562.29.65950024187"
-                                            :kaytetaanHakukohdekohtaistaHakuaikaa true
-                                            :hakuaikaAlkuPvm                      (- (System/currentTimeMillis)
-                                                                                    86400000)
-                                            :hakuaikaLoppuPvm                     (- (System/currentTimeMillis)
-                                                                                    16400000)
-                                            :koulutukset                          [{:oid "1.2.246.562.17.74335799465"}]
-                                            :ryhmaliitokset                       [{:ryhmaOid "1.2.246.562.28.00000000001"}]
-                                            :hakukohteenNimet
-                                                                                  {:kieli_fi "Aikaloppu 1"
-                                                                                   :kieli_sv "sv Aikaloppu 1"}})
-   :1.2.246.562.20.49028100002           (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain                     "hakija-hakukohteen-hakuaika-test-form"
-                                            :oid                                  "1.2.246.562.20.49028100002"
-                                            :hakuOid                              "1.2.246.562.29.65950024187"
-                                            :kaytetaanHakukohdekohtaistaHakuaikaa true
-                                            :hakuaikaAlkuPvm                      (- (System/currentTimeMillis)
-                                                                                    86400000)
-                                            :hakuaikaLoppuPvm                     (+ (System/currentTimeMillis)
-                                                                                    86400000)
-                                            :koulutukset                          [{:oid "1.2.246.562.17.74335799465"}]
-                                            :hakukohteenNimet
-                                                                                  {:kieli_fi "Aikaa jäljellä 2"
-                                                                                   :kieli_sv "sv Aikaa jäljellä 2"}})
-   :1.2.246.562.20.49028100003           (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain "hakija-hakukohteen-hakuaika-test-form"
-                                            :oid              "1.2.246.562.20.49028100003"
-                                            :hakuOid          "1.2.246.562.29.65950024187"
-                                            :koulutukset      [{:oid "1.2.246.562.17.74335799465"}]
-                                            :ryhmaliitokset   [{:ryhmaOid "1.2.246.562.28.00000000001"}
-                                                               {:ryhmaOid "1.2.246.562.28.00000000002"}]
-                                            :hakukohteenNimet
-                                                              {:kieli_fi "Aikaa loputtomasti 3"
-                                                               :kieli_sv "sv Aikaa loputtomasti 3"}})
-   :1.2.246.562.20.490281000035          (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain "hakija-hakukohteen-hakuaika-test-form"
-                                            :oid              "1.2.246.562.20.490281000035"
-                                            :hakuOid          "1.2.246.562.29.65950024187"
-                                            :koulutukset      [{:oid "1.2.246.562.17.74335799465"}]
-                                            :ryhmaliitokset   [{:ryhmaOid "1.2.246.562.28.00000000001"}
-                                                               {:ryhmaOid "1.2.246.562.28.00000000002"}]
-                                            :hakukohteenNimet
-                                                              {:kieli_fi "Aikaa loputtomasti 3.5"
-                                                               :kieli_sv "sv Aikaa loputtomasti 3.5"}})
-   :1.2.246.562.20.49028100004           (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain "hakukohteen-organisaatiosta-form"
-                                            :oid              "1.2.246.562.20.49028100004"
-                                            :hakuOid          "1.2.246.562.29.65950024188"
-                                            :tarjoajaOids     ["1.2.246.562.10.10826252480"]
-                                            :koulutukset      [{:oid "1.2.246.562.17.74335799465"}]
-                                            :hakukohteenNimet {:kieli_fi "Hakukohde johon käyttäjällä on organisaatio"
-                                                               :kieli_sv "sv Hakukohde johon käyttäjällä on organisaatio"}})
+   :1.2.246.562.20.49028196525             (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain "41101b4f-1762-49af-9db0-e3603adae3ae"
+                                              :oid              "1.2.246.562.20.49028196525"
+                                              :hakuOid          "1.2.246.562.29.65950024186"
+                                              :koulutukset      [{:oid "1.2.246.562.17.74335799464"}]
+                                              :hakukohteenNimet
+                                              {:kieli_fi "Testihakukohde 3"
+                                               :kieli_sv "sv Testihakukohde 3"}})
+   :1.2.246.562.20.49028100001             (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain                     "hakija-hakukohteen-hakuaika-test-form"
+                                              :oid                                  "1.2.246.562.20.49028100001"
+                                              :hakuOid                              "1.2.246.562.29.65950024187"
+                                              :kaytetaanHakukohdekohtaistaHakuaikaa true
+                                              :hakuaikaAlkuPvm                      (- (System/currentTimeMillis)
+                                                                                       86400000)
+                                              :hakuaikaLoppuPvm                     (- (System/currentTimeMillis)
+                                                                                       16400000)
+                                              :koulutukset                          [{:oid "1.2.246.562.17.74335799465"}]
+                                              :ryhmaliitokset                       [{:ryhmaOid "1.2.246.562.28.00000000001"}]
+                                              :hakukohteenNimet
+                                              {:kieli_fi "Aikaloppu 1"
+                                               :kieli_sv "sv Aikaloppu 1"}})
+   :1.2.246.562.20.49028100002             (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain                     "hakija-hakukohteen-hakuaika-test-form"
+                                              :oid                                  "1.2.246.562.20.49028100002"
+                                              :hakuOid                              "1.2.246.562.29.65950024187"
+                                              :kaytetaanHakukohdekohtaistaHakuaikaa true
+                                              :hakuaikaAlkuPvm                      (- (System/currentTimeMillis)
+                                                                                       86400000)
+                                              :hakuaikaLoppuPvm                     (+ (System/currentTimeMillis)
+                                                                                       86400000)
+                                              :koulutukset                          [{:oid "1.2.246.562.17.74335799465"}]
+                                              :hakukohteenNimet
+                                              {:kieli_fi "Aikaa jäljellä 2"
+                                               :kieli_sv "sv Aikaa jäljellä 2"}})
+   :1.2.246.562.20.49028100003             (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain "hakija-hakukohteen-hakuaika-test-form"
+                                              :oid              "1.2.246.562.20.49028100003"
+                                              :hakuOid          "1.2.246.562.29.65950024187"
+                                              :koulutukset      [{:oid "1.2.246.562.17.74335799465"}]
+                                              :ryhmaliitokset   [{:ryhmaOid "1.2.246.562.28.00000000001"}
+                                                                 {:ryhmaOid "1.2.246.562.28.00000000002"}]
+                                              :hakukohteenNimet
+                                              {:kieli_fi "Aikaa loputtomasti 3"
+                                               :kieli_sv "sv Aikaa loputtomasti 3"}})
+   :1.2.246.562.20.490281000035            (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain "hakija-hakukohteen-hakuaika-test-form"
+                                              :oid              "1.2.246.562.20.490281000035"
+                                              :hakuOid          "1.2.246.562.29.65950024187"
+                                              :koulutukset      [{:oid "1.2.246.562.17.74335799465"}]
+                                              :ryhmaliitokset   [{:ryhmaOid "1.2.246.562.28.00000000001"}
+                                                                 {:ryhmaOid "1.2.246.562.28.00000000002"}]
+                                              :hakukohteenNimet
+                                              {:kieli_fi "Aikaa loputtomasti 3.5"
+                                               :kieli_sv "sv Aikaa loputtomasti 3.5"}})
+   :1.2.246.562.20.49028100004             (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain "hakukohteen-organisaatiosta-form"
+                                              :oid              "1.2.246.562.20.49028100004"
+                                              :hakuOid          "1.2.246.562.29.65950024188"
+                                              :tarjoajaOids     ["1.2.246.562.10.10826252480"]
+                                              :koulutukset      [{:oid "1.2.246.562.17.74335799465"}]
+                                              :hakukohteenNimet {:kieli_fi "Hakukohde johon käyttäjällä on organisaatio"
+                                                                 :kieli_sv "sv Hakukohde johon käyttäjällä on organisaatio"}})
 
-   :1.2.246.562.20.49028100005           (merge
-                                           base-hakukohde
-                                           {:ataruLomakeAvain "41101b4f-1762-49af-9db0-e3603adae3ae"
-                                            :oid              "1.2.246.562.20.49028100005"
+   :1.2.246.562.20.49028100005             (merge
+                                             base-hakukohde
+                                             {:ataruLomakeAvain "41101b4f-1762-49af-9db0-e3603adae3ae"
+                                              :oid              "1.2.246.562.20.49028100005"
                                             :hakuOid          "1.2.246.562.29.65950024189"
                                             :koulutukset      [{:oid "1.2.246.562.17.74335799464"}]
                                             :hakukohteenNimet

--- a/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
@@ -458,15 +458,14 @@
   {:tila                                                 "julkaistu",
    :hakulomaketyyppi                                     "ataru"
    :hakulomakeAtaruId                                    "41101b4f-1762-49af-9db0-e3603adae3ad",
-   :koulutuksenAlkamisVuosi                              2024,
    :hakutapaKoodiUri                                     "hakutapa_02#1",
    :modified                                             "2024-04-16T10:12:10",
    :nimi                                                 {:fi "testing2"},
    :oid                                                  "1.2.246.562.29.65950024185",
    :hakukohdeOids                                        ["1.2.246.562.20.49028196522"],
    :organisaatioOid                                      "1.2.246.562.10.73539475928",
-   :alkamiskausiKoodiUri                                 "kausi_s",
-   :alkamisvuosi                                         "2024",
+   :alkamiskausiKoodiUri                                 "kausi_s#1",
+   :alkamisvuosi                                         2025,
    :hakuvuosi                                            2024,
    :hakukausi                                            "kausi_k#1",
    :kohdejoukkoKoodiUri                                  "haunkohdejoukko_10#1",
@@ -541,7 +540,9 @@
                                 {:oid                         "payment-info-test-kk-haku"
                                  :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
                                  :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
-                                 :hakukohdeOids               ["payment-info-test-kk-hakukohde"]})
+                                 :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
+                                 :hakuajat                    [{:alkaa "2025-01-01T08:00:00",
+                                                                :paattyy "2025-01-01T15:00:00"}]})
    :payment-info-test-kk-no-tutkinto-haku (merge
                                              base-kouta-haku
                                              {:oid                         "payment-info-test-kk-haku"
@@ -630,6 +631,9 @@
 
                "payment-info-test-kk-jatko-form"
                "payment-info-test-kk-jatko-haku"
+
+               "payment-exemption-test-form"
+               "payment-info-test-kk-haku"
 
                nil)]
       [(.get-haku this haku-key)]

--- a/src/clj/ataru/tarjonta_service/tarjonta_client.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_client.clj
@@ -116,6 +116,8 @@
    {:oid                                        (:oid haku)
     :name                                       (localized-names (:nimi haku))
     :hakukohteet                                (:hakukohdeOids haku)
+    :alkamiskausi                               (:koulutuksenAlkamiskausiUri haku)
+    :alkamisvuosi                               (:koulutuksenAlkamisVuosi haku)
     :ylioppilastutkinto-antaa-hakukelpoisuuden? (boolean (:ylioppilastutkintoAntaaHakukelpoisuuden haku))
     :kohdejoukko-uri                            (:kohdejoukkoUri haku)
     :kohdejoukon-tarkenne-uri                   (:kohdejoukonTarkenne haku)

--- a/src/clj/ataru/tarjonta_service/tarjonta_parser.clj
+++ b/src/clj/ataru/tarjonta_service/tarjonta_parser.clj
@@ -104,6 +104,8 @@
            :can-submit-multiple-applications (:can-submit-multiple-applications haku)
            :kohdejoukko-uri                  (:kohdejoukko-uri haku)
            :kohdejoukon-tarkenne-uri         (:kohdejoukon-tarkenne-uri haku)
+           :alkamiskausi                     (:alkamiskausi haku)
+           :alkamisvuosi                     (:alkamisvuosi haku)
            :hakutapa-uri                     (:hakutapa-uri haku)
            :yhteishaku                       (:yhteishaku haku)}}))))
   ([koodisto-cache tarjonta-service organization-service ohjausparametrit-service haku-oid]

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -271,7 +271,9 @@
    :kohdejoukko-uri                    s/Str
    :kohdejoukon-tarkenne-uri           (s/maybe s/Str)
    :hakutapa-uri                       s/Str
-   :yhteishaku                         (s/maybe s/Bool)})
+   :yhteishaku                         (s/maybe s/Bool)
+   (s/optional-key :alkamiskausi)      (s/maybe s/Str)
+   (s/optional-key :alkamisvuosi)      (s/maybe s/Int)})
 
 (s/defschema Haku
   {:oid                                        s/Str

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -289,6 +289,8 @@
                                                  :start                org.joda.time.DateTime
                                                  (s/optional-key :end) org.joda.time.DateTime}]
    :haun-tiedot-url                            s/Str
+   (s/optional-key :alkamiskausi)              (s/maybe s/Str)
+   (s/optional-key :alkamisvuosi)              (s/maybe s/Int)
    (s/optional-key :hakukausi-vuosi)           s/Int
    (s/optional-key :ataru-form-key)            s/Str
    (s/optional-key :max-hakukohteet)           s/Int


### PR DESCRIPTION
Payment state setting logic for hakemusmaksu:
- Complete constraints for filtering which hakus are in scope of hakemusmaksu (application period, studies start period, higher education related parameters)
- Checks for EU citizenship and application level exemptions (Final exemption field naming and option parsing are TBD, this one's a collaborative best guess)
- Determine, resolve and set payment state for applicant with possible multiple OID aliases (Polling for payments will be done separately)

Whenever some important piece of data is missing (eg. no exemption question on application form, or missing koodisto), throw an exception instead of failing silently - otherwise we risk making wrong decisions on the state.