### PR TITLE
OK-748 payment invalidation

### DIFF
--- a/resources/ataru-oph.properties
+++ b/resources/ataru-oph.properties
@@ -119,6 +119,7 @@ maksut-service.hakija-create = ${url-hakija}/maksut/api/lasku
 maksut-service.virkailija-create = ${maksut-service}/api/lasku
 maksut-service.virkailija-list = ${maksut-service}/api/lasku/$1
 maksut-service.virkailija-receipt = ${maksut-service}/api/kuitti/$1
+maksut-service.virkailija-invalidate = ${maksut-service}/api/lasku-invalidate
 maksut-service.background-lasku-status = ${maksut-service}/api/lasku-check
 
 valpas.baseUrl = ${url-virkailija}/valpas

--- a/src/clj/ataru/maksut/maksut_protocol.clj
+++ b/src/clj/ataru/maksut/maksut_protocol.clj
@@ -11,4 +11,6 @@
 
   (list-laskut-by-application-key [this application-key])
 
-  (download-receipt [this order-id]))
+  (download-receipt [this order-id])
+
+  (invalidate-laskut [this application-keys]))

--- a/src/clj/ataru/maksut/maksut_service.clj
+++ b/src/clj/ataru/maksut/maksut_service.clj
@@ -5,6 +5,7 @@
             [ataru.config.url-helper :as url]
             [cheshire.core :as json]
             [clojure.core.match :as match]
+            [clojure.string :as str]
             [schema.coerce :as c]))
 
 (defn throw-error [msg]
@@ -68,7 +69,7 @@
                  {:status 200 :body body}
                  (parse-and-validate body [maksut-schema/LaskuStatus])
 
-                 :else (throw-error (str "Could not invalidate laskut for keys " (apply str keys)
+                 :else (throw-error (str "Could not invalidate laskut for keys " (str/join ", " keys)
                                          " status: " (:status result)
                                          " response body: " (:body result))))))
 

--- a/src/cljc/ataru/schema/maksut_schema.cljc
+++ b/src/cljc/ataru/schema/maksut_schema.cljc
@@ -6,7 +6,8 @@
   (s/enum
     :active
     :paid
-    :overdue))
+    :overdue
+    :invalidated))
 
 (s/defschema Locale
   (s/enum


### PR DESCRIPTION
Whenever a payment for a term is made, other payment invoices for the person and term should be invalidated to avoid accidental double payments. Here we call maksut with the relevant payment references / application keys, because only ataru holds the up to date information on person oid linkages and all that.