### PR TITLE
OK-554 Payment indicator to form editor

### DIFF
--- a/resources/less/editor.less
+++ b/resources/less/editor.less
@@ -202,6 +202,17 @@
   font-size: 14px;
 }
 
+.editor-form__requires-kk-application-payment {
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.editor-form__requires-kk-application-payment i {
+  font-size: 20px;
+  color: @warning-yellow;
+}
+
+
 .editor-form__haku-preview-link {
   font-size: 14px;
 }

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -2275,6 +2275,9 @@
    :used-by-haut                                             {:fi "Tämä lomake on seuraavien hakujen käytössä"
                                                               :sv "Denna blankett används i följande ansökningar"
                                                               :en "EN: Tämä lomake on seuraavien hakujen käytössä"}
+   :requires-kk-application-payment                          {:fi "Haussa on käytössä hakemusmaksu"
+                                                              :sv "SV: Haussa on käytössä hakemusmaksu"
+                                                              :en "EN: Haussa on käytössä hakemusmaksu"}
    :kevyt-valinta-valinnan-tila-change                       {:fi "Valinta: %s"
                                                               :sv "Antagning: %s"
                                                               :en "Student selection: %s"}

--- a/src/cljs/ataru/virkailija/editor/view.cljs
+++ b/src/cljs/ataru/virkailija/editor/view.cljs
@@ -230,6 +230,12 @@
 (defn- in-language [term lang]
   (util/non-blank-val term [lang :fi :sv :en]))
 
+(defn- requires-kk-application-payment-label [haku]
+  (let [label @(subscribe [:editor/virkailija-translation :requires-kk-application-payment])]
+    (when (:admission-payment-required? haku)
+      [:div.editor-form__requires-kk-application-payment
+       [:span [:i.zmdi.zmdi-alert-triangle] (str " " label)]])))
+
 (defn- used-in-haku-list-haku-name [haku]
   (let [lang @(subscribe [:editor/virkailija-lang])]
     [:div.editor-form__used-in-haku-list-haku-name
@@ -287,6 +293,7 @@
         ^{:key (str "haku-" (:oid haku))}
         [:li
          [used-in-haku-list-haku-name haku]
+         [requires-kk-application-payment-label haku]
          [haku-preview-link haku]]))]])
 
 (defn- form-not-in-use-in-hakus [form-key]
@@ -486,20 +493,23 @@
       @(subscribe [:editor/virkailija-translation :close-form])]]))
 
 (defn- properties []
-  [:div.editor-form__component-wrapper
-   [:div.editor-form__header-wrapper
-    [:header.editor-form__component-header {:data-test-id "properties-header"}
-     [:span.editor-form__component-main-header @(subscribe [:editor/virkailija-translation :properties])]]]
-   [:div.editor-form__component-content-wrapper
-    [:div.editor-form__module-fields
-     [allow-only-yhteishaku-component]
-     [allow-hakeminen-tunnistautuneena-component]
-     [lomakkeeseen-liittyy-maksutoiminto-component]
-     [close-form-component]]]
-   (when @(subscribe [:editor/show-demo-config])
-    [:div.editor-form__component-content-wrapper
-     [:div.editor-form__module-fields
-      [demo-validity]]])])
+  (let [form-key              @(subscribe [:editor/selected-form-key])
+        form-used-in-hakus    @(subscribe [:editor/form-used-in-hakus form-key])
+        kk-payments-required? (some true? (map :admission-payment-required? form-used-in-hakus))]
+    [:div.editor-form__component-wrapper
+     [:div.editor-form__header-wrapper
+      [:header.editor-form__component-header {:data-test-id "properties-header"}
+       [:span.editor-form__component-main-header @(subscribe [:editor/virkailija-translation :properties])]]]
+     [:div.editor-form__component-content-wrapper
+      [:div.editor-form__module-fields
+       [allow-only-yhteishaku-component]
+       [allow-hakeminen-tunnistautuneena-component]
+       (when-not kk-payments-required? [lomakkeeseen-liittyy-maksutoiminto-component])
+       [close-form-component]]]
+     (when @(subscribe [:editor/show-demo-config])
+       [:div.editor-form__component-content-wrapper
+        [:div.editor-form__module-fields
+         [demo-validity]]])]))
 
 (defn- editor-panel [form-key]
   [:div.editor-form__panel-container


### PR DESCRIPTION
Whenever a form has one or more hakus attached that have kk application payment required,
- Indicate the payment requirement next to the haku information
- Hide the option of manually adding other payment types to the form