### PR TITLE
OK-720 kk payment timezone fixes

### DIFF
--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -579,7 +579,7 @@
               :person-oid "1.2.3.4.5.303"})
       (update :answers
               (comp vec concat)
-              [{:key "vapautus_hakemusmaksusta" :value "0" :fieldType "dropdown"}])))
+              [{:key "kk-application-payment-option" :value "0" :fieldType "dropdown"}])))
 
 (def application-without-hakemusmaksu-exemption
   (-> person-info-form-application

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -164,7 +164,7 @@
                               primary-payment (first (payment/get-raw-payments [primary-application-key]))
                               linked-payment (first (payment/get-raw-payments [linked-application-key]))]
                           (should= 1 (count changed))
-                          (should= primary-payment (first changed))
+                          (should= (assoc primary-payment :email "aku@ankkalinna.com") (first changed))
                           (should-be-matching-state {:application-key primary-application-key, :state state-ok-by-proxy
                                                      :reason nil}
                                                     primary-payment)
@@ -186,7 +186,7 @@
                                                                                         oid term-fall year-ok))
                               payment (first (payment/get-raw-payments [application-key]))]
                           (should= 1 (count changed))
-                          (should= (first changed) payment)
+                          (should= (assoc payment :email "aku@ankkalinna.com") (first changed))
                           (should-be-matching-state {:application-key application-key, :state state-ok-by-proxy
                                                      :reason nil} initial-payment)
                           (should-be-matching-state {:application-key application-key, :state state-awaiting
@@ -205,7 +205,7 @@
                                                                                         oid term-fall year-ok))
                               payment (first (payment/get-raw-payments [application-key]))]
                           (should= 1 (count changed))
-                          (should= (first changed) payment)
+                          (should= (assoc payment :email "aku@ankkalinna.com") (first changed))
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-eu-citizen} payment)))
 
@@ -223,7 +223,7 @@
                                                                                           oid term-fall year-ok))
                                 payment (first (payment/get-raw-payments [application-key]))]
                             (should= 1 (count changed))
-                            (should= (first changed) payment)
+                            (should= (assoc payment :email "aku@ankkalinna.com") (first changed))
                             (should-be-matching-state {:application-key application-key, :state state-awaiting
                                                        :reason nil} payment))))
 
@@ -248,7 +248,7 @@
                                 primary-payment (first (payment/get-raw-payments [primary-application-key]))
                                 linked-payment (first (payment/get-raw-payments [linked-application-key]))]
                             (should= 1 (count changed))
-                            (should= primary-payment (first changed))
+                            (should= (assoc primary-payment :email "aku@ankkalinna.com") (first changed))
                             (should-be-matching-state {:application-key primary-application-key, :state state-awaiting
                                                        :reason nil} primary-payment)
                             (should-be-matching-state {:application-key linked-application-key, :state state-overdue
@@ -270,7 +270,7 @@
                                                                                         oid term-fall year-ok))
                               payment (first (payment/get-raw-payments [application-key]))]
                           (should= 1 (count changed))
-                          (should= (first changed) payment)
+                          (should= (assoc payment :email "aku@ankkalinna.com") (first changed))
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-exemption} payment)))))
 

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -313,6 +313,16 @@
                         (save-and-check-single-state
                           "1.2.3.4.5.10" payment/set-application-fee-overdue state-overdue nil)))
 
+          (describe "due date"
+                    (it "should store and retrieve due date correctly"
+                        (let [data            (payment/set-application-fee-required "1.2.3.4.5.12" nil)
+                              due-date-stored (payment/parse-due-date (:due-date data))
+                              due-date-midday (time/plus (time/today-at 12 0 0)
+                                                         (time/days payment/kk-application-payment-due-days))]
+                          (should= (time/year due-date-stored) (time/year due-date-midday))
+                          (should= (time/month due-date-stored) (time/month due-date-midday))
+                          (should= (time/day due-date-stored) (time/day due-date-midday)))))
+
           (describe "preserving and overwriting previous state data"
                     (it "should reset approved state data when fee is required"
                         (let [initial-data (payment/set-application-fee-not-required-for-exemption "1.2.3.4.5.11" nil)

--- a/src/clj/ataru/forms/form_payment_info.clj
+++ b/src/clj/ataru/forms/form_payment_info.clj
@@ -13,9 +13,6 @@
 (def kk-processing-fee
   (bigdec (get-in config [:kk-application-payments :processing-fee])))
 
-(def tutu-processing-fee
-  (bigdec (get-in config [:tutkintojen-tunnustaminen :maksut :decision-amount])))
-
 (defn- valid-fees?
   [payment-type processing-fee decision-fee]
   (let [fee-nonpositive? (fn [amount] (and (some? amount) (<= amount 0.00M)))

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_maksut_poller_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_maksut_poller_job.clj
@@ -14,6 +14,7 @@
   (let [keys-states (into {}
                           (map (fn [state] [(payment/payment->maksut-reference state) state])
                                payments))
+        ; TODO: the amount of open payments may be quite large at a given moment, should we partition the API queries here?
         maksut    (maksut-protocol/list-lasku-statuses maksut-service (keys keys-states))]
     (log/debug "Received statuses for" (count maksut) "kk payment invoices")
     (let [terminal (filter #(some #{(:status %)} '(:paid :overdue)) maksut)

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -10,15 +10,15 @@
             [ataru.config.core :refer [config]]))
 
 (defn- create-payment-and-send-email
-  [maksut-service payment person]
+  [maksut-service enriched-payment-data person]
   (let [lang (:language person)
-        invoice-data (payment/generate-invoicing-data payment person)
+        invoice-data (payment/generate-invoicing-data enriched-payment-data person)
         invoice (maksut-protocol/create-kk-application-payment-lasku maksut-service invoice-data)
         url (url-helper/resolve-url :maksut-service.hakija-get-by-secret (:secret invoice) lang)]
     (when invoice
       (log/info "Kk application payment invoice details" invoice)
       (log/info "Store kk application payment maksut secret for reference " (:reference invoice))
-      (payment/set-maksut-secret (:application-key payment) (:secret invoice))
+      (payment/set-maksut-secret (:application-key enriched-payment-data) (:secret invoice))
       (log/info "Generate kk application payment maksut-link for email" url))))
 
 (defn update-kk-payment-status-for-person-handler

--- a/src/clj/ataru/kk_application_payment/utils.clj
+++ b/src/clj/ataru/kk_application_payment/utils.clj
@@ -28,7 +28,8 @@
 
 (def first-application-payment-hakuaika-start
   "Application payments are only charged from admissions starting in 2025 or later"
-  (time/date-time 2025 1 1))
+  (time/from-time-zone (time/date-time 2025 1 1)
+                       (time/time-zone-for-id "Europe/Helsinki")))
 
 (defn haku-active-for-updating
   "Check whether valid haku is recent enough that payments related to its applications may still need updating.


### PR DESCRIPTION
PR with several smaller fixes / improvements:

- Handle time zones better in payment due date (will be mainly used for display and reminder logic here) and first possible eligible admission start time 
- Enrich modified payment data info with applicant e-mail for sending notifications and creating payments
- Use correct exemption field name and exemption values (for testing for now - may still change before module goes to production?)