### PR TITLE
Vaihdetaan docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,8 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI --encoding=UTF8" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
+          docker build -f -f test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph localhost/test-postgres
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 
@@ -103,7 +104,8 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI --encoding=UTF8" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
+          docker build -f test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph localhost/test-postgres
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF-8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF-8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI --encoding=UTF8" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 
@@ -103,7 +103,7 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF-8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF-8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI --encoding=UTF8" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker build -f -f test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres
+          docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres
           docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph localhost/test-postgres
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
@@ -104,7 +104,7 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker build -f test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres
+          docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres
           docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph localhost/test-postgres
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres
+          docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres .
           docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph localhost/test-postgres
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
@@ -104,7 +104,7 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres
+          docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres .
           docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph localhost/test-postgres
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF-8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI --encoding=UTF8" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI --encoding=UTF8" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 
@@ -103,7 +103,7 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF-8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI --encoding=UTF8" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI --encoding=UTF8" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,7 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres .
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph localhost/test-postgres
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph $(docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -q .)
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 
@@ -104,8 +103,7 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -t test-postgres .
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph localhost/test-postgres
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph $(docker build -f ./test-postgres/Dockerfile --build-arg POSTGRESQL_VERSION=15 -q .)
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,8 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph $REGISTRY/utility/postgres:11
-          docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/utility/redis:5.0
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph $REGISTRY/ecr-public/docker/library/postgres:15
+          docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 
       - name: Run integration tests (Cypress & Playwright)
@@ -103,8 +103,8 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph $REGISTRY/utility/postgres:11
-          docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/utility/redis:5.0
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph $REGISTRY/ecr-public/docker/library/postgres:15
+          docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 
       - name: Run Spec and Mocha tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph $REGISTRY/ecr-public/docker/library/postgres:15
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.utf8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 
@@ -103,7 +103,7 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph $REGISTRY/ecr-public/docker/library/postgres:15
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.utf8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.utf8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF-8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 
@@ -103,7 +103,7 @@ jobs:
           sudo apt-get install -y lftp
           git clone https://github.com/Opetushallitus/ci-tools.git
           source ci-tools/common/setup-tools.sh
-          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.utf8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
+          docker run -d --name ataru-test-db -p 5433:5432 -e POSTGRES_DB=ataru-test -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e LANG=fi_FI.UTF-8 -e POSTGRES_INITDB_ARGS="--locale-provider=icu --icu-locale=fi_FI" $REGISTRY/ecr-public/docker/library/postgres:15-alpine
           docker run -d --name ataru-test-redis -p 6380:6379 $REGISTRY/ecr-public/docker/library/redis:7
           docker run -d --name ataru-test-ftpd -p 2221:21 -p 30000-30009:30000-30009 $REGISTRY/utility/hiekkalaatikko:ataru-test-ftpd
 


### PR DESCRIPTION
Docker-image-kakuttaja on tullut tiensä päähän ja nyt tämä actions-putki voi luoda itse tarvitsemansa dockerimagen, jolloin ulkoiset riippuvuudet vähenevät.

- Postgres rakennetaan pitkästä tavarasta - en saanut toimimaan ilman localen muokkausta edes initdb:n avulla (ICU, alpine). Flyway odottaa collationin olevan fi_FI, mutta pelkän kannan collation ei riitä, kun myös käyttöjärjestelmä pitää olla "linjassa"
- Redis vaihdettu uudempaan versioon 7 ja haetaan omasta repostaan, joka on pull-through cachetettu ecr public reposta
- hiekkalaatikko pidetty entisellään