### PR TITLE
OK-738 Add initial update run after application has a person assigned

### DIFF
--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -174,17 +174,6 @@
                                                                                        oid term-fall year-ok)]
                           (should= 0 (count states))))
 
-                    (it "should throw an error when EU country codes could not be read"
-                        (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
-                                                      (merge
-                                                        application-fixtures/application-without-hakemusmaksu-exemption
-                                                        {:person-oid "1.1.1"}) nil)
-                        (with-redefs [koodisto/get-koodisto-options (constantly [])]
-                          (should-throw
-                            (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                              fake-koodisto-cache fake-haku-cache
-                                                                              "1.1.1" term-fall year-ok))))
-
                     (it "should return existing paid (terminal) state"
                         (let [oid "1.2.3.4.5.6"
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -218,6 +218,9 @@
                                        nil)
                       check-mail-fn (fn [mail-content]
                                       (and
+                                        (= (count (:recipients mail-content)) 1)
+                                        (= "aku@ankkalinna.com" (first (:recipients mail-content)))
+                                        (not-empty (:subject mail-content))
                                         (str/includes? (:body mail-content) "Voit maksaa hakemusmaksun osoitteessa (fi)")
                                         (str/includes? (:body mail-content) test-maksut-secret)))
                       _ (updater-job/update-kk-payment-status-for-person-handler

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -115,6 +115,20 @@
                                      {:times 1
                                       :with [#(= (:oid %) "payment-info-test-kk-haku") :*]})))
 
+          (it "should update payment status fetching person and term with application id"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     application-fixtures/application-without-hakemusmaksu-exemption
+                                     nil)
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:application_id application-id} runner)
+                    application-key (:key (application-store/get-application application-id))
+                    payment (first (payment/get-raw-payments [application-key]))]
+                (should=
+                  {:application-key application-key :state (:awaiting payment/all-states)
+                   :maksut-secret test-maksut-secret}
+                  (select-keys payment [:application-key :state :maksut-secret]))))
+
           (it "should update payment status for oid"
               (let [application-id (unit-test-db/init-db-fixture
                                      form-fixtures/payment-exemption-test-form

--- a/spec/ataru/person_service/person_integration_spec.clj
+++ b/spec/ataru/person_service/person_integration_spec.clj
@@ -27,11 +27,12 @@
           (with-stubs)
 
           (around [spec]
-                  (with-redefs [person-integration/muu-person-info-module? (stub :muu-person-info
-                                                                                 {:return false})
-                                application-store/add-application-event    (stub :add-application-event)
-                                application-store/add-person-oid           (stub :add-person-oid)
-                                person-integration/start-jobs-for-person   (stub :start-jobs-for-person)]
+                  (with-redefs [person-integration/muu-person-info-module?    (stub :muu-person-info
+                                                                                    {:return false})
+                                application-store/add-application-event       (stub :add-application-event)
+                                application-store/add-person-oid              (stub :add-person-oid)
+                                person-integration/start-jobs-for-person      (stub :start-jobs-for-person)
+                                person-integration/start-jobs-for-application (stub :start-jobs-for-application)]
                     (spec)))
 
           (it "upserts a person and updates application but does not add an event for a normal created person"
@@ -40,6 +41,7 @@
                 (should= "1.2.3.4.5.6"
                          (person-integration/upsert-person {:application-id (:normal test-application-ids)} {:person-service fake-person-service}))
                 (should-have-invoked :start-jobs-for-person {:with [{:person-service fake-person-service} (:normal test-person-oids)]})
+                (should-have-invoked :start-jobs-for-application {:with [{:person-service fake-person-service} (:normal test-application-ids)]})
                 (should-have-invoked :add-person-oid {:with [(:normal test-application-ids) (:normal test-person-oids)]})
                 (should-not-have-invoked :add-application-event)))
 
@@ -49,6 +51,7 @@
                 (should= "2.3.4.5.6.7"
                          (person-integration/upsert-person {:application-id (:matched-person test-application-ids)} {:person-service fake-person-service}))
                 (should-have-invoked :start-jobs-for-person {:with [{:person-service fake-person-service} (:matched-person test-person-oids)]})
+                (should-have-invoked :start-jobs-for-application {:with [{:person-service fake-person-service} (:matched-person test-application-ids)]})
                 (should-have-invoked :add-person-oid {:with [(:matched-person test-application-ids) (:matched-person test-person-oids)]})
                 (should-have-invoked :add-application-event {:with [{:application-key application-key :event-type "person-found-matching"} nil]})))
 
@@ -58,5 +61,6 @@
                 (should= "3.4.5.6.7.8"
                          (person-integration/upsert-person {:application-id (:conflicting-person test-application-ids)} {:person-service fake-person-service}))
                 (should-have-invoked :start-jobs-for-person {:with [{:person-service fake-person-service} (:conflicting-person test-person-oids)]})
+                (should-have-invoked :start-jobs-for-application {:with [{:person-service fake-person-service} (:conflicting-person test-application-ids)]})
                 (should-have-invoked :add-person-oid {:with [(:conflicting-person test-application-ids) (:conflicting-person test-person-oids)]})
                 (should-have-invoked :add-application-event {:with [{:application-key application-key :event-type "person-dob-or-gender-conflict"} nil]}))))

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -6,7 +6,6 @@
   (:require [ataru.cache.cache-service :as cache]
             [ataru.kk-application-payment.kk-application-payment-store :as store]
             [ataru.applications.application-store :as application-store]
-            [ataru.koodisto.koodisto :as koodisto]
             [ataru.person-service.person-service :as person-service]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
             [ataru.util :as util]
@@ -218,14 +217,18 @@
                            (:hakukohteet haku))]
     (utils/requires-higher-education-application-fee? tarjonta-service haku hakukohde-oids)))
 
-(defn- is-eu-citizen? [koodisto-cache person]
-  (let [eu-area (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
-                     (filter #(= "EU" (:value %)))
-                     (first))
-        eu-country-codes (set (map :value (:within eu-area)))]
-    (if (> (count eu-country-codes) 0)
-      (some #(contains? eu-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person))
-      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))))
+; TODO: this may still be needed later for yksilöity EU citizen handling.
+;(defn- is-eu-citizen? [koodisto-cache person]
+;  (let [eu-area (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+;                     (filter #(= "EU" (:value %)))
+;                     (first))
+;        eu-country-codes (set (map :value (:within eu-area)))]
+;    (if (> (count eu-country-codes) 0)
+;      (some #(contains? eu-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person))
+;      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))))
+
+(defn- is-finnish-citizen? [person]
+  (some #(= "246" (:kansalaisuusKoodi %)) (:kansalaisuus person)))
 
 (defn- exemption-in-application?
   [application]
@@ -302,12 +305,12 @@
       (state-change-fn (:key application) payment))))
 
 (defn- update-payments-for-applications
-  [applications-payments is-eu-citizen? has-exemption? has-existing-payment?]
+  [applications-payments is-finnish-citizen? has-exemption? has-existing-payment?]
   (let [map-payments (fn [new-state state-change-fn]
                        (doall
                          (remove nil? (map #(set-payment new-state state-change-fn %) applications-payments))))]
     (cond
-      is-eu-citizen?        (map-payments (:not-required all-states) set-application-fee-not-required-for-eu-citizen)
+      is-finnish-citizen?   (map-payments (:not-required all-states) set-application-fee-not-required-for-eu-citizen)
       has-exemption?        (map-payments (:not-required all-states) set-application-fee-not-required-for-exemption)
       has-existing-payment? (map-payments (:ok-by-proxy all-states) set-application-fee-ok-by-proxy)
       :else                 (map-payments (:awaiting all-states) set-application-fee-required))))
@@ -318,7 +321,7 @@
    - Does not poll payments, they should be updated separately.
    - Does not send notification e-mails.
    Returns a vector of changed states of all applications for possible further processing."
-  [person-service tarjonta-service koodisto-cache get-haut-cache person-oid term year]
+  [person-service tarjonta-service _ get-haut-cache person-oid term year]
   (let [valid-haku-oids (get-valid-haku-oids get-haut-cache tarjonta-service term year)
         linked-oids     (get (person-service/linked-oids person-service [person-oid]) person-oid)
         master-oid      (:master-oid linked-oids)
@@ -337,13 +340,13 @@
                                              :payment     (get payment-by-application (:key application))})
                                           applications)
               payment-state-set      (->> (vals payment-by-application) (map :state) set)
-              is-eu-citizen?         (is-eu-citizen? koodisto-cache person)
+              is-finnish-citizen?    (is-finnish-citizen? person)
               has-exemption?         (some true? (map exemption-in-application? applications))
               has-existing-payment?  (contains? payment-state-set (:paid all-states))]
           {:person            person
            :existing-payments applications-payments
            :modified-payments (update-payments-for-applications
-                                applications-payments is-eu-citizen? has-exemption? has-existing-payment?)})))))
+                                applications-payments is-finnish-citizen? has-exemption? has-existing-payment?)})))))
 
 (defn get-kk-payment-state
   "Returns higher education application fee related info to single application.

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -263,6 +263,20 @@
     (log/info "Found" (count active-hakus) "active hakus for kk payment status updates")
     active-hakus))
 
+(defn get-valid-payment-info-for-application-id
+  "Return person and term data for an application id when application's haku is valid for updates"
+  [tarjonta-service application-id]
+  (let [application        (application-store/get-application application-id)
+        latest-application (application-store/get-latest-application-by-key (:key application))
+        haku-oid           (:haku latest-application)
+        person-oid         (:person-oid latest-application)
+        haku               (when haku-oid (tarjonta/get-haku tarjonta-service haku-oid))
+        valid-haku?        (if haku
+                             (haku-valid-for-kk-payments? tarjonta-service haku)
+                             false)]
+    (when valid-haku?
+      [person-oid (:alkamiskausi haku) (:alkamisvuosi haku)])))
+
 (defn- get-valid-haku-oids
   [get-haut-cache tarjonta-service term year]
   (->> (get-haut-for-start-term-and-year get-haut-cache tarjonta-service term year)

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -25,7 +25,7 @@
 
 (defn- payment-link-email-params
   [lang]
-  {:subject-key :email-kk-payment-reminder-subject
+  {:subject-key :email-kk-payment-link-subject
    :template-path (str "templates/email_kk_payment_link_" (name lang) ".html")})
 
 (defn- start-payment-email-job [job-runner application email-address lang payment-url params-fn type-str]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -35,7 +35,7 @@
     (if mail-content
       (let [job-id (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
                                              (job/start-job job-runner conn job-type mail-content))]
-        (log/info (str "Created kk application payment" type-str "email job " job-id " for application " application-key)))
+        (log/info "Created kk application payment" type-str "email job" job-id "for application" application-key))
       (log/warn "Creating kk application payment" type-str "mail to application" application-key "failed"))))
 
 (defn- create-payment-and-send-email
@@ -77,30 +77,41 @@
       (and (= (:awaiting payment/all-states) (:state payment))
            remind-at-met))))
 
+(defn- resolve-term-data
+  [tarjonta-service person-oid term year application-id]
+  (if (and person-oid term year)
+    [person-oid term year]
+    (payment/get-valid-payment-info-for-application-id tarjonta-service application-id)))
+
 (defn update-kk-payment-status-for-person-handler
-  "Updates payment requirement status for a single (person oid, term, year). Creates payments and
-  sends e-mails when necessary. Marking status as paid/overdue is done separately via
-  kk-application-payment-maksut-poller-job, never here."
-  [{:keys [person_oid term year]}
+  "Updates payment requirement status for a single (person oid, term, year) either directly or
+  via an application id. Creates payments and sends e-mails when necessary. Marking status as paid/overdue
+  is done separately via kk-application-payment-maksut-poller-job, never here."
+  [{:keys [person_oid term year application_id]}
    {:keys [person-service tarjonta-service koodisto-cache get-haut-cache maksut-service] :as job-runner}]
   (when (get-in config [:kk-application-payments :enabled?])
-    (let [{:keys [modified-payments existing-payments]}
-          (payment/update-payments-for-person-term-and-year person-service tarjonta-service
-                                                            koodisto-cache get-haut-cache
-                                                            person_oid term year)]
-      (doseq [payment modified-payments]
-        (let [new-state (:state payment)]
-          (cond
-            (= (:awaiting payment/all-states) new-state)
-            (create-payment-and-send-email job-runner maksut-service payment))))
+    (let [[person-oid application-term application-year]
+          (resolve-term-data tarjonta-service person_oid term year application_id)]
+      (if (and person-oid application-term application-year)
+        (let [{:keys [modified-payments existing-payments]}
+              (payment/update-payments-for-person-term-and-year person-service tarjonta-service
+                                                                koodisto-cache get-haut-cache
+                                                                person-oid application-term application-year)]
+          (log/info "Update kk payment status hander for" person-oid application-term application-year)
+          (doseq [payment modified-payments]
+            (let [new-state (:state payment)]
+              (cond
+                (= (:awaiting payment/all-states) new-state)
+                (create-payment-and-send-email job-runner maksut-service payment))))
 
-      (doseq [application-payment existing-payments]
-        (let [{:keys [application payment]} application-payment]
-          (cond
-            ; TODO: Check existing payments that were not updated:
+          (doseq [application-payment existing-payments]
+            (let [{:keys [application payment]} application-payment]
+              (cond
+                ; TODO: Check existing payments that were not updated:
 
-            (needs-reminder-sent? payment)
-            (send-reminder-email-and-mark-sent job-runner payment application)))))))
+                (needs-reminder-sent? payment)
+                (send-reminder-email-and-mark-sent job-runner payment application)))))
+        (log/debug "Application id" application_id "not in haku with kk application payments")))))
 
 (defn start-update-kk-payment-status-for-person-job
   [job-runner person-oid term year]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -46,7 +46,7 @@
         email-address   (utils/get-application-email application)
         invoice-data    (payment/generate-invoicing-data payment-data application)
         invoice         (maksut-protocol/create-kk-application-payment-lasku maksut-service invoice-data)
-        url             (url-helper/resolve-url :maksut-service.hakija-get-by-secret (:secret invoice) lang)]
+        url             (url-helper/resolve-url :maksut-service.hakija-get-by-secret (:secret invoice) (name lang))]
     (when invoice
       (log/info "Kk application payment invoice details" invoice)
       (log/info "Store kk application payment maksut secret for reference " (:reference invoice))
@@ -60,7 +60,8 @@
   (let [application-key (:application-key payment-data)
         lang            (utils/get-application-language application)
         email-address   (utils/get-application-email application)
-        url             (url-helper/resolve-url :maksut-service.hakija-get-by-secret (:maksut-secret payment-data) lang)]
+        url             (url-helper/resolve-url :maksut-service.hakija-get-by-secret
+                                                (:maksut-secret payment-data) (name lang))]
     (log/info "Generate kk application payment reminder for email" email-address
               "URL" url "application key" application-key)
     (start-payment-email-job job-runner application email-address lang url payment-reminder-email-params "reminder")

--- a/src/clj/ataru/kk_application_payment/utils.clj
+++ b/src/clj/ataru/kk_application_payment/utils.clj
@@ -50,7 +50,7 @@
 
 (defn get-application-email
   [application]
-  (->> (get-in application [:content :answers])
+  (->> (get application :answers)
        (filter #(= (:key %) "email"))
        first
        :value))

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -614,9 +614,15 @@
    :email-myos-pistevalinnassa                  {:fi "Olet hakenut yhteishaussa perusopetuksen jälkeiseen koulutukseen. Hakemuksellasi ilmoittamiesi tietojen perusteella sait ilmoituksen, että hakemuksesi käsitellään harkinnanvaraisessa valinnassa. Oppilaitoksesi mukaan tämä tieto on ollut virheellinen, joten hakemuksesi käsitellään normaalissa pistevalinnassa harkinnanvaraisen valinnan sijaan."
                                                  :sv "Du har sökt i den gemensamma ansökan till utbildning efter den grundläggande utbildningen. På grund av uppgifterna du uppgav på ansökningen fick du ett meddelande att din ansökning behandlas i antagning enligt prövning. Eftersom den här uppgiften enligt din läroanstalt har varit felaktig, behandlas din ansökan i den vanliga poängantagningen och inte i antagning enligt prövning."
                                                  :en "EN: Olet hakenut yhteishaussa perusopetuksen jälkeiseen koulutukseen. Hakemuksellasi ilmoittamiesi tietojen perusteella sait ilmoituksen, että hakemuksesi käsitellään harkinnanvaraisessa valinnassa. Oppilaitoksesi mukaan tämä tieto on ollut virheellinen, joten hakemuksesi käsitellään normaalissa pistevalinnassa harkinnanvaraisen valinnan sijaan."}
-   :email-kk-payment-link-subject               {:fi "Korkeakoulujen hakemusmaksun maksulinkki"
-                                                 :sv "SV: Korkeakoulujen hakemusmaksun maksulinkki"
-                                                 :en "EN: Korkeakoulujen hakemusmaksun maksulinkki"}
+   :email-kk-payment-link-subject               {:fi "Korkeakouluhaun hakemusmaksun maksulinkki"
+                                                 :sv "SV: Korkeakouluhaun hakemusmaksun maksulinkki"
+                                                 :en "EN: Korkeakouluhaun hakemusmaksun maksulinkki"}
+   :email-kk-payment-reminder-subject           {:fi "Muistathan maksaa korkeakouluhaun hakemusmaksun"
+                                                 :sv "SV: Muistathan maksaa korkeakouluhaun hakemusmaksun"
+                                                 :en "EN: Muistathan maksaa korkeakouluhaun hakemusmaksun"}
+   :email-kk-payment-confirmation-subject       {:fi "Vahvistus korkeakouluhaun hakemusmaksun maksamisesta"
+                                                 :sv "SV: Vahvistus korkeakouluhaun hakemusmaksun maksamisesta"
+                                                 :en "EN: Vahvistus korkeakouluhaun hakemusmaksun maksamisesta"}
    :ht-lander-header                            {:fi "Miten haluat siirtyä hakulomakkeelle?"
                                                  :sv "Hur vill du öppna ansökningsblanketten?"
                                                  :en "How do you want to access the application form?"}


### PR DESCRIPTION
The first kk payment state update was previously made only in the first scheduled run (eg. possibly the next morning). Trigger the first update run right after an ONR person with OID gets added to the application. 

Adds the option to trigger the single person update run with an application id: fetches the person oid and haku information via application, and runs the update iff haku requires application payments.

Also includes some other fixes for issues during testing:

- Notification e-mails now get proper recipient and subject
- Only Finnish citizens are exempt from payment without any extra forms
- First payment status update run is triggered right after a person OID gets attached to an application