### PR TITLE
OK-716 Applicant kk payment info text

### DIFF
--- a/resources/less/hakija.less
+++ b/resources/less/hakija.less
@@ -2232,6 +2232,13 @@ th.application__readonly-adjacent--header {
   text-align: center;
 }
 
+.application__submitted-submit-notification-additional-info {
+  max-width: 600px;
+  margin-top: 1em;
+  align-self: center;
+  text-align: center;
+}
+
 .application__submitted-submit-notification-paragraph {
   text-align: center;
   margin-top: 1em;

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -35,6 +35,9 @@
    :application-can-be-found-here               {:fi "Hakemuksesi löytyy täältä"
                                                  :sv "Din ansökan kan hittas här"
                                                  :en "You can find your application here"}
+   :application-confirmation-kk-payment-info    {:fi "Hakemuksen käsittelyn jälkeen saat tiedon maksuvelvollisuudestasi. Saat maksulinkin sähköpostiisi, mikäli olet maksuvelvollinen."
+                                                 :sv "Hakemuksen käsittelyn jälkeen saat tiedon maksuvelvollisuudestasi. Saat maksulinkin sähköpostiisi, mikäli olet maksuvelvollinen. (SV)"
+                                                 :en "Hakemuksen käsittelyn jälkeen saat tiedon maksuvelvollisuudestasi. Saat maksulinkin sähköpostiisi, mikäli olet maksuvelvollinen. (EN)"}
    :application-confirmation                    {:fi "Saat vahvistuksen sähköpostiisi"
                                                  :sv "Du får en bekräftelse till din e-post"
                                                  :en "Confirmation email will be sent to the email address you've provided"}

--- a/src/cljs/ataru/hakija/application_view.cljs
+++ b/src/cljs/ataru/hakija/application_view.cljs
@@ -251,6 +251,7 @@
   [hidden? demo?]
   (fn []
     (let [lang @(subscribe [:application/form-language])
+          may-need-kk-application-payment @(subscribe [:application/may-need-kk-application-payment])
           answers @(subscribe [:state-query [:application :answers]])]
       [:div.application__submitted-submit-notification
        {:role "alertdialog"
@@ -270,6 +271,11 @@
           {:id "submitted-submit-notification-confirmation"
            :role "text"}
           (translations/get-hakija-translation :application-confirmation lang)])
+       (when may-need-kk-application-payment
+         [:div.application__submitted-submit-notification-additional-info
+          {:id "submitted-submit-notification-additional-info"
+           :role "text"}
+          (translations/get-hakija-translation :application-confirmation-kk-payment-info lang)])
        [:div.application__submitted-submit-notification-inner
         [:button.application__overlay-button.application__overlay-button--enabled
          {:tab-index    "1"

--- a/src/cljs/ataru/hakija/subs.cljs
+++ b/src/cljs/ataru/hakija/subs.cljs
@@ -13,7 +13,8 @@
             [ataru.hakukohde.liitteet :as liitteet]
             [ataru.hakija.demo :as demo]
             [ataru.tarjonta.haku :as haku]
-            [ataru.hakija.application-handlers :as handlers]))
+            [ataru.hakija.application-handlers :as handlers]
+            [ataru.koodisto.koodisto-codes :refer [finland-country-code]]))
 
 (defonce attachment-modify-grace-period-days
   (get (js->clj js/config) "attachment-modify-grace-period-days" 14))
@@ -965,3 +966,23 @@
  :application/hakukohde-siirretty-alert
  (fn [db _]
    (:hakukohde-siirretty-alert db)))
+
+(re-frame/reg-sub
+  :application/nationality-values
+  (fn [db _]
+    (get-in db [:application :answers :nationality :values])))
+
+(re-frame/reg-sub
+  :application/payment-type
+  (fn [db _]
+    (get-in db [:form :properties :payment :type])))
+
+(re-frame/reg-sub
+  :application/may-need-kk-application-payment
+  (fn [_ _]
+    [(re-frame/subscribe [:application/nationality-values])
+     (re-frame/subscribe [:application/payment-type])])
+  (fn [[nationality-values payment-type] _]
+    (and
+      (empty? (filter (fn [[v & _]] (= (:value v) finland-country-code)) nationality-values))
+      (= "payment-type-kk" payment-type))))


### PR DESCRIPTION
Add an additional kk application payment info text to the application submitted confirmation screen - only displayed when the form has kk application payment enabled and the nationality of the applicant is not Finnish.