### PR TITLE
OK-741 Trigger update run on payment paid

### DIFF
--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -129,6 +129,20 @@
                    :maksut-secret test-maksut-secret}
                   (select-keys payment [:application-key :state :maksut-secret]))))
 
+          (it "should update payment status fetching person and term with application key"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     application-fixtures/application-without-hakemusmaksu-exemption
+                                     nil)
+                    application-key (:key (application-store/get-application application-id))
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:application_key application-key} runner)
+                    payment (first (payment/get-raw-payments [application-key]))]
+                (should=
+                  {:application-key application-key :state (:awaiting payment/all-states)
+                   :maksut-secret test-maksut-secret}
+                  (select-keys payment [:application-key :state :maksut-secret]))))
+
           (it "should update payment status for oid"
               (let [application-id (unit-test-db/init-db-fixture
                                      form-fixtures/payment-exemption-test-form

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -266,11 +266,12 @@
     (log/info "Found" (count active-hakus) "active hakus for kk payment status updates")
     active-hakus))
 
-(defn get-valid-payment-info-for-application-id
-  "Return person and term data for an application id when application's haku is valid for updates"
-  [tarjonta-service application-id]
-  (let [application        (application-store/get-application application-id)
-        latest-application (application-store/get-latest-application-by-key (:key application))
+(defn get-valid-payment-info-for-application-id-or-key
+  "Return person and term data for an application id or key when application's haku is valid for updates"
+  [tarjonta-service application-id application-key]
+  (let [application        (when application-id (application-store/get-application application-id))
+        key                (if (some? application) (:key application) application-key)
+        latest-application (application-store/get-latest-application-by-key key)
         haku-oid           (:haku latest-application)
         person-oid         (:person-oid latest-application)
         haku               (when haku-oid (tarjonta/get-haku tarjonta-service haku-oid))


### PR DESCRIPTION
Whenever payment poller marks a person's application paid, trigger the status update run for person and term so that any dependent changes happen immediately (eg. other applications for the same term may be marked exempt from payment).