### PR TITLE
OK-576 payment status to applications

### DIFF
--- a/dev-resources/sql/dev-form-queries.sql
+++ b/dev-resources/sql/dev-form-queries.sql
@@ -50,3 +50,9 @@ WHERE id = :id;
 -- name: yesql-delete-fixture-forms-with-key!
 DELETE FROM forms
 WHERE key = :key;
+
+-- name: yesql-delete-kk-payment-events!
+DELETE FROM kk_application_payment_events;
+
+-- name: yesql-delete-kk-payment-states!
+DELETE FROM kk_application_payment_states;

--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -23,7 +23,7 @@
    :haku       "payment-info-test-kk-haku"
    :id         543211
    :person-oid "1.2.3.4.5.303"
-   :answers    [{:key "foo" :value "1" :fieldType "dropdown"}]})
+   :answers    [{:key "vapautus_hakemusmaksusta" :value "12345" :fieldType "dropdown"}]})
 
 (def application-with-koodisto-form
   {:form       981230123,

--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -574,7 +574,7 @@
       (merge {:form       909909,
               :lang       "fi"
               :haku       "payment-info-test-kk-haku"
-              :hakukohde  "payment-info-test-kk-hakukohde"
+              :hakukohde  ["payment-info-test-kk-hakukohde"]
               :id         543210
               :person-oid "1.2.3.4.5.303"})
       (update :answers
@@ -586,12 +586,10 @@
       (merge {:form       909909,
               :lang       "fi"
               :haku       "payment-info-test-kk-haku"
-              :hakukohde  "payment-info-test-kk-hakukohde"
+              :hakukohde  ["payment-info-test-kk-hakukohde"]
               :id         543211
               :person-oid "1.2.3.4.5.303"})
       (update
         :answers
         (comp vec concat)
         [{:key "vapautus_hakemusmaksusta" :value "12345" :fieldType "dropdown"}])))
-
-

--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -9,22 +9,6 @@
                              :date "2018-03-22T07:55:08Z"
                              :name "Teppo Testinen"}})
 
-(def application-with-hakemusmaksu-exemption
-  {:form       909909,
-   :lang       "fi"
-   :haku       "payment-info-test-kk-haku"
-   :id         543210
-   :person-oid "1.2.3.4.5.303"
-   :answers    [{:key "vapautus_hakemusmaksusta" :value "0" :fieldType "dropdown"}]})
-
-(def application-without-hakemusmaksu-exemption
-  {:form       909909,
-   :lang       "fi"
-   :haku       "payment-info-test-kk-haku"
-   :id         543211
-   :person-oid "1.2.3.4.5.303"
-   :answers    [{:key "vapautus_hakemusmaksusta" :value "12345" :fieldType "dropdown"}]})
-
 (def application-with-koodisto-form
   {:form       981230123,
    :lang       "fi"
@@ -584,3 +568,30 @@
   {:application-keys ["c58df586-fdb9-4ee1-b4c4-030d4cfe9f81"]
    :notes           "Some notes about the applicant"
    :state-name      "processing-state"})
+
+(def application-with-hakemusmaksu-exemption
+  (-> person-info-form-application
+      (merge {:form       909909,
+              :lang       "fi"
+              :haku       "payment-info-test-kk-haku"
+              :hakukohde  "payment-info-test-kk-hakukohde"
+              :id         543210
+              :person-oid "1.2.3.4.5.303"})
+      (update :answers
+              (comp vec concat)
+              [{:key "vapautus_hakemusmaksusta" :value "0" :fieldType "dropdown"}])))
+
+(def application-without-hakemusmaksu-exemption
+  (-> person-info-form-application
+      (merge {:form       909909,
+              :lang       "fi"
+              :haku       "payment-info-test-kk-haku"
+              :hakukohde  "payment-info-test-kk-hakukohde"
+              :id         543211
+              :person-oid "1.2.3.4.5.303"})
+      (update
+        :answers
+        (comp vec concat)
+        [{:key "vapautus_hakemusmaksusta" :value "12345" :fieldType "dropdown"}])))
+
+

--- a/spec/ataru/fixtures/db/unit_test_db.clj
+++ b/spec/ataru/fixtures/db/unit_test_db.clj
@@ -18,6 +18,8 @@
 (declare yesql-delete-fixture-form!)
 (declare yesql-delete-fixture-forms-with-key!)
 (declare yesql-set-form-id!)
+(declare yesql-delete-kk-payment-events!)
+(declare yesql-delete-kk-payment-states!)
 
 (defqueries "sql/dev-form-queries.sql")
 
@@ -33,6 +35,10 @@
 
 (defn nuke-old-fixture-forms-with-key [form-key]
   (ataru-db/exec :db yesql-delete-fixture-forms-with-key! {:key form-key}))
+
+(defn nuke-kk-payment-data []
+  (ataru-db/exec :db yesql-delete-kk-payment-events! {})
+  (ataru-db/exec :db yesql-delete-kk-payment-states! {}))
 
 (defn init-db-form-fixture
   [form-fixture]
@@ -64,7 +70,8 @@
        (:key stored-application) hakukohde review-requirement review-state {} audit-logger))
     (doseq [review application-reviews-fixture]
       (application-store/save-application-review
-        (merge review {:application-key (:key stored-application)}) {} audit-logger))))
+        (merge review {:application-key (:key stored-application)}) {} audit-logger))
+    application-id))
 
 (defn init-db-fixture
   ([form-fixture]

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -1,5 +1,6 @@
 (ns ataru.hakija.hakija-routes-spec
   (:require [ataru.applications.field-deadline :as field-deadline]
+            [ataru.kk-application-payment.kk-application-payment :as payment]
             [ataru.util :as util]
             [ataru.log.audit-log :as audit-log]
             [ataru.koodisto.koodisto :as koodisto]
@@ -518,9 +519,22 @@
         (should= 200 (:status resp))
         (should (-> (get-in resp [:body :application])
                   (get-answer "87834771-34da-40a4-a9f6-sensitive")
-                  nil?)))))
+                  nil?))))
 
-  (describe "PUT application"
+    (it "should get application's kk payment data"
+        (with-redefs [hakuaika/hakukohteen-hakuaika hakuaika-ongoing]
+          (with-get-response "12345" resp
+            (let [application-id (get-in resp [:body :application :id])]
+              (store/add-person-oid application-id "1.2.3.4.5.6")
+              (payment/set-application-fee-required "1.2.3.4.5.6" "kausi_s" 2025 nil nil)
+              (with-get-response "12345" resp
+                (should= 200 (:status resp))
+                (should= {:person-oid "1.2.3.4.5.6", :start-term "kausi_s", :start-year 2025, :state "payment-pending"}
+                         (select-keys
+                           (get-in resp [:body :kk-payment :status])
+                           [:person-oid :start-term :start-year :state]))))))))
+
+          (describe "PUT application"
     (around [spec]
       (with-redefs [application-email/start-email-submit-confirmation-job (constantly nil)
                     application-email/start-email-edit-confirmation-job   (constantly nil)

--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -529,7 +529,7 @@
               (payment/set-application-fee-required "1.2.3.4.5.6" "kausi_s" 2025 nil nil)
               (with-get-response "12345" resp
                 (should= 200 (:status resp))
-                (should= {:person-oid "1.2.3.4.5.6", :start-term "kausi_s", :start-year 2025, :state "payment-pending"}
+                (should= {:person-oid "1.2.3.4.5.6", :start-term "kausi_s", :start-year 2025, :state "awaiting-payment"}
                          (select-keys
                            (get-in resp [:body :kk-payment :status])
                            [:person-oid :start-term :start-year :state]))))))))

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -77,7 +77,7 @@
                               id (payment/update-payment-status fake-person-service fake-tarjonta-service
                                                                fake-koodisto-cache fake-haku-cache
                                                                oid term-fall year-ok nil)
-                              state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                              state (first (payment/get-raw-payment-states [oid] term-fall year-ok))]
                           (should-be-nil state)
                           (should-be-nil id)))
 
@@ -103,7 +103,7 @@
                               id (payment/update-payment-status fake-person-service fake-tarjonta-service
                                                                 fake-koodisto-cache fake-haku-cache
                                                                 linked-oid term-fall year-ok nil)
-                              state (first (payment/get-payment-states [linked-oid] term-fall year-ok))]
+                              state (first (payment/get-raw-payment-states [linked-oid] term-fall year-ok))]
                           (should-not-be-nil id)
                           (should-not-be-nil state)
                           (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
@@ -120,7 +120,7 @@
                               id (payment/update-payment-status fake-person-service fake-tarjonta-service
                                                                 fake-koodisto-cache fake-haku-cache
                                                                 oid term-fall year-ok nil)
-                              state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                              state (first (payment/get-raw-payment-states [oid] term-fall year-ok))]
                           (should-not-be-nil id)
                           (should-not-be-nil state)
                           (should-be-matching-state {:person-oid oid, :start-term term-fall,
@@ -136,7 +136,7 @@
                               id (payment/update-payment-status fake-person-service fake-tarjonta-service
                                                                 fake-koodisto-cache fake-haku-cache
                                                                 oid term-fall year-ok nil)
-                              state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                              state (first (payment/get-raw-payment-states [oid] term-fall year-ok))]
                           (should-not-be-nil id)
                           (should-not-be-nil state)
                           (should-be-matching-state {:person-oid oid, :start-term term-fall,
@@ -151,7 +151,7 @@
                               id (payment/update-payment-status fake-person-service fake-tarjonta-service
                                                                 fake-koodisto-cache fake-haku-cache
                                                                 oid term-fall year-ok nil)
-                              state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                              state (first (payment/get-raw-payment-states [oid] term-fall year-ok))]
                           (should-not-be-nil id)
                           (should-not-be-nil state)
                           (should-be-matching-state {:person-oid oid, :start-term term-fall,
@@ -166,7 +166,7 @@
                                 id (payment/update-payment-status fake-person-service fake-tarjonta-service
                                                                   fake-koodisto-cache fake-haku-cache
                                                                   oid term-fall year-ok nil)
-                                state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                                state (first (payment/get-raw-payment-states [oid] term-fall year-ok))]
                             (should-not-be-nil id)
                             (should-not-be-nil state)
                             (should-be-matching-state {:person-oid oid, :start-term term-fall,
@@ -185,7 +185,7 @@
                               id (payment/update-payment-status fake-person-service fake-tarjonta-service
                                                                 fake-koodisto-cache fake-haku-cache
                                                                 oid term-fall year-ok nil)
-                              state (first (payment/get-payment-states [oid] term-fall year-ok))]
+                              state (first (payment/get-raw-payment-states [oid] term-fall year-ok))]
                           (should-not-be-nil id)
                           (should-not-be-nil state)
                           (should-be-matching-state {:person-oid oid, :start-term term-fall,
@@ -194,8 +194,8 @@
 (defn save-and-check-single-state-and-event
   [oid term year state-func desired-state]
   (let [state-id (state-func oid term-fall year-ok nil nil)
-        states   (payment/get-payment-states [oid] term year)
-        events   (payment/get-payment-events [state-id])
+        states   (payment/get-raw-payment-states [oid] term year)
+        events   (payment/get-raw-payment-events [state-id])
         state    (first states)
         event    (first events)]
     (should= 1 (count states))

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -191,64 +191,6 @@
                           (should-be-matching-state {:person-oid oid, :start-term term-fall,
                                                      :start-year year-ok, :state state-not-required} state)))))
 
-(describe "resolve-payment-status"
-          (tags :unit :kk-application-payment)
-
-          (before-all
-            (delete-states-and-events!))
-
-          (it "should return nil when no states found"
-              (let [oid "1.2.3.4.5.6"
-                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-nil state)))
-
-          (it "should return a simple single state when no states for linked oids"
-              (let [oid "1.2.3.4.5.7"
-                    _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
-                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person-oid oid, :start-term term-fall,
-                                           :start-year year-ok, :state state-pending}
-                                          state)))
-
-          (it "should resolve a simple single state for linked oid"
-              (let [oid "1.2.3.4.5.8"
-                    linked-oid (str oid "2")                ; See FakePersonService
-                    _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
-                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
-                                           :start-year year-ok, :state state-paid}
-                                          state)))
-
-          (it "should resolve a possible paid state with linked oids and conflicting states"
-              (let [oid "1.2.3.4.5.9"
-                    linked-oid (str oid "2")                ; See FakePersonService
-                    _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
-                    _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
-                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
-                                           :start-year year-ok, :state state-paid}
-                                          state)))
-
-          (it "should resolve a possible not required state with linked oids, conflicting states and no paid state"
-              (let [oid "1.2.3.4.5.10"
-                    linked-oid (str oid "2")                ; See FakePersonService
-                    _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
-                    _ (payment/set-application-fee-not-required linked-oid term-fall year-ok nil nil)
-                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
-                                           :start-year year-ok, :state state-not-required}
-                                          state)))
-
-          (it "should resolve a required state with linked oids whenever no paid or not required states found"
-              (let [oid "1.2.3.4.5.11"
-                    linked-oid (str oid "2")                ; See FakePersonService
-                    _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
-                    _ (payment/set-application-fee-required linked-oid term-fall year-ok nil nil)
-                    state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person-oid oid, :start-term term-fall,
-                                           :start-year year-ok, :state state-pending}
-                                          state))))
-
 (defn save-and-check-single-state-and-event
   [oid term year state-func desired-state]
   (let [state-id (state-func oid term-fall year-ok nil nil)

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -46,11 +46,11 @@
 
 (defn- should-be-matching-state
   [example state]
-  (should= example (dissoc state :id :created_time :modified_time)))
+  (should= example (dissoc state :id :created-time :modified-time)))
 
 (defn- should-be-matching-event
   [example event]
-  (should= example (dissoc event :id :created_time)))
+  (should= example (dissoc event :id :created-time)))
 
 (declare spec)
 
@@ -105,8 +105,8 @@
                               state (first (payment/get-payment-states [linked-oid] term-fall year-ok))]
                           (should-not-be-nil id)
                           (should-not-be-nil state)
-                          (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
-                                                     :start_year year-ok, :state state-paid} state)))
+                          (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
+                                                     :start-year year-ok, :state state-paid} state)))
 
                     (it "should set payment status for eu citizen as not required"
                         (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
@@ -120,8 +120,8 @@
                               state (first (payment/get-payment-states [oid] term-fall year-ok))]
                           (should-not-be-nil id)
                           (should-not-be-nil state)
-                          (should-be-matching-state {:person_oid oid, :start_term term-fall,
-                                                     :start_year year-ok, :state state-not-required} state)))
+                          (should-be-matching-state {:person-oid oid, :start-term term-fall,
+                                                     :start-year year-ok, :state state-not-required} state)))
 
                     (it "should set payment status for non eu citizen without exemption as required"
                         (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
@@ -135,8 +135,8 @@
                                 state (first (payment/get-payment-states [oid] term-fall year-ok))]
                             (should-not-be-nil id)
                             (should-not-be-nil state)
-                            (should-be-matching-state {:person_oid oid, :start_term term-fall,
-                                                       :start_year year-ok, :state state-pending} state)))))
+                            (should-be-matching-state {:person-oid oid, :start-term term-fall,
+                                                       :start-year year-ok, :state state-pending} state)))))
 
           (describe "with exemption"
                     (before-all
@@ -154,8 +154,8 @@
                               state (first (payment/get-payment-states [oid] term-fall year-ok))]
                           (should-not-be-nil id)
                           (should-not-be-nil state)
-                          (should-be-matching-state {:person_oid oid, :start_term term-fall,
-                                                     :start_year year-ok, :state state-not-required} state)))))
+                          (should-be-matching-state {:person-oid oid, :start-term term-fall,
+                                                     :start-year year-ok, :state state-not-required} state)))))
 
 (describe "resolve-payment-status"
           (tags :unit :kk-application-payment)
@@ -172,8 +172,8 @@
               (let [oid "1.2.3.4.5.7"
                     _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
                     state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person_oid oid, :start_term term-fall,
-                                           :start_year year-ok, :state state-pending}
+                (should-be-matching-state {:person-oid oid, :start-term term-fall,
+                                           :start-year year-ok, :state state-pending}
                                           state)))
 
           (it "should resolve a simple single state for linked oid"
@@ -181,8 +181,8 @@
                     linked-oid (str oid "2")                ; See FakePersonService
                     _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
                     state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
-                                           :start_year year-ok, :state state-paid}
+                (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
+                                           :start-year year-ok, :state state-paid}
                                           state)))
 
           (it "should resolve a possible paid state with linked oids and conflicting states"
@@ -191,8 +191,8 @@
                     _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
                     _ (payment/set-application-fee-paid linked-oid term-fall year-ok nil nil)
                     state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
-                                           :start_year year-ok, :state state-paid}
+                (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
+                                           :start-year year-ok, :state state-paid}
                                           state)))
 
           (it "should resolve a possible not required state with linked oids, conflicting states and no paid state"
@@ -201,8 +201,8 @@
                     _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
                     _ (payment/set-application-fee-not-required linked-oid term-fall year-ok nil nil)
                     state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person_oid linked-oid, :start_term term-fall,
-                                           :start_year year-ok, :state state-not-required}
+                (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
+                                           :start-year year-ok, :state state-not-required}
                                           state)))
 
           (it "should resolve a required state with linked oids whenever no paid or not required states found"
@@ -211,8 +211,8 @@
                     _ (payment/set-application-fee-required oid term-fall year-ok nil nil)
                     _ (payment/set-application-fee-required linked-oid term-fall year-ok nil nil)
                     state (payment/resolve-payment-status fake-person-service oid term-fall year-ok)]
-                (should-be-matching-state {:person_oid oid, :start_term term-fall,
-                                           :start_year year-ok, :state state-pending}
+                (should-be-matching-state {:person-oid oid, :start-term term-fall,
+                                           :start-year year-ok, :state state-pending}
                                           state))))
 
 (defn save-and-check-single-state-and-event
@@ -224,9 +224,9 @@
         event    (first events)]
     (should= 1 (count states))
     (should= 1 (count events))
-    (should-be-matching-state {:person_oid oid, :start_term term, :start_year year, :state desired-state} state)
-    (should-be-matching-event {:kk_application_payment_state_id state-id, :new_state desired-state,
-                               :event_type event-updated, :virkailija_oid nil, :message nil} event)))
+    (should-be-matching-state {:person-oid oid, :start-term term, :start-year year, :state desired-state} state)
+    (should-be-matching-event {:kk-application-payment-state-id state-id, :new-state desired-state,
+                               :event-type event-updated, :virkailija-oid nil, :message nil} event)))
 
 (describe "application payment states"
           (tags :unit :kk-application-payment)

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -39,7 +39,7 @@
 (def term-error "kausi_a")
 (def year-ok 2025)
 (def year-error 2024)
-(def state-pending "payment-pending")
+(def state-pending "awaiting-payment")
 (def state-not-required "payment-not-required")
 (def state-paid "payment-paid")
 (def state-ok-via-linked-oid "payment-ok-via-linked-oid")

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -42,7 +42,7 @@
 (def state-pending "payment-pending")
 (def state-not-required "payment-not-required")
 (def state-paid "payment-paid")
-(def state-paid-via-linked-oid "payment-paid-for-linked-oid")
+(def state-ok-via-linked-oid "payment-ok-via-linked-oid")
 (def event-updated "state-updated")
 
 (defn- should-be-matching-state
@@ -109,7 +109,7 @@
                           (should-be-matching-state {:person-oid linked-oid, :start-term term-fall,
                                                      :start-year year-ok, :state state-paid} state)))
 
-                    (it "should set paid via linked oid status"
+                    (it "should set ok via linked oid status when linked oid has payment info"
                         (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
                                                       (merge
                                                         application-fixtures/application-without-hakemusmaksu-exemption
@@ -124,7 +124,7 @@
                           (should-not-be-nil id)
                           (should-not-be-nil state)
                           (should-be-matching-state {:person-oid oid, :start-term term-fall,
-                                                     :start-year year-ok, :state state-paid-via-linked-oid} state)))
+                                                     :start-year year-ok, :state state-ok-via-linked-oid} state)))
 
                     (it "should reset paid via linked oid status when the linking has been removed"
                         (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
@@ -132,7 +132,7 @@
                                                         application-fixtures/application-without-hakemusmaksu-exemption
                                                         {:person-oid "1.2.3.4.5.300"}) nil)
                         (let [oid "1.2.3.4.5.300"
-                              _ (payment/set-application-fee-paid-for-alias oid term-fall year-ok nil nil)
+                              _ (payment/set-application-fee-ok-via-linked-oid oid term-fall year-ok nil nil)
                               id (payment/update-payment-status fake-person-service fake-tarjonta-service
                                                                 fake-koodisto-cache fake-haku-cache
                                                                 oid term-fall year-ok nil)

--- a/spec/ataru/kk_application_payment/kk_application_payment_store_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_store_spec.clj
@@ -9,7 +9,7 @@
 (def test-term-fall "kausi_s")
 (def test-year 2025)
 (def test-year-2 2026)
-(def test-state-pending "payment-pending")
+(def test-state-pending "awaiting-payment")
 (def test-state-paid "payment-paid")
 (def test-event-updated "state-updated")
 (def test-event-comment "comment")

--- a/spec/ataru/kk_application_payment/kk_application_payment_store_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_store_spec.clj
@@ -48,12 +48,12 @@
                                          test-person-oid test-term-fall test-year test-state-paid))
                     spring-state (first (store/get-kk-application-payment-states [test-person-oid] test-term-spring test-year))
                     fall-state (first (store/get-kk-application-payment-states [test-person-oid] test-term-fall test-year))
-                    expected-spring-state {:id spring-state-id :person_oid test-person-oid :start_term test-term-spring
-                                           :start_year test-year :state test-state-pending}
-                    expected-fall-state {:id fall-state-id :person_oid test-person-oid :start_term test-term-fall
-                                         :start_year test-year :state test-state-paid}]
-                (should= expected-spring-state (dissoc spring-state :created_time :modified_time))
-                (should= expected-fall-state (dissoc fall-state :created_time :modified_time)))))
+                    expected-spring-state {:id spring-state-id :person-oid test-person-oid :start-term test-term-spring
+                                           :start-year test-year :state test-state-pending}
+                    expected-fall-state {:id fall-state-id :person-oid test-person-oid :start-term test-term-fall
+                                         :start-year test-year :state test-state-paid}]
+                (should= expected-spring-state (dissoc spring-state :created-time :modified-time))
+                (should= expected-fall-state (dissoc fall-state :created-time :modified-time)))))
 
 (describe "kk application payment events"
           (tags :unit :kk-application-payment)

--- a/src/clj/ataru/applications/application_access_control.clj
+++ b/src/clj/ataru/applications/application_access_control.clj
@@ -368,14 +368,14 @@
     (constantly nil)
     #(tilastokeskus-service/get-application-info-for-tilastokeskus person-service tarjonta-service valintalaskentakoostepalvelu-service suoritus-service haku-oid hakukohde-oid)))
 
-(defn get-applications-for-valintapiste [organization-service session haku-oid hakukohde-oid]
+(defn get-applications-for-valintapiste [organization-service session tarjonta-service haku-oid hakukohde-oid]
   (session-orgs/run-org-authorized
     session
     organization-service
     [:view-applications :edit-applications]
     (constantly nil)
     (constantly nil)
-    #(valintapiste-service/get-application-info-for-valintapiste haku-oid hakukohde-oid)))
+    #(valintapiste-service/get-application-info-for-valintapiste tarjonta-service haku-oid hakukohde-oid)))
 
 (defn get-applications-for-valintalaskenta [organization-service session hakukohde-oid application-keys]
   (session-orgs/run-org-authorized

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -115,27 +115,6 @@
           (update :virkailija-organizations
                   (partial organization-service/get-organizations-for-oids organization-service))))
 
-(defn- get-kk-payment-state
-  "Adds higher education application fee related info to application. If add-events is truthy, also returns
-   specific processing events."
-  [application haku return-payment-events]
-  (let [tarjonta           (:tarjonta haku)
-        person-oid         (:person-oid application)
-        studies-start-term (:alkamiskausi tarjonta)
-        studies-start-year (:alkamisvuosi tarjonta)
-        payment-status     (when (and person-oid studies-start-term studies-start-year)
-                             (first
-                               (kk-application-payment/get-payment-states
-                                 [person-oid] studies-start-term studies-start-year)))
-        payment-events     (when (and payment-status return-payment-events)
-                             (kk-application-payment/get-payment-events (:id payment-status)))]
-    (cond-> {}
-            payment-status (assoc :status
-                                  (select-keys payment-status [:person-oid :start-term :start-year :state :created-time]))
-            payment-events (assoc :events
-                                  (map #(select-keys % [:new-state :event-type :virkailija-oid :message :created-time])
-                                       payment-events)))))
-
 (defn- get-application-events
   [organization-service application-key]
   (map (partial enrich-virkailija-organizations organization-service)
@@ -511,7 +490,7 @@
             hakukohde-reviews     (future (parse-application-hakukohde-reviews application-key))
             attachment-reviews    (future (parse-application-attachment-reviews application-key))
             events                (future (get-application-events organization-service application-key))
-            kk-payment-state      (future (get-kk-payment-state application tarjonta-info true))
+            kk-payment-state      (future (kk-application-payment/get-kk-payment-state application tarjonta-info true))
             review                (future (application-store/get-application-review application-key))
             review-notes          (future (map (partial enrich-virkailija-organizations organization-service)
                                                (application-store/get-application-review-notes application-key)))

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -37,8 +37,7 @@
     [clojure.set :as set]
     [clojure.string :as str]
     [ataru.person-service.person-util :as person-util]
-    [ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-protocol :as valintalaskentakoostepalvelu]
-    [ataru.kk-application-payment.kk-application-payment :as kk-application-payment])
+    [ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-protocol :as valintalaskentakoostepalvelu])
   (:import
     java.io.ByteArrayInputStream
     java.security.SecureRandom
@@ -398,24 +397,6 @@
      session
      application-keys
      [:view-applications :edit-applications])))
-
-(defn- add-kk-application-payment-data
-  "Adds higher education application fee related info to application"
-  [person-service application haku add-events]
-  (let [person-oid         (:person-oid application)
-        studies-start-term (:alkamiskausi haku)
-        studies-start-year (:alkamisvuosi haku)
-        payment-status     (when (and person-oid haku studies-start-term studies-start-year)
-                             (kk-application-payment/resolve-payment-status person-service person-oid
-                                                                            studies-start-term studies-start-year))
-        payment-events     (when (and payment-status add-events)
-                             (kk-application-payment/get-payment-events (:id payment-status)))]
-    (cond-> application
-            payment-status (assoc :payment-status
-                                  (select-keys payment-status [:person-oid :start-term :start-year :state :created-time]))
-            payment-events (assoc :payment-events
-                                  (map #(select-keys % [:new-state :event-type :virkailija-oid :message :created-time])
-                                       payment-events)))))
 
 (defprotocol ApplicationService
   (get-person [this application])

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -37,7 +37,8 @@
     [clojure.set :as set]
     [clojure.string :as str]
     [ataru.person-service.person-util :as person-util]
-    [ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-protocol :as valintalaskentakoostepalvelu])
+    [ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-protocol :as valintalaskentakoostepalvelu]
+    [ataru.kk-application-payment.kk-application-payment :as kk-application-payment])
   (:import
     java.io.ByteArrayInputStream
     java.security.SecureRandom
@@ -398,6 +399,24 @@
      application-keys
      [:view-applications :edit-applications])))
 
+(defn- add-kk-application-payment-data
+  "Adds higher education application fee related info to application"
+  [person-service application haku add-events]
+  (let [person-oid         (:person-oid application)
+        studies-start-term (:alkamiskausi haku)
+        studies-start-year (:alkamisvuosi haku)
+        payment-status     (when (and person-oid haku studies-start-term studies-start-year)
+                             (kk-application-payment/resolve-payment-status person-service person-oid
+                                                                            studies-start-term studies-start-year))
+        payment-events     (when (and payment-status add-events)
+                             (kk-application-payment/get-payment-events (:id payment-status)))]
+    (cond-> application
+            payment-status (assoc :payment-status
+                                  (select-keys payment-status [:person-oid :start-term :start-year :state :created-time]))
+            payment-events (assoc :payment-events
+                                  (map #(select-keys % [:new-state :event-type :virkailija-oid :message :created-time])
+                                       payment-events)))))
+
 (defprotocol ApplicationService
   (get-person [this application])
   (get-person-for-securelink [this application])
@@ -548,7 +567,7 @@
                                                                        selected-hakukohderyhma
                                                                        skip-answers-to-preserve-memory?
                                                                        included-ids
-                                                                       ids-only? 
+                                                                       ids-only?
                                                                        (keyword sort-by-field)
                                                                        (keyword sort-order)
                                                                        lang

--- a/src/clj/ataru/applications/filtering.clj
+++ b/src/clj/ataru/applications/filtering.clj
@@ -4,6 +4,12 @@
             [ataru.application.application-states :as application-states]
             [ataru.application.review-states :as review-states]))
 
+(defn- filter-by-kk-payment-states
+  [application states]
+  (if (empty? states)
+    true
+    (contains? states (:kk-payment-state application))))
+
 (defn- filter-by-attachment-review
   [application selected-hakukohteet states-to-include]
   (or (empty? (:hakukohde application))
@@ -96,13 +102,16 @@
       (-> filters :only-identified :unidentified))))
 
 (defn filter-applications
-  [applications {:keys [selected-hakukohteet attachment-states-to-include processing-states-to-include filters]}]
+  [applications {:keys [selected-hakukohteet attachment-states-to-include kk-payment-states-to-include
+                                         processing-states-to-include filters]}]
   (let [selected-hakukohteet-set         (when selected-hakukohteet (set selected-hakukohteet))
         applications-with-requirements   (map
-                                           #(assoc % :application-hakukohde-reviews (application-states/get-all-reviews-for-all-requirements %))
+                                           #(assoc % :application-hakukohde-reviews
+                                                     (application-states/get-all-reviews-for-all-requirements %))
                                            applications)
         processing-states-to-include-set (set processing-states-to-include)
         attachment-states-to-include-set (set attachment-states-to-include)
+        kk-payment-states-to-include-set (set kk-payment-states-to-include)
         with-ssn?                        (-> filters :only-ssn :with-ssn)
         without-ssn?                     (-> filters :only-ssn :without-ssn)
         identified?                      (-> filters :only-identified :identified)
@@ -118,6 +127,7 @@
           (filter-by-ssn application with-ssn? without-ssn?)
           (filter-by-yksiloity application identified? unidentified?)
           (filter-by-active application active? passive?)
+          (filter-by-kk-payment-states application kk-payment-states-to-include-set)
           (or
             all-base-educations-enabled?
             (filter-by-base-education application (:base-education filters)))

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -332,7 +332,7 @@
       :summary "Get submitted application by secret"
       :query-params [{secret :- s/Str nil}
                      {virkailija-secret :- s/Str nil}]
-      :return ataru-schema/ApplicationWithPersonAndForm
+      :return ataru-schema/ApplicationWithPersonFormAndPayment
       (cond (not-blank? secret)
             (get-application form-by-id-cache
                              koodisto-cache

--- a/src/clj/ataru/haku/haku_service.clj
+++ b/src/clj/ataru/haku/haku_service.clj
@@ -10,7 +10,6 @@
     [ataru.hakukohde.hakukohde-store :as hakukohde-store]
     [clj-time.core :as t]
     [clj-time.coerce :as c]
-    [clojure.string :as str]
     [taoensso.timbre :as log]
     [ataru.tarjonta.haku :as haku]
     [ataru.user-rights :as user-rights]

--- a/src/clj/ataru/haku/haku_service.clj
+++ b/src/clj/ataru/haku/haku_service.clj
@@ -319,12 +319,4 @@
            :hakukohteet      hakukohteet-with-kevyt-valinta
            :hakukohderyhmat  hakukohderyhmat}))
 
-(defn get-haut-for-start-term-and-year
-  "Get hakus according to study start term and year. Only for internal use, does not do authorization."
-  [get-haut-cache tarjonta-service start-term start-year]
-  (->> (cache/get-from get-haut-cache :haut)
-       (map :haku)
-       distinct
-       (keep #(tarjonta/get-haku tarjonta-service %))
-       (filter #(and (= start-year (:alkamisvuosi %))
-                     (str/starts-with? (:alkamiskausi %) start-term)))))
+

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -47,7 +47,8 @@
 
 (defn get-payment-states
   [person-oids term year]
-  (store/get-kk-application-payment-states person-oids term year))
+  (let [simplified-term (first (str/split term #"#"))]
+    (store/get-kk-application-payment-states person-oids simplified-term year)))
 
 (defn get-payment-events
   [state-ids]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -128,14 +128,6 @@
        (filter #(and (= start-year (:alkamisvuosi %))
                      (str/starts-with? (:alkamiskausi %) start-term)))))
 
-(defn resolve-payment-status
-  "Determines a single payment status out of the statuses attached to possible aliases of the person.
-   Returns full state data."
-  [person-service person-oid term year]
-  (let [linked-oids (get (person-service/linked-oids person-service [person-oid]) person-oid)
-        aliases (into [] (conj (:linked-oids linked-oids) (:master-oid linked-oids) person-oid))]
-    (resolve-actual-payment-state (get-payment-states aliases term year))))
-
 (defn update-payment-status
   "Infers and sets new payment status for person according to their personal data, possible OID linkings
   and applications for term. Does not poll payments, they should be updated separately. Returns state id."

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
@@ -1,5 +1,7 @@
 (ns ataru.kk-application-payment.kk-application-payment-store
   (:require [ataru.db.db :as db]
+            [camel-snake-kebab.core :refer [->kebab-case-keyword]]
+            [camel-snake-kebab.extras :refer [transform-keys]]
             [yesql.core :refer [defqueries]]))
 
 (defqueries "sql/kk-application-payment-queries.sql")
@@ -8,6 +10,8 @@
 (declare yesql-upsert-kk-application-payment-state<!)
 (declare yesql-add-kk-application-payment-event<!)
 (declare yesql-get-kk-application-payment-events)
+
+(def ^:private ->kebab-case-kw (partial transform-keys ->kebab-case-keyword))
 
 (defn- exec-db
   [ds-key query params]
@@ -22,9 +26,10 @@
 
 (defn get-kk-application-payment-states
   [person-oids start-term start-year]
-  (exec-db :db yesql-get-kk-application-payment-states-for-person-oids {:person_oids person-oids
-                                                                        :start_term  start-term
-                                                                        :start_year  start-year}))
+  (->> (exec-db :db yesql-get-kk-application-payment-states-for-person-oids {:person_oids person-oids
+                                                                             :start_term  start-term
+                                                                             :start_year  start-year})
+       (map ->kebab-case-kw)))
 
 (defn create-kk-application-payment-event!
   [payment-state-id, new-state, event-type, virkailija-oid, message]
@@ -36,5 +41,6 @@
 
 (defn get-kk-application-payment-events
   [payment-state-ids]
-  (exec-db :db yesql-get-kk-application-payment-events
-           {:kk_application_payment_state_ids payment-state-ids}))
+  (->> (exec-db :db yesql-get-kk-application-payment-events
+                {:kk_application_payment_state_ids payment-state-ids})
+       (map ->kebab-case-kw)))

--- a/src/clj/ataru/person_service/person_service.clj
+++ b/src/clj/ataru/person_service/person_service.clj
@@ -146,7 +146,9 @@
                       :sukunimi    "Vatanen"
                       :hetu         "141196-933S"})
       "1.2.3.4.5.303" (merge fake-onr-person
-                             {:kansalaisuus [{:kansalaisuusKoodi "784"}]})
+                             {:kansalaisuus [{:kansalaisuusKoodi "784"}]
+                              :yksiloity true
+                              :yksiloityVTJ true})
       (merge fake-onr-person
              {:oidHenkilo oid})))
 

--- a/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
@@ -106,6 +106,10 @@
    :1.2.246.562.29.93102260101               (merge
                                                base-haku
                                                {:oid "1.2.246.562.29.93102260101"
+                                                :hakukausiVuosi 2025,
+                                                :koulutuksenAlkamisVuosi 2025,
+                                                :kohdejoukkoUri "haunkohdejoukko_12#1"
+                                                :kohdejoukonTarkenne "haunkohdejoukontarkenne_1#1"
                                                 :ataruLomakeAvain "synthetic-application-test-form"})
    :haku.oid                                 (merge
                                                base-haku

--- a/src/clj/ataru/tilastokeskus/tilastokeskus_service.clj
+++ b/src/clj/ataru/tilastokeskus/tilastokeskus_service.clj
@@ -1,5 +1,6 @@
 (ns ataru.tilastokeskus.tilastokeskus-service
-  (:require [clj-time.core :as t]
+  (:require [ataru.kk-application-payment.kk-application-payment :as kk-application-payment]
+            [clj-time.core :as t]
             [ataru.applications.application-store :as application-store]
             [ataru.applications.answer-util :as answer-util]
             [ataru.applications.suoritus-filter :as suoritus-filter]
@@ -81,7 +82,10 @@
 
 (defn get-application-info-for-tilastokeskus
   [person-service tarjonta-service valintalaskentakoostepalvelu-service suoritus-service haku-oid hakukohde-oid]
-  (let [applications (application-store/get-application-info-for-tilastokeskus haku-oid hakukohde-oid)
+  (let [applications (kk-application-payment/filter-out-unpaid-kk-applications
+                       tarjonta-service
+                       (application-store/get-application-info-for-tilastokeskus haku-oid hakukohde-oid)
+                       :henkilo_oid :haku_oid)
         haut         (->> (keep :haku_oid applications)
                           distinct
                           (map (fn [oid] [oid (tarjonta-protocol/get-haku tarjonta-service oid)]))

--- a/src/clj/ataru/valintapiste/valintapiste_service.clj
+++ b/src/clj/ataru/valintapiste/valintapiste_service.clj
@@ -1,6 +1,10 @@
 (ns ataru.valintapiste.valintapiste-service
-  (:require [ataru.applications.application-store :as application-store]))
+  (:require [ataru.applications.application-store :as application-store]
+            [ataru.kk-application-payment.kk-application-payment :as kk-application-payment]))
 
 (defn get-application-info-for-valintapiste
-  [haku-oid hakukohde-oid]
-  (application-store/get-application-info-for-valintapiste haku-oid hakukohde-oid))
+  [tarjonta-service haku-oid hakukohde-oid]
+  (kk-application-payment/filter-out-unpaid-kk-applications
+    tarjonta-service
+    (application-store/get-application-info-for-valintapiste haku-oid hakukohde-oid)
+    :henkilo_oid :haku_oid))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -562,7 +562,8 @@
                  :form                         ataru-schema/FormWithContent
                  (s/optional-key :latest-form) form-schema/Form
                  :information-requests         [ataru-schema/InformationRequest]
-                 (s/optional-key :master-oid)  (s/maybe s/Str)}
+                 (s/optional-key :master-oid)  (s/maybe s/Str)
+                 (s/optional-key :kk-payment) (s/maybe ataru-schema/KkPaymentState)}
         (if-let [application (application-service/get-application-with-human-readable-koodis
                               application-service
                               application-key

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -1524,7 +1524,8 @@
               (response/unauthorized {:error "Unauthorized"})
               :else
               (response/ok
-                (application-store/valinta-tulos-service-applications
+                (application-service/valinta-tulos-service-applications
+                  application-service
                   hakuOid
                   hakukohdeOid
                   hakemusOids
@@ -1554,18 +1555,11 @@
                                          name))
                                  true
                                  seq)]
-          (if-let [applications (access-controlled-application/valinta-ui-applications
-                                  organization-service
-                                  tarjonta-service
-                                  person-service
+          (if-let [applications (application-service/valinta-ui-applications
+                                  application-service
                                   session
                                   (reduce application-service/->and-query queries))]
-            (response/ok
-              (->> applications
-                   (map #(dissoc % :hakukohde))
-                   (map #(clojure.set/rename-keys % {:haku-oid      :hakuOid
-                                                     :person-oid    :personOid
-                                                     :asiointikieli :asiointiKieli}))))
+            (response/ok applications)
             (response/unauthorized {:error "Unauthorized"}))
           (response/bad-request {:error "No query parameters given"})))
 
@@ -1624,6 +1618,7 @@
                                 application-key)]
           (response/ok applications)
           (response/unauthorized {:error "Unauthorized"})))
+
       (api/GET "/tilastokeskus" {session :session}
         :summary "Get application info for tilastokeskus"
         :query-params [hakuOid :- s/Str
@@ -1677,6 +1672,7 @@
         :return [ataru-schema/ValintapisteApplication]
         (if-let [applications (access-controlled-application/get-applications-for-valintapiste organization-service
                                                                                                session
+                                                                                               tarjonta-service
                                                                                                hakuOid
                                                                                                hakukohdeOid)]
           (response/ok applications)

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -494,6 +494,26 @@
    (s/optional-key :ssn)         s/Str
    (s/optional-key :minor)       s/Bool})
 
+(s/defschema PaymentStatus
+  {:person-oid   s/Str
+   :start-term   s/Str
+   :start-year   s/Int
+   :state        s/Str
+   :created-time #?(:clj  (s/maybe DateTime)
+                    :cljs (s/maybe s/Str)) })
+
+(s/defschema PaymentEvent
+  {:new-state      (s/maybe s/Str)
+   :event-type     s/Str
+   :virkailija-oid (s/maybe s/Str)
+   :message        (s/maybe s/Str)
+   :created-time   #?(:clj  (s/maybe DateTime)
+                      :cljs (s/maybe s/Str)) })
+
+(s/defschema KkPaymentState
+  {(s/optional-key :status) PaymentStatus
+   (s/optional-key :events) [PaymentEvent]})
+
 (s/defschema ApplicationWithPerson
   (-> Application
       (st/dissoc :person-oid)
@@ -501,14 +521,15 @@
       (st/assoc :rights-by-hakukohde {s/Str [user-rights/Right]})
       (st/assoc :person Person)))
 
-(s/defschema ApplicationWithPersonAndForm
+(s/defschema ApplicationWithPersonFormAndPayment
   {:application (-> Application
                     (st/assoc (s/optional-key :application-identifier) s/Str)
                     (st/dissoc :person-oid)
                     (st/assoc :cannot-edit-because-in-processing s/Bool))
    :person      Person
    :form        (s/conditional #(contains? % :tarjonta) FormWithContentAndTarjontaMetadata
-                               :else FormWithContent)})
+                               :else FormWithContent)
+   :kk-payment  KkPaymentState})
 
 (s/defschema OmatsivutApplication
   {:oid s/Str
@@ -1005,23 +1026,3 @@
   {:paymentType                    (s/maybe s/Str)
    (s/optional-key :processingFee) s/Str
    (s/optional-key :decisionFee)   s/Str})
-
-(s/defschema PaymentStatus
-  {:person-oid   s/Str
-   :start-term   s/Str
-   :start-year   s/Int
-   :state        s/Str
-   :created-time #?(:clj  (s/maybe DateTime)
-                    :cljs (s/maybe s/Str)) })
-
-(s/defschema PaymentEvent
-  {:new-state      (s/maybe s/Str)
-   :event-type     s/Str
-   :virkailija-oid (s/maybe s/Str)
-   :message        (s/maybe s/Str)
-   :created-time   #?(:clj  (s/maybe DateTime)
-                      :cljs (s/maybe s/Str)) })
-
-(s/defschema KkPaymentState
-  {(s/optional-key :status) PaymentStatus
-   (s/optional-key :events) [PaymentEvent]})

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -18,7 +18,9 @@
             [schema.coerce :as c]
             [schema.core :as s]
             [schema-tools.core :as st]
-            [ataru.application.harkinnanvaraisuus.harkinnanvaraisuus-types :refer [harkinnanvaraisuus-types]]))
+            [ataru.application.harkinnanvaraisuus.harkinnanvaraisuus-types :refer [harkinnanvaraisuus-types]])
+  #?(:clj (:import [org.joda.time DateTime])))
+
 
 ;        __.,,------.._
 ;     ,'"   _      _   "`.
@@ -1003,3 +1005,23 @@
   {:paymentType                    (s/maybe s/Str)
    (s/optional-key :processingFee) s/Str
    (s/optional-key :decisionFee)   s/Str})
+
+(s/defschema PaymentStatus
+  {:person-oid   s/Str
+   :start-term   s/Str
+   :start-year   s/Int
+   :state        s/Str
+   :created-time #?(:clj  (s/maybe DateTime)
+                    :cljs (s/maybe s/Str)) })
+
+(s/defschema PaymentEvent
+  {:new-state      (s/maybe s/Str)
+   :event-type     s/Str
+   :virkailija-oid (s/maybe s/Str)
+   :message        (s/maybe s/Str)
+   :created-time   #?(:clj  (s/maybe DateTime)
+                      :cljs (s/maybe s/Str)) })
+
+(s/defschema KkPaymentState
+  {(s/optional-key :status) PaymentStatus
+   (s/optional-key :events) [PaymentEvent]})

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -954,7 +954,8 @@
                                            :attachment-states-to-include        [s/Str]
                                            :processing-states-to-include        [s/Str]
                                            (s/optional-key :school-filter)      (s/maybe s/Str)
-                                           (s/optional-key :classes-of-school)  (s/maybe [s/Str])}})
+                                           (s/optional-key :classes-of-school)  (s/maybe [s/Str])
+                                           (s/optional-key :kk-payment-states-to-include) (s/maybe [s/Str])}})
 
 (s/defschema ApplicationQueryResponse
   {:sort         Sort

--- a/src/cljc/ataru/schema/form_schema.cljc
+++ b/src/cljc/ataru/schema/form_schema.cljc
@@ -457,7 +457,8 @@
                                                       :state          (apply s/enum review-states/attachment-review-type-names)
                                                       :hakukohde      s/Str}]
    :eligibility-set-automatically                   [s/Str]
-   (s/optional-key :tunnistautuminen)                 (s/maybe s/Str)})
+   (s/optional-key :tunnistautuminen)               (s/maybe s/Str)
+   (s/optional-key :kk-payment-state)               (s/maybe s/Str)})
 
 (s/defschema Application
   {(s/optional-key :key)                s/Str


### PR DESCRIPTION
- Add payment status and history to application data whenever required (when returning a submitted application to virkailija or hakija, when listing applications on the virkailija side)
- Minor: convert payment states and events back to kebab-case when querying from db (missing from previous PRs).
- Also includes filtering from https://github.com/Opetushallitus/ataru/pull/1604