### PR TITLE
Fix due date timezone after db selects

### DIFF
--- a/spec/ataru/kk_application_payment/kk_application_payment_store_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_store_spec.clj
@@ -18,13 +18,13 @@
             (unit-test-db/nuke-kk-payment-data))
 
           (it "should store and retrieve due date in correct time zone"
-              (let [data            (payment/set-application-fee-required "1.2.3.4.5.12" nil)
-                    due-date-stored (:due-date data)
-                    due-date-midday (time/plus (time/today-at 12 0 0)
-                                               (time/days payment/kk-application-payment-due-days))]
-                (should= (time/year due-date-stored) (time/year due-date-midday))
-                (should= (time/month due-date-stored) (time/month due-date-midday))
-                (should= (time/day due-date-stored) (time/day due-date-midday))))
+              (let [data               (payment/set-application-fee-required "1.2.3.4.5.12" nil)
+                    due-date-stored    (:due-date data)
+                    due-date-generated (time/from-time-zone
+                                          (time/plus (time/today-at 23 59 0)
+                                                     (time/days payment/kk-application-payment-due-days))
+                                          (time/time-zone-for-id "Europe/Helsinki"))]
+                (should= due-date-stored due-date-generated)))
 
           (it "should do a roundtrip of store, retrieve and store due date without the date changing."
               (let [old-data        (payment/set-application-fee-required "1.2.3.4.5.12" nil)
@@ -33,8 +33,11 @@
                                       {:application-key "1.2.3.4.5.12"
                                        :state           test-state-paid
                                        :due-date        due-date-old})
-                    due-date-new    (:due-date new-data)]
-                (should= due-date-old due-date-new)))
+                    due-date-new    (:due-date new-data)
+                    new-data-fetch  (first (store/get-kk-application-payments ["1.2.3.4.5.12"]))
+                    due-date-fetch  (:due-date new-data-fetch)]
+                (should= due-date-old due-date-new)
+                (should= due-date-old due-date-fetch)))
 
           (it "should do nothing to due-date if it is not set."
               (let [old-data        (payment/set-application-fee-not-required-for-exemption "1.2.3.4.5.12" nil)

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -53,8 +53,7 @@
 (defn parse-due-date
   "Convert due date retrieved from db to local date, interpreting it in correct time zone"
   [due-date]
-  (let [due-date-local (time/to-time-zone due-date (time/time-zone-for-id "Europe/Helsinki"))]
-    (time/local-date (time/year due-date-local) (time/month due-date-local) (time/day due-date-local))))
+    (time/local-date (time/year due-date) (time/month due-date) (time/day due-date)))
 
 (defn maksut-reference->maksut-order-id
   "Maksut order id is in format KKHA1234 where 1234 is the unique component of application key/oid"

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
@@ -2,7 +2,8 @@
   (:require [ataru.db.db :as db]
             [camel-snake-kebab.core :refer [->kebab-case-keyword]]
             [camel-snake-kebab.extras :refer [transform-keys]]
-            [yesql.core :refer [defqueries]]))
+            [yesql.core :refer [defqueries]]
+            [clj-time.core :as time]))
 
 (defqueries "sql/kk-application-payment-queries.sql")
 
@@ -14,6 +15,11 @@
 (declare yesql-mark-reminder-sent!)
 
 (def ^:private ->kebab-case-kw (partial transform-keys ->kebab-case-keyword))
+(defn due-date-to-finnish-tz [payment]
+  (if-let [due-date (:due-date payment)]
+    (assoc payment :due-date
+                   (time/to-time-zone due-date (time/time-zone-for-id "Europe/Helsinki")))
+    payment))
 
 (defn- exec-db
   [ds-key query params]
@@ -31,17 +37,20 @@
 (defn get-awaiting-kk-application-payments
   []
   (->> (exec-db :db yesql-get-awaiting-kk-application-payments {})
-       (map ->kebab-case-kw)))
+       (map ->kebab-case-kw)
+       (map due-date-to-finnish-tz)))
 
 (defn get-kk-application-payments-history
   [application-keys]
   (->> (exec-db :db yesql-get-kk-application-payments-history-for-application-keys {:application_keys application-keys})
-       (map ->kebab-case-kw)))
+       (map ->kebab-case-kw)
+       (map due-date-to-finnish-tz)))
 
 (defn get-kk-application-payments
   [application-keys]
   (->> (exec-db :db yesql-get-kk-application-payments-for-application-keys {:application_keys application-keys})
-       (map ->kebab-case-kw)))
+       (map ->kebab-case-kw)
+       (map due-date-to-finnish-tz)))
 
 (defn create-or-update-kk-application-payment!
   [{:keys [application-key state reason due-date total-sum maksut-secret
@@ -55,4 +64,5 @@
                                                            :required_at          required-at
                                                            :reminder_sent_at     reminder-sent-at
                                                            :approved_at          approved-at})
-       (->kebab-case-kw)))
+       (->kebab-case-kw)
+       (due-date-to-finnish-tz)))


### PR DESCRIPTION
Yesql enjoys automatically interpreting PostgreSQL dates as a timestamps converted to UTC instead of LocalDate - which means dates are off in Finnish time. Always reinterpret the timestamps in Helsinki time zone.