### PR TITLE
OK-770 attachment deadline logic for kk application payments

### DIFF
--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -14,7 +14,8 @@
             [ataru.fixtures.db.unit-test-db :as unit-test-db]
             [ataru.tarjonta-service.mock-tarjonta-service :as mock-tarjonta-service]
             [ataru.kk-application-payment.utils :as payment-utils]
-            [ataru.applications.application-store :as application-store]))
+            [ataru.applications.application-store :as application-store]
+            [ataru.ohjausparametrit.mock-ohjausparametrit-service :refer [->MockOhjausparametritService]]))
 
 (def fake-person-service (person-service/->FakePersonService))
 (def fake-tarjonta-service (mock-tarjonta-service/->MockTarjontaKoutaService))
@@ -31,6 +32,9 @@
                        (get-many-from [_ _])
                        (remove-from [_ _])
                        (clear-all [_])))
+
+(def fake-ohjausparametrit-service
+  (->MockOhjausparametritService))
 
 (declare conn)
 (defn- delete-states-and-events! []
@@ -178,7 +182,8 @@
                                                       application-fixtures/application-without-hakemusmaksu-exemption
                                                       nil)
                         (let [oid "1.2.3.4.5.1234"                       ; Should have no applications
-                              states (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
+                              states (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                       fake-person-service fake-tarjonta-service
                                                                                        fake-koodisto-cache fake-haku-cache
                                                                                        oid term-fall year-ok)]
                           (should= 0 (count states))))
@@ -192,9 +197,10 @@
                               application-key (:key (application-store/get-application application-id))
                               initial-payment (payment/set-application-fee-paid application-key nil)
                               changed (:modified-payments
-                                       (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                                        fake-koodisto-cache fake-haku-cache
-                                                                                        oid term-fall year-ok))
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
+                                                                                         fake-koodisto-cache fake-haku-cache
+                                                                                         oid term-fall year-ok))
                               payment (first (payment/get-raw-payments [application-key]))]
                           (should= 0 (count changed))
                           (should= initial-payment payment)
@@ -214,7 +220,8 @@
                               linked-application-key (:key (application-store/get-application (second application-ids)))
                               _ (payment/set-application-fee-paid linked-application-key nil)
                               changed (:modified-payments
-                                        (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
+                                        (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                          fake-person-service fake-tarjonta-service
                                                                                           fake-koodisto-cache fake-haku-cache
                                                                                           oid term-fall year-ok))
                               primary-payment (first (payment/get-raw-payments [primary-application-key]))
@@ -237,9 +244,10 @@
                               application-key (:key (application-store/get-application application-id))
                               initial-payment (payment/set-application-fee-ok-by-proxy application-key nil)
                               changed (:modified-payments
-                                       (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                                        fake-koodisto-cache fake-haku-cache
-                                                                                        oid term-fall year-ok))
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
+                                                                                         fake-koodisto-cache fake-haku-cache
+                                                                                         oid term-fall year-ok))
                               payment (first (payment/get-raw-payments [application-key]))]
                           (should= 1 (count changed))
                           (should= payment (first changed))
@@ -256,9 +264,10 @@
                                                                              {:person-oid oid}) nil)
                               application-key (:key (application-store/get-application application-id))
                               changed (:modified-payments
-                                       (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                                        fake-koodisto-cache fake-haku-cache
-                                                                                        oid term-fall year-ok))
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
+                                                                                         fake-koodisto-cache fake-haku-cache
+                                                                                         oid term-fall year-ok))
                               payment (first (payment/get-raw-payments [application-key]))]
                           (should= 1 (count changed))
                           (should= payment (first changed))
@@ -274,9 +283,10 @@
                                                                                {:person-oid oid}) nil)
                                 application-key (:key (application-store/get-application application-id))
                                 changed (:modified-payments
-                                         (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                                          fake-koodisto-cache fake-haku-cache
-                                                                                          oid term-fall year-ok))
+                                         (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                           fake-person-service fake-tarjonta-service
+                                                                                           fake-koodisto-cache fake-haku-cache
+                                                                                           oid term-fall year-ok))
                                 payment (first (payment/get-raw-payments [application-key]))]
                             (should= 1 (count changed))
                             (should= payment (first changed))
@@ -298,9 +308,10 @@
                                 linked-application-key (:key (application-store/get-application (second application-ids)))
                                 _ (payment/set-application-fee-overdue linked-application-key nil)
                                 changed (:modified-payments
-                                         (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                                          fake-koodisto-cache fake-haku-cache
-                                                                                          oid term-fall year-ok))
+                                         (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                           fake-person-service fake-tarjonta-service
+                                                                                           fake-koodisto-cache fake-haku-cache
+                                                                                           oid term-fall year-ok))
                                 primary-payment (first (payment/get-raw-payments [primary-application-key]))
                                 linked-payment (first (payment/get-raw-payments [linked-application-key]))]
                             (should= 1 (count changed))
@@ -321,9 +332,10 @@
                                                                              {:person-oid oid}) nil)
                               application-key (:key (application-store/get-application application-id))
                               changed (:modified-payments
-                                       (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                                        fake-koodisto-cache fake-haku-cache
-                                                                                        oid term-fall year-ok))
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
+                                                                                         fake-koodisto-cache fake-haku-cache
+                                                                                         oid term-fall year-ok))
                               payment (first (payment/get-raw-payments [application-key]))]
                           (should= 1 (count changed))
                           (should= payment (first changed))
@@ -346,14 +358,17 @@
                               primary-application-key (:key (application-store/get-application (first application-ids)))
                               linked-application-key (:key (application-store/get-application (second application-ids)))
                               changed (:modified-payments
-                                       (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                                        fake-koodisto-cache fake-haku-cache
-                                                                                        oid term-fall year-ok))
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
+                                                                                         fake-koodisto-cache fake-haku-cache
+                                                                                         oid term-fall year-ok))
+                              primary-changed (first (filter #(= primary-application-key (:application-key %)) changed))
+                              linked-changed (first (filter #(= linked-application-key (:application-key %)) changed))
                               primary-payment (first (payment/get-raw-payments [primary-application-key]))
                               linked-payment (first (payment/get-raw-payments [linked-application-key]))]
                             (should= 2 (count changed))
-                            (should= primary-payment (first changed))
-                            (should= linked-payment (second changed))
+                            (should= primary-payment primary-changed)
+                            (should= linked-payment linked-changed)
                             (should-be-matching-state {:application-key primary-application-key, :state state-not-required
                                                        :reason reason-exemption} primary-payment)
                             (should-be-matching-state {:application-key linked-application-key, :state state-awaiting
@@ -374,9 +389,10 @@
                               linked-application-key (:key (application-store/get-application (second application-ids)))
                               _ (payment/set-application-fee-paid linked-application-key nil)
                               changed (:modified-payments
-                                       (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
-                                                                                        fake-koodisto-cache fake-haku-cache
-                                                                                        oid term-fall year-ok))
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
+                                                                                         fake-koodisto-cache fake-haku-cache
+                                                                                         oid term-fall year-ok))
                               primary-payment (first (payment/get-raw-payments [primary-application-key]))
                               linked-payment (first (payment/get-raw-payments [linked-application-key]))]
                             (should= 1 (count changed))
@@ -395,7 +411,8 @@
                               application-key (:key (application-store/get-application application-id))
                               _ (payment/set-application-fee-overdue application-key nil)
                               changed (:modified-payments
-                                       (payment/update-payments-for-person-term-and-year fake-person-service fake-tarjonta-service
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
                                                                                          fake-koodisto-cache fake-haku-cache
                                                                                          oid term-fall year-ok))
                               payment (first (payment/get-raw-payments [application-key]))]

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -386,7 +386,7 @@
                                                                       {:application_key application-key
                                                                        :attachment_key "brexit-passport-attachment"
                                                                        :hakukohde "payment-info-test-kk-hakukohde"
-                                                                       :state "incomplete-attachment"}])
+                                                                       :state "missing-attachment"}])
                               [changed payment] (update-exempt-payment application-key)]
                           (should= 1 (count changed))
                           (should= payment (first changed))
@@ -425,7 +425,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-exemption} payment)))
 
-                    (it "should set payment status as not required if an unrelated attachment is missing after deadline"
+                    (it "should set payment status as not required if an unrelated attachment is missing or incomplete after deadline"
                         (let [application-key   (create-past-payment-exempt-by-application)
                               _                 (save-reviews-to-db! [{:application_key application-key
                                                                        :attachment_key "none-passport-attachment"
@@ -441,7 +441,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-exemption} payment)))
 
-                    (it "should set payment status as required if an exemption attachment is missing after deadline"
+                    (it "should set payment status as required if an exemption attachment is incomplete after deadline"
                         (let [application-key   (create-past-payment-exempt-by-application)
                               _                 (save-reviews-to-db! [{:application_key application-key
                                                                        :attachment_key "brexit-permit-attachment"
@@ -457,7 +457,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-awaiting
                                                      :reason nil} payment)))
 
-                    (it "should set payment status as required if an exemption attachment is incomplete after deadline"
+                    (it "should set payment status as required if an exemption attachment is missing after deadline"
                         (let [application-key   (create-past-payment-exempt-by-application)
                               _                 (save-reviews-to-db! [{:application_key application-key
                                                                        :attachment_key "brexit-permit-attachment"

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -17,6 +17,14 @@
             [ataru.applications.application-store :as application-store]
             [ataru.ohjausparametrit.mock-ohjausparametrit-service :refer [->MockOhjausparametritService]]))
 
+(defn- store-field-deadline [deadline]
+  (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
+                            (jdbc/insert! conn "field_deadlines" deadline)))
+
+(defn- save-reviews-to-db! [reviews]
+  (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
+                            (application-store/store-reviews reviews {:connection conn})))
+
 (def fake-person-service (person-service/->FakePersonService))
 (def fake-tarjonta-service (mock-tarjonta-service/->MockTarjontaKoutaService))
 
@@ -28,7 +36,10 @@
 
 (def fake-haku-cache (reify cache-service/Cache
                        (get-from [_ _]
-                         [{:haku "payment-info-test-kk-haku"}])
+                         [{:haku "payment-info-test-kk-haku"}
+                          {:haku "payment-info-test-kk-haku-future"}
+                          {:haku "payment-info-test-kk-haku-past"}
+                          {:haku "payment-info-test-kk-haku-custom-grace"}])
                        (get-many-from [_ _])
                        (remove-from [_ _])
                        (clear-all [_])))
@@ -40,7 +51,9 @@
 (defn- delete-states-and-events! []
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
                             (jdbc/delete! conn :kk_application_payments [])
-                            (jdbc/delete! conn :kk_application_payments_history [])))
+                            (jdbc/delete! conn :kk_application_payments_history [])
+                            (jdbc/delete! conn :application_hakukohde_attachment_reviews [])
+                            (jdbc/delete! conn :field_deadlines [])))
 
 (def term-fall "kausi_s")
 (def year-ok 2025)
@@ -160,6 +173,52 @@
 
           (it "should throw an exception when trying to set maksut secret for nonexisting payment"
               (should-throw (payment/set-maksut-secret "1.2.3.4.5.1234" "1234ABCD5678EFGH"))))
+
+(def exempt-test-oid "1.2.3.4.5.303") ; FakePersonService returns non-EU nationality for this one
+
+(defn create-payment-exempt-by-application []
+  (let [application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                     (merge
+                                                       application-fixtures/application-with-hakemusmaksu-exemption
+                                                       {:person-oid exempt-test-oid}) nil)
+        application-key (:key (application-store/get-application application-id))]
+    application-key))
+
+(defn create-future-payment-exempt-by-application []
+  (let [application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                     (merge
+                                                       application-fixtures/application-with-hakemusmaksu-exemption
+                                                       {:person-oid exempt-test-oid
+                                                        :haku "payment-info-test-kk-haku-future"}) nil)
+        application-key (:key (application-store/get-application application-id))]
+    application-key))
+
+(defn create-past-payment-exempt-by-application []
+  (let [application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                     (merge
+                                                       application-fixtures/application-with-hakemusmaksu-exemption
+                                                       {:person-oid exempt-test-oid
+                                                        :haku "payment-info-test-kk-haku-past"}) nil)
+        application-key (:key (application-store/get-application application-id))]
+    application-key))
+
+(defn create-past-payment-exempt-by-application-with-custom-grace-days []
+  (let [application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                     (merge
+                                                       application-fixtures/application-with-hakemusmaksu-exemption
+                                                       {:person-oid exempt-test-oid
+                                                        :haku "payment-info-test-kk-haku-custom-grace"}) nil)
+        application-key (:key (application-store/get-application application-id))]
+    application-key))
+
+(defn update-exempt-payment [application-key]
+  (let [changed         (:modified-payments
+                          (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                            fake-person-service fake-tarjonta-service
+                                                                            fake-koodisto-cache fake-haku-cache
+                                                                            exempt-test-oid term-fall year-ok))
+        payment (first (payment/get-raw-payments [application-key]))]
+    [changed payment]))
 
 (describe "update-payment-status"
           (tags :unit :kk-application-payment)
@@ -322,21 +381,146 @@
                                                        :reason nil} linked-payment)))))
 
           (describe "with exemption"
-                    (before (delete-states-and-events!))
+                    (around [spec]
+                            (delete-states-and-events!)
+                            (with-redefs [payment-utils/first-application-payment-hakuaika-start (time/date-time 2024 1 1)]
+                              (spec)))
 
                     (it "should set payment status for non eu citizen with exemption as not required"
-                        (let [oid "1.2.3.4.5.303"                       ; FakePersonService returns non-EU nationality for this one
-                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
-                                                                           (merge
-                                                                             application-fixtures/application-with-hakemusmaksu-exemption
-                                                                             {:person-oid oid}) nil)
-                              application-key (:key (application-store/get-application application-id))
-                              changed (:modified-payments
-                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
-                                                                                         fake-person-service fake-tarjonta-service
-                                                                                         fake-koodisto-cache fake-haku-cache
-                                                                                         oid term-fall year-ok))
-                              payment (first (payment/get-raw-payments [application-key]))]
+                        (let [application-key   (create-payment-exempt-by-application)
+                              [changed payment] (update-exempt-payment application-key)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-exemption} payment)))
+
+                    (it "should set payment status as not required if an exemption attachment is missing before deadline"
+                        (let [application-key   (create-future-payment-exempt-by-application)
+                              _                 (save-reviews-to-db! [{:application_key application-key
+                                                                       :attachment_key "brexit-permit-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "not-checked"}
+                                                                      {:application_key application-key
+                                                                       :attachment_key "brexit-passport-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "incomplete-attachment"}])
+                              [changed payment] (update-exempt-payment application-key)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-exemption} payment)))
+
+                    (it "should set payment status as not required if an exemption attachment is incomplete before deadline"
+                        (let [application-key   (create-future-payment-exempt-by-application)
+                              _                 (save-reviews-to-db! [{:application_key application-key
+                                                                       :attachment_key "brexit-permit-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "not-checked"}
+                                                                      {:application_key application-key
+                                                                       :attachment_key "brexit-passport-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "incomplete-attachment"}])
+                              [changed payment] (update-exempt-payment application-key)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-exemption} payment)))
+
+                    (it "should set payment status as not required if an exemption attachments are ok after deadline"
+                        (let [application-key   (create-past-payment-exempt-by-application)
+                              _                 (save-reviews-to-db! [{:application_key application-key
+                                                                       :attachment_key "brexit-permit-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "not-checked"}
+                                                                      {:application_key application-key
+                                                                       :attachment_key "brexit-passport-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "not-checked"}])
+                              [changed payment] (update-exempt-payment application-key)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-exemption} payment)))
+
+                    (it "should set payment status as not required if an unrelated attachment is missing after deadline"
+                        (let [application-key   (create-past-payment-exempt-by-application)
+                              _                 (save-reviews-to-db! [{:application_key application-key
+                                                                       :attachment_key "none-passport-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "missing-attachment"}
+                                                                      {:application_key application-key
+                                                                       :attachment_key "foobar-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "incomplete-attachment"}])
+                              [changed payment] (update-exempt-payment application-key)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-exemption} payment)))
+
+                    (it "should set payment status as required if an exemption attachment is missing after deadline"
+                        (let [application-key   (create-past-payment-exempt-by-application)
+                              _                 (save-reviews-to-db! [{:application_key application-key
+                                                                       :attachment_key "brexit-permit-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "not-checked"}
+                                                                      {:application_key application-key
+                                                                       :attachment_key "brexit-passport-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "incomplete-attachment"}])
+                              [changed payment] (update-exempt-payment application-key)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-awaiting
+                                                     :reason nil} payment)))
+
+                    (it "should set payment status as required if an exemption attachment is incomplete after deadline"
+                        (let [application-key   (create-past-payment-exempt-by-application)
+                              _                 (save-reviews-to-db! [{:application_key application-key
+                                                                       :attachment_key "brexit-permit-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "attachment-missing"}
+                                                                      {:application_key application-key
+                                                                       :attachment_key "brexit-passport-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "not-checked"}])
+                              [changed payment] (update-exempt-payment application-key)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-awaiting
+                                                     :reason nil} payment)))
+
+                    (it "should use custom application field deadline date"
+                        (let [application-key   (create-past-payment-exempt-by-application)
+                              _                 (store-field-deadline {:application_key application-key
+                                                                       :field_id "brexit-permit-attachment"
+                                                                       :deadline (time/plus (time/now) (time/days 1))})
+                              _                 (save-reviews-to-db! [{:application_key application-key
+                                                                       :attachment_key "brexit-permit-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "attachment-missing"}
+                                                                      {:application_key application-key
+                                                                       :attachment_key "brexit-passport-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "not-checked"}])
+                              [changed payment] (update-exempt-payment application-key)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-exemption} payment)))
+
+                    (it "should use custom ohjausparametrit deadline days"
+                        ; Mock ohjausparametrit returns grace days 10000 for the attached haku...
+                        (let [application-key   (create-past-payment-exempt-by-application-with-custom-grace-days)
+                              _                 (save-reviews-to-db! [{:application_key application-key
+                                                                       :attachment_key "brexit-permit-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "attachment-missing"}
+                                                                      {:application_key application-key
+                                                                       :attachment_key "brexit-passport-attachment"
+                                                                       :hakukohde "payment-info-test-kk-hakukohde"
+                                                                       :state "not-checked"}])
+                              [changed payment] (update-exempt-payment application-key)]
                           (should= 1 (count changed))
                           (should= payment (first changed))
                           (should-be-matching-state {:application-key application-key, :state state-not-required

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -176,40 +176,23 @@
 
 (def exempt-test-oid "1.2.3.4.5.303") ; FakePersonService returns non-EU nationality for this one
 
-(defn create-payment-exempt-by-application []
+(defn create-payment-exempt-by-application [merge-map]
   (let [application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
                                                      (merge
                                                        application-fixtures/application-with-hakemusmaksu-exemption
-                                                       {:person-oid exempt-test-oid}) nil)
+                                                       {:person-oid exempt-test-oid}
+                                                       merge-map) nil)
         application-key (:key (application-store/get-application application-id))]
     application-key))
 
 (defn create-future-payment-exempt-by-application []
-  (let [application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
-                                                     (merge
-                                                       application-fixtures/application-with-hakemusmaksu-exemption
-                                                       {:person-oid exempt-test-oid
-                                                        :haku "payment-info-test-kk-haku-future"}) nil)
-        application-key (:key (application-store/get-application application-id))]
-    application-key))
+  (create-payment-exempt-by-application {:haku "payment-info-test-kk-haku-future"}))
 
 (defn create-past-payment-exempt-by-application []
-  (let [application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
-                                                     (merge
-                                                       application-fixtures/application-with-hakemusmaksu-exemption
-                                                       {:person-oid exempt-test-oid
-                                                        :haku "payment-info-test-kk-haku-past"}) nil)
-        application-key (:key (application-store/get-application application-id))]
-    application-key))
+  (create-payment-exempt-by-application {:haku "payment-info-test-kk-haku-past"}))
 
 (defn create-past-payment-exempt-by-application-with-custom-grace-days []
-  (let [application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
-                                                     (merge
-                                                       application-fixtures/application-with-hakemusmaksu-exemption
-                                                       {:person-oid exempt-test-oid
-                                                        :haku "payment-info-test-kk-haku-custom-grace"}) nil)
-        application-key (:key (application-store/get-application application-id))]
-    application-key))
+  (create-payment-exempt-by-application {:haku "payment-info-test-kk-haku-custom-grace"}))
 
 (defn update-exempt-payment [application-key]
   (let [changed         (:modified-payments
@@ -387,7 +370,7 @@
                               (spec)))
 
                     (it "should set payment status for non eu citizen with exemption as not required"
-                        (let [application-key   (create-payment-exempt-by-application)
+                        (let [application-key   (create-payment-exempt-by-application {})
                               [changed payment] (update-exempt-payment application-key)]
                           (should= 1 (count changed))
                           (should= payment (first changed))

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -108,6 +108,15 @@
                                     application-key "payment-obligation" hakukohde])
                                  first)))
 
+(defn- store-not-obligated-review [application-key hakukohde]
+  (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
+                            (jdbc/insert! conn "application_hakukohde_reviews"
+                                          {:application_key application-key
+                                           :requirement "payment-obligation"
+                                           :hakukohde hakukohde
+                                           :state "not-obligated"})))
+
+
 (defn- clear! []
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
                             (jdbc/delete! conn :applications [])
@@ -489,4 +498,20 @@
                     payment (first (payment/get-raw-payments [application-key]))
                     obligation (get-payment-obligation-review application-key "payment-info-test-kk-fisv-hakukohde")]
                 (should= (:awaiting payment/all-states) (:state payment))
-                (should-be-nil obligation))))
+                (should-be-nil obligation)))
+
+          (it "should not override a non-automatic obligation"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     application-fixtures/application-without-hakemusmaksu-exemption
+                                     nil)
+                    application-key (:key (application-store/get-application application-id))
+                    _ (store-not-obligated-review application-key "payment-info-test-kk-hakukohde")
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:person_oid test-person-oid :term test-term :year test-year} runner)
+                    payment (first (payment/get-raw-payments [application-key]))
+                    obligation (get-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
+                (should= (:awaiting payment/all-states) (:state payment))
+                (should= {:application_key application-key, :requirement "payment-obligation",
+                          :state "not-obligated", :hakukohde "payment-info-test-kk-hakukohde"}
+                         (select-keys obligation [:application_key :requirement :state :hakukohde])))))

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -100,7 +100,7 @@
 (declare conn)
 (declare spec)
 
-(defn- get-payment-obligation-review [application-key hakukohde]
+(defn- get-tuition-payment-obligation-review [application-key hakukohde]
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
                             (->> (jdbc/query
                                    conn
@@ -108,7 +108,7 @@
                                     application-key "payment-obligation" hakukohde])
                                  first)))
 
-(defn- store-not-obligated-review [application-key hakukohde]
+(defn- store-tuition-fee-not-required-review [application-key hakukohde]
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
                             (jdbc/insert! conn "application_hakukohde_reviews"
                                           {:application_key application-key
@@ -431,6 +431,9 @@
                                                check-mail-fn]}))))
 
           (it "should set tuition fee obligation for non fi/sv hakukohde when payment state changes to awaiting"
+              ; Initial state: hakukohde in the application has only english as teaching language,
+              ; and the application / person has no exemption, meaning the application should require both
+              ; application fee AND tuition fee for the hakukohde.
               (let [application-id (unit-test-db/init-db-fixture
                                      form-fixtures/payment-exemption-test-form
                                      application-fixtures/application-without-hakemusmaksu-exemption
@@ -439,13 +442,17 @@
                         {:person_oid test-person-oid :term test-term :year test-year} runner)
                     application-key (:key (application-store/get-application application-id))
                     payment (first (payment/get-raw-payments [application-key]))
-                    obligation (get-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
+                    obligation (get-tuition-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
                 (should= (:awaiting payment/all-states) (:state payment))
                 (should= {:application_key application-key, :requirement "payment-obligation",
                           :state "obligated", :hakukohde "payment-info-test-kk-hakukohde"}
                          (select-keys obligation [:application_key :requirement :state :hakukohde]))))
 
           (it "should set tuition fee obligation for non fi/sv hakukohde when payment state changes to ok-by-proxy"
+              ; Initial state: hakukohde in both applications has only english as teaching language,
+              ; and the application / person has no exemption, and we mark one of the applications paid manually.
+              ; This means the other application should not require application payment BUT should still require
+              ; tuition fee.
               (let [application-ids (unit-test-db/init-db-fixture
                                       form-fixtures/payment-exemption-test-form
                                       [application-fixtures/application-without-hakemusmaksu-exemption
@@ -466,13 +473,16 @@
                     _ (updater-job/update-kk-payment-status-for-person-handler
                         {:person_oid test-person-oid :term test-term :year test-year} runner)
                     payment (first (payment/get-raw-payments [second-key]))
-                    obligation (get-payment-obligation-review second-key "payment-info-test-kk-hakukohde")]
+                    obligation (get-tuition-payment-obligation-review second-key "payment-info-test-kk-hakukohde")]
                 (should= (:ok-by-proxy payment/all-states) (:state payment))
                 (should= {:application_key second-key, :requirement "payment-obligation",
                           :state "obligated", :hakukohde "payment-info-test-kk-hakukohde"}
                          (select-keys obligation [:application_key :requirement :state :hakukohde]))))
 
           (it "should not set tuition fee obligation for non fi/sv hakukohde when payment state changes to not-required"
+              ; Initial state: hakukohde in the application has only english as teaching language,
+              ; but the application / person has an exemption, meaning the application should require neither
+              ; application fee nor tuition fee for the hakukohde.
               (let [application-id (unit-test-db/init-db-fixture
                                      form-fixtures/payment-exemption-test-form
                                      application-fixtures/application-with-hakemusmaksu-exemption
@@ -481,11 +491,14 @@
                         {:person_oid test-person-oid :term test-term :year test-year} runner)
                     application-key (:key (application-store/get-application application-id))
                     payment (first (payment/get-raw-payments [application-key]))
-                    obligation (get-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
+                    obligation (get-tuition-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
                 (should= (:not-required payment/all-states) (:state payment))
                 (should-be-nil obligation)))
 
           (it "should not set tuition fee obligation for fi/sv hakukohde"
+              ; Initial state: hakukohde in the application has swedish and/or finnish in its teaching languages,
+              ; so even the application / person has no exemption, the application should require only an
+              ; application fee, but no tuition fee for the hakukohde.
               (let [application-id (unit-test-db/init-db-fixture
                                      form-fixtures/payment-exemption-test-form
                                      (merge
@@ -496,21 +509,24 @@
                         {:person_oid test-person-oid :term test-term :year test-year} runner)
                     application-key (:key (application-store/get-application application-id))
                     payment (first (payment/get-raw-payments [application-key]))
-                    obligation (get-payment-obligation-review application-key "payment-info-test-kk-fisv-hakukohde")]
+                    obligation (get-tuition-payment-obligation-review application-key "payment-info-test-kk-fisv-hakukohde")]
                 (should= (:awaiting payment/all-states) (:state payment))
                 (should-be-nil obligation)))
 
           (it "should not override a non-automatic obligation"
+              ; Initial state: hakukohde in the application has only english as teaching language,
+              ; and application / person has no exemption, but there's a human review already for the tuition.
+              ; Application fee should be required, but tuition fee state should not change automatically anymore.
               (let [application-id (unit-test-db/init-db-fixture
                                      form-fixtures/payment-exemption-test-form
                                      application-fixtures/application-without-hakemusmaksu-exemption
                                      nil)
                     application-key (:key (application-store/get-application application-id))
-                    _ (store-not-obligated-review application-key "payment-info-test-kk-hakukohde")
+                    _ (store-tuition-fee-not-required-review application-key "payment-info-test-kk-hakukohde")
                     _ (updater-job/update-kk-payment-status-for-person-handler
                         {:person_oid test-person-oid :term test-term :year test-year} runner)
                     payment (first (payment/get-raw-payments [application-key]))
-                    obligation (get-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
+                    obligation (get-tuition-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
                 (should= (:awaiting payment/all-states) (:state payment))
                 (should= {:application_key application-key, :requirement "payment-obligation",
                           :state "not-obligated", :hakukohde "payment-info-test-kk-hakukohde"}

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -9,8 +9,9 @@
             [clj-time.format :as time-format]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
-            [speclj.core :refer [it describe should-throw should-not-throw stub should-have-invoked
-                                 should-not-have-invoked tags with-stubs should= around before]]
+            [speclj.core :refer [it describe should-throw should-not-throw stub
+                                 should-have-invoked should-not-have-invoked
+                                 should-be-nil tags with-stubs should= around before]]
             [ataru.kk-application-payment.kk-application-payment :as payment]
             [ataru.fixtures.application :as application-fixtures]
             [ataru.fixtures.form :as form-fixtures]
@@ -98,6 +99,14 @@
 
 (declare conn)
 (declare spec)
+
+(defn- get-payment-obligation-review [application-key hakukohde]
+  (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
+                            (->> (jdbc/query
+                                   conn
+                                   ["select * FROM application_hakukohde_reviews WHERE application_key = ? AND requirement = ? AND hakukohde = ?"
+                                    application-key "payment-obligation" hakukohde])
+                                 first)))
 
 (defn- clear! []
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]
@@ -410,4 +419,74 @@
                   (should-have-invoked :start-job
                                        {:with [:* :*
                                                "ataru.kk-application-payment.kk-application-payment-email-job"
-                                               check-mail-fn]})))))
+                                               check-mail-fn]}))))
+
+          (it "should set tuition fee obligation for non fi/sv hakukohde when payment state changes to awaiting"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     application-fixtures/application-without-hakemusmaksu-exemption
+                                     nil)
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:person_oid test-person-oid :term test-term :year test-year} runner)
+                    application-key (:key (application-store/get-application application-id))
+                    payment (first (payment/get-raw-payments [application-key]))
+                    obligation (get-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
+                (should= (:awaiting payment/all-states) (:state payment))
+                (should= {:application_key application-key, :requirement "payment-obligation",
+                          :state "obligated", :hakukohde "payment-info-test-kk-hakukohde"}
+                         (select-keys obligation [:application_key :requirement :state :hakukohde]))))
+
+          (it "should set tuition fee obligation for non fi/sv hakukohde when payment state changes to ok-by-proxy"
+              (let [application-ids (unit-test-db/init-db-fixture
+                                      form-fixtures/payment-exemption-test-form
+                                      [application-fixtures/application-without-hakemusmaksu-exemption
+                                       application-fixtures/application-without-hakemusmaksu-exemption])
+                    [first-key second-key] (map #(:key (application-store/get-application %)) application-ids)
+                    _ (payment-store/create-or-update-kk-application-payment!
+                        {:application-key      first-key
+                         :state                (:paid payment/all-states)
+                         :reason               nil
+                         :due-date             (time-format/unparse payment/default-time-format
+                                                                    (time/plus (time/today-at 12 0 0)
+                                                                               (time/days 3)))
+                         :total-sum            payment/kk-application-payment-amount
+                         :maksut-secret        test-maksut-secret
+                         :required-at          "now()"
+                         :notification-sent-at nil
+                         :approved-at          "now()"})
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:person_oid test-person-oid :term test-term :year test-year} runner)
+                    payment (first (payment/get-raw-payments [second-key]))
+                    obligation (get-payment-obligation-review second-key "payment-info-test-kk-hakukohde")]
+                (should= (:ok-by-proxy payment/all-states) (:state payment))
+                (should= {:application_key second-key, :requirement "payment-obligation",
+                          :state "obligated", :hakukohde "payment-info-test-kk-hakukohde"}
+                         (select-keys obligation [:application_key :requirement :state :hakukohde]))))
+
+          (it "should not set tuition fee obligation for non fi/sv hakukohde when payment state changes to not-required"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     application-fixtures/application-with-hakemusmaksu-exemption
+                                     nil)
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:person_oid test-person-oid :term test-term :year test-year} runner)
+                    application-key (:key (application-store/get-application application-id))
+                    payment (first (payment/get-raw-payments [application-key]))
+                    obligation (get-payment-obligation-review application-key "payment-info-test-kk-hakukohde")]
+                (should= (:not-required payment/all-states) (:state payment))
+                (should-be-nil obligation)))
+
+          (it "should not set tuition fee obligation for fi/sv hakukohde"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     (merge
+                                       application-fixtures/application-without-hakemusmaksu-exemption
+                                       {:hakukohde ["payment-info-test-kk-fisv-hakukohde"]})
+                                     nil)
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:person_oid test-person-oid :term test-term :year test-year} runner)
+                    application-key (:key (application-store/get-application application-id))
+                    payment (first (payment/get-raw-payments [application-key]))
+                    obligation (get-payment-obligation-review application-key "payment-info-test-kk-fisv-hakukohde")]
+                (should= (:awaiting payment/all-states) (:state payment))
+                (should-be-nil obligation))))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -860,6 +860,11 @@
                      (= "unreviewed" (:state existing-requirement-review "unreviewed")))
                 (and (= "unreviewed" (:state review-to-store))
                      (= "not-obligated" (:state existing-requirement-review))
+                     automatically-changed?)
+                (and (= "obligated" (:state review-to-store))
+                     (= "unreviewed" (:state existing-requirement-review "unreviewed")))
+                (and (= "obligated" (:state review-to-store))
+                     (= "not-obligated" (:state existing-requirement-review))
                      automatically-changed?))
         (queries/yesql-upsert-application-hakukohde-review! review-to-store connection)
         (let [event {:application_key          application-key

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -50,9 +50,8 @@
                        (time/plus (time/today-at 12 0 0)
                                   (time/days kk-application-payment-due-days))))
 
-; This could be done automatically on every DB select, but needed so rarely that let's just convert on demand.
 (defn parse-due-date
-  "Convert due date retrieved from db to local date, interpreting it in correct time zone"
+  "Convert due date timestamp retrieved from db to local date"
   [due-date]
     (time/local-date (time/year due-date) (time/month due-date) (time/day due-date)))
 

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -6,6 +6,7 @@
   (:require [ataru.cache.cache-service :as cache]
             [ataru.kk-application-payment.kk-application-payment-store :as store]
             [ataru.applications.application-store :as application-store]
+            [ataru.ohjausparametrit.ohjausparametrit-protocol :as ohjausparametrit]
             [ataru.person-service.person-service :as person-service]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
             [ataru.util :as util]
@@ -243,12 +244,66 @@
 (defn- is-finnish-citizen? [person]
   (some #(= "246" (:kansalaisuusKoodi %)) (:kansalaisuus person)))
 
+(defn- keep-if-deadline-passed
+  [field-deadlines haku haku-grace-days now review]
+  (let [id             (:attachment-key review)
+        field-deadline (some->> field-deadlines
+                                (filter #(= id (:field-id %)))
+                                first
+                                :deadline)]
+    (if (some? field-deadline)
+      (time/before? now field-deadline)
+      (not (utils/time-before-some-hakuaika-grace-period? haku haku-grace-days now)))))
+
+(defn- haku-grace-days
+  [ohjausparametrit-service haku]
+  (let [default-grace-days (-> config
+                               :public-config
+                               (get :attachment-modify-grace-period-days 14))
+        ohjausparametrit   (ohjausparametrit/get-parametri ohjausparametrit-service (:oid haku))
+        custom-grace-days  (-> ohjausparametrit :PH_LMT :value)]
+    (or custom-grace-days default-grace-days)))
+
+(defn- includes-fields-with-passed-deadlines?
+  "Returns true when one or more of the fields in the input reviews have their deadlines passed / overdue"
+  [tarjonta-service ohjausparametrit-service application field-reviews]
+  (let [now              (time/now)
+        application-key  (:key application)
+        haku-oid         (:haku application)
+        haku             (tarjonta/get-haku tarjonta-service haku-oid)
+        field-deadlines  (store/get-field-deadlines application-key)
+        haku-grace-days  (haku-grace-days ohjausparametrit-service haku)
+        passed           (remove nil?
+                                 (map (partial keep-if-deadline-passed
+                                               field-deadlines haku haku-grace-days now) field-reviews))]
+    (when (seq passed)
+      (log/info "Application" application-key "has passed kk application deadlines for invalid attachments:" passed)
+      true)))
+
+(defn- get-invalid-attachment-reviews
+  "Returns reviews for those fields that are (still) in missing or incomplete state."
+  [application-key]
+  (let [attachment-keys payment-module/kk-application-payment-exempt-attachment-keys
+        invalid-states  #{"attachment-missing" "incomplete-attachment"}
+        reviews         (application-store/get-application-hakukohde-reviews application-key)]
+    (filter (fn [review]
+              (and (contains? attachment-keys (:attachment-key review))
+                   (contains? invalid-states  (:state review))))
+            reviews)))
+
+(defn- attachments-invalid-and-deadline-passed?
+  "If application's relevant attachments are marked missing or invalid and attachment deadline has passed,
+   the applicant is not exempt by application even if the exemption question was answered as such."
+  [tarjonta-service ohjausparametrit-service application]
+  (when-let [invalid-field-reviews (seq (get-invalid-attachment-reviews (:key application)))]
+    (includes-fields-with-passed-deadlines? tarjonta-service ohjausparametrit-service application invalid-field-reviews)))
+
 (defn- exemption-in-application?
-  [application]
+  [tarjonta-service ohjausparametrit-service application]
   (let [answers (util/application-answers-by-key application)]
-    (if-let [exemption-answer (exemption-form-field-name answers)]
-      (contains? exemption-field-ok-values (:value exemption-answer))
-      false)))
+    (when-let [exemption-answer (exemption-form-field-name answers)]
+      (and (contains? exemption-field-ok-values (:value exemption-answer))
+           (not (attachments-invalid-and-deadline-passed? tarjonta-service ohjausparametrit-service application))))))
 
 (defn- get-haut-with-tarjonta-data
   [get-haut-cache tarjonta-service]
@@ -346,7 +401,7 @@
    - Does not poll payments, they should be updated separately.
    - Does not send notification e-mails.
    Returns a vector of changed states of all applications for possible further processing."
-  [person-service tarjonta-service _ get-haut-cache person-oid term year]
+  [ohjausparametrit-service person-service tarjonta-service _ get-haut-cache person-oid term year]
   (let [valid-haku-oids (get-valid-haku-oids get-haut-cache tarjonta-service term year)
         linked-oids     (get (person-service/linked-oids person-service [person-oid]) person-oid)
         master-oid      (:master-oid linked-oids)
@@ -371,7 +426,7 @@
                                                :payment     (get payment-by-application (:key application))})
                                             applications)
                 payment-state-set      (->> (vals payment-by-application) (map :state) set)
-                exempt-keys            (set (map :key (filter exemption-in-application? applications)))
+                exempt-keys            (set (map :key (filter #(exemption-in-application? tarjonta-service ohjausparametrit-service %) applications)))
                 is-finnish-citizen?    (is-finnish-citizen? person)
                 has-existing-payment?  (contains? payment-state-set (:paid all-states))]
             (log/info "Updating application level kk application payment status for person" person-oid "term" term "year" year

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -253,7 +253,7 @@
                                 :deadline)
         passed         (if (some? field-deadline)
                          (time/after? now field-deadline)
-                         (not (utils/time-before-some-hakuaika-grace-period? haku haku-grace-days now)))]
+                         (not (utils/time-is-before-some-hakuaika-grace-period? haku haku-grace-days now)))]
     (when passed
       review)))
 

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -121,16 +121,15 @@
       (payment/get-valid-payment-info-for-application-id tarjonta-service application-id)
       (payment/get-valid-payment-info-for-application-key tarjonta-service application-key))))
 
-(defn- oid-if-needs-tuition-fee
+(defn- needs-tuition-fee?
   [hakukohde]
   (let [codes (->> (:opetuskieli-koodi-urit hakukohde)
                    (map #(first (str/split % #"#")))
                    set)]
-    (when (and (seq codes)
-               (not (contains? codes "oppilaitoksenopetuskieli_1"))  ; fi
-               (not (contains? codes "oppilaitoksenopetuskieli_2"))  ; sv
-               (not (contains? codes "oppilaitoksenopetuskieli_3"))) ; fi/sv
-      (:oid hakukohde))))
+    (and (seq codes)
+         (not (contains? codes "oppilaitoksenopetuskieli_1"))    ; fi
+         (not (contains? codes "oppilaitoksenopetuskieli_2"))    ; sv
+         (not (contains? codes "oppilaitoksenopetuskieli_3"))))) ; fi/sv
 
 (defn- mark-tuition-fee-obligated
   "Marks tuition fee (lukuvuosimaksu) obligation for application key for every hakukohde that does not organize
@@ -141,7 +140,8 @@
         hakukohteet            (tarjonta/get-hakukohteet
                                  tarjonta-service
                                  (remove nil? hakukohde-oids))
-        tuition-hakukohde-oids (remove nil? (map oid-if-needs-tuition-fee hakukohteet))]
+        tuition-hakukohde-oids (remove nil?
+                                       (map #(when (needs-tuition-fee? %) (:oid %)) hakukohteet))]
     (doseq [hakukohde-oid tuition-hakukohde-oids]
       (log/info "Marking tuition payment obligation due to kk application fee eligibility for application key"
                 application-key "and hakukohde oid" hakukohde-oid)

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -9,6 +9,7 @@
             [clj-time.core :as time]
             [clj-time.format :as f]
             [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [taoensso.timbre :as log]
             [ataru.config.core :refer [config]]
             [ataru.kk-application-payment.kk-application-payment-email-job :as email-job]
@@ -120,6 +121,36 @@
       (payment/get-valid-payment-info-for-application-id tarjonta-service application-id)
       (payment/get-valid-payment-info-for-application-key tarjonta-service application-key))))
 
+(defn- oid-if-needs-tuition-fee
+  [hakukohde]
+  (let [codes (->> (:opetuskieli-koodi-urit hakukohde)
+                   (map #(first (str/split % #"#")))
+                   set)]
+    (when (and (seq codes)
+               (not (contains? codes "oppilaitoksenopetuskieli_1"))  ; fi
+               (not (contains? codes "oppilaitoksenopetuskieli_2"))  ; sv
+               (not (contains? codes "oppilaitoksenopetuskieli_3"))) ; fi/sv
+      (:oid hakukohde))))
+
+(defn- mark-tuition-fee-obligated
+  "Marks tuition fee (lukuvuosimaksu) obligation for application key for every hakukohde that does not organize
+  studies in Finnish and/or Swedish."
+  [{:keys [tarjonta-service]} application-key]
+  (let [application            (application-store/get-latest-application-by-key application-key)
+        hakukohde-oids         (:hakukohde application)
+        hakukohteet            (tarjonta/get-hakukohteet
+                                 tarjonta-service
+                                 (remove nil? hakukohde-oids))
+        tuition-hakukohde-oids (remove nil? (map oid-if-needs-tuition-fee hakukohteet))]
+    (doseq [hakukohde-oid tuition-hakukohde-oids]
+      (log/info "Marking tuition payment obligation due to kk application fee eligibility for application key"
+                application-key "and hakukohde oid" hakukohde-oid)
+      (application-store/save-payment-obligation-automatically-changed
+        application-key
+        hakukohde-oid
+        "payment-obligation"
+        "obligated"))))
+
 (defn- invalidate-maksut-payments-if-needed
   "Whenever a payment for a term is made, other payment invoices for the person and term
   should be invalidated to avoid accidental double payments."
@@ -133,8 +164,9 @@
 
 (defn update-kk-payment-status-for-person-handler
   "Updates payment requirement status for a single (person oid, term, year) either directly or
-  via an application id/key. Creates payments and sends e-mails when necessary. Marking status as paid/overdue
-  is done separately via kk-application-payment-maksut-poller-job, never here."
+  via an application id/key. Creates payments and sends e-mails when necessary. Also marks tuition fee obligation
+  if necessary. Marking status as paid/overdue is done separately via kk-application-payment-maksut-poller-job,
+  never here."
   [{:keys [person_oid term year application_id application_key]}
    {:keys [ohjausparametrit-service person-service tarjonta-service
            koodisto-cache get-haut-cache maksut-service] :as job-runner}]
@@ -157,7 +189,13 @@
                 (let [new-state (:state payment)]
                   (cond
                     (= (:awaiting payment/all-states) new-state)
-                    (create-payment-and-send-email job-runner maksut-service payment))))
+                    (do
+                      (create-payment-and-send-email job-runner maksut-service payment)
+                      ; If application payment is required, tuition fee will be always required as well.
+                      (mark-tuition-fee-obligated job-runner (:application-key payment)))
+
+                    (= (:ok-by-proxy payment/all-states) new-state)
+                    (mark-tuition-fee-obligated job-runner (:application-key payment)))))
 
               (doseq [application-payment existing-payments]
                 (let [{:keys [application payment]} application-payment]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -136,13 +136,15 @@
   via an application id/key. Creates payments and sends e-mails when necessary. Marking status as paid/overdue
   is done separately via kk-application-payment-maksut-poller-job, never here."
   [{:keys [person_oid term year application_id application_key]}
-   {:keys [person-service tarjonta-service koodisto-cache get-haut-cache maksut-service] :as job-runner}]
+   {:keys [ohjausparametrit-service person-service tarjonta-service
+           koodisto-cache get-haut-cache maksut-service] :as job-runner}]
   (when (get-in config [:kk-application-payments :enabled?])
     (let [[person-oid application-term application-year]
           (resolve-term-data tarjonta-service person_oid term year application_id application_key)]
       (if (and person-oid application-term application-year)
         (let [{:keys [modified-payments existing-payments]}
-              (payment/update-payments-for-person-term-and-year person-service tarjonta-service
+              (payment/update-payments-for-person-term-and-year ohjausparametrit-service
+                                                                person-service tarjonta-service
                                                                 koodisto-cache get-haut-cache
                                                                 person-oid application-term application-year)]
           (if (or (some? modified-payments) (some? existing-payments))

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
@@ -6,6 +6,7 @@
             [clj-time.core :as time]))
 
 (defqueries "sql/kk-application-payment-queries.sql")
+(defqueries "sql/field-deadline-queries.sql")
 
 (declare yesql-get-awaiting-kk-application-payments)
 (declare yesql-get-kk-application-payments-for-application-keys)
@@ -13,6 +14,7 @@
 (declare yesql-upsert-kk-application-payment<!)
 (declare yesql-update-maksut-secret!)
 (declare yesql-mark-reminder-sent!)
+(declare yesql-get-field-deadlines)
 
 (def ^:private ->kebab-case-kw (partial transform-keys ->kebab-case-keyword))
 
@@ -30,6 +32,12 @@
 (defn- exec-db
   [ds-key query params]
   (db/exec ds-key query params))
+
+; This is here to avoid messy cyclic dependency conflicts. If kk-application-payment was refactored into a service
+; we might do better using dependency injections and ataru.applications.field-deadline
+(defn get-field-deadlines
+  ([application-key]
+   (db/exec :db yesql-get-field-deadlines {:application_key application-key})))
 
 (defn mark-reminder-sent!
   [application-key]

--- a/src/clj/ataru/kk_application_payment/utils.clj
+++ b/src/clj/ataru/kk_application_payment/utils.clj
@@ -69,7 +69,7 @@
         (and (contains? valid-terms term-kw) (> year application-payment-start-year))
         (and (= term-kw :kausi_s) (= year application-payment-start-year))))))
 
-(defn time-before-some-hakuaika-grace-period?
+(defn time-is-before-some-hakuaika-grace-period?
   "Returns true if time 'now' is before specified grace days for one or more hakuaikas, for given haku"
   [haku grace-days now]
   (let [hakuajat-end                (if-let [hakuajat (:hakuajat haku)]
@@ -86,7 +86,7 @@
   "Check whether valid haku is recent enough that payments related to its applications may still need updating.
    Returns all hakus that have their last application end date max grace days before today."
   [haku]
-  (time-before-some-hakuaika-grace-period?
+  (time-is-before-some-hakuaika-grace-period?
     haku (+ haku-update-grace-days 1) (time/now)))
 
 (defn requires-higher-education-application-fee?

--- a/src/clj/ataru/ohjausparametrit/mock_ohjausparametrit_service.clj
+++ b/src/clj/ataru/ohjausparametrit/mock_ohjausparametrit_service.clj
@@ -20,6 +20,7 @@
      :target         "1.2.246.562.29.75477542726",
      :PH_VTJH        {:dateStart nil, :dateEnd nil},
      :PH_IP          {:date nil},
+     :PH_LMT         (if (= haku-oid "payment-info-test-kk-haku-custom-grace") {:value 10000} nil)
      :synteettisetHakemukset (not (= haku-oid "1.2.246.562.29.12345678910")),
      :synteettisetLomakeavain (if (= haku-oid "1.2.246.562.29.12345678910") "" "synthetic-application-test-form"),
      :__modifiedBy__ "1.2.246.562.24.64667668834",

--- a/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
@@ -569,40 +569,64 @@
                                  :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
                                  :hakuajat                    [{:alkaa "2025-01-01T08:00:00",
                                                                 :paattyy "2025-01-01T15:00:00"}]})
-   :payment-info-test-kk-haku-custom-form (merge
+   :payment-info-test-kk-haku-future (merge
+                                       base-kouta-haku
+                                       {:oid                         "payment-info-test-kk-haku-future"
+                                        :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
+                                        :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
+                                        :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
+                                        :hakuajat                    [{:alkaa "2030-01-01T08:00:00",
+                                                                       :paattyy "2030-06-01T15:00:00"}]})
+    :payment-info-test-kk-haku-past (merge
+                                      base-kouta-haku
+                                      {:oid                         "payment-info-test-kk-haku-past"
+                                       :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
+                                       :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
+                                       :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
+                                       :hakuajat                    [{:alkaa "2024-06-01T08:00:00",
+                                                                      :paattyy "2024-08-01T15:00:00"}]})
+   :payment-info-test-kk-haku-custom-grace (merge
+                                             base-kouta-haku
+                                             {:oid                         "payment-info-test-kk-haku-custom-grace"
+                                              :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
+                                              :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
+                                              :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
+                                              :hakuajat                    [{:alkaa "2024-06-01T08:00:00",
+                                                                             :paattyy "2024-08-01T15:00:00"}]})
+    :payment-info-test-kk-haku-custom-form (merge
                                              base-kouta-haku
                                              {:oid                         "payment-info-test-kk-haku-custom-form"
                                               :hakulomakeAtaruId           custom-form-key
                                               :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
                                               :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
                                               :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
-                                              :hakuajat                    [{:alkaa "2025-01-01T08:00:00",
+                                              :hakuajat                    [{:alkaa   "2025-01-01T08:00:00",
                                                                              :paattyy "2025-01-01T15:00:00"}]})
-   :payment-info-test-kk-no-tutkinto-haku (merge
+    :payment-info-test-kk-no-tutkinto-haku (merge
                                              base-kouta-haku
                                              {:oid                         "payment-info-test-kk-haku"
                                               :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
                                               :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
                                               :hakukohdeOids               ["payment-info-test-kk-no-tutkinto-hakukohde"]})
     :payment-info-test-kk-jatko-haku (merge
-                                        base-kouta-haku
-                                        {:oid                         "payment-info-test-kk-haku"
-                                         :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
-                                         :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_3#1"
-                                         :hakukohdeOids               ["payment-info-test-kk-hakukohde"]})
-   :payment-info-test-non-kk-haku (merge
-                                    base-kouta-haku
-                                    {:oid                         "payment-info-test-non-kk-haku"
-                                     :kohdejoukkoKoodiUri         "haunkohdejoukko_11#1"
-                                     :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
-                                     :hakukohdeOids               ["payment-info-test-non-kk-hakukohde"]})
-   :payment-info-test-non-kk-haku-custom-form (merge
-                                                base-kouta-haku
-                                                {:oid                         "payment-info-test-non-kk-haku-custom-form"
-                                                 :hakulomakeAtaruId           custom-form-key
-                                                 :kohdejoukkoKoodiUri         "haunkohdejoukko_11#1"
-                                                 :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
-                                                 :hakukohdeOids               ["payment-info-test-non-kk-hakukohde"]})})
+                                       base-kouta-haku
+                                       {:oid                         "payment-info-test-kk-haku"
+                                        :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
+                                        :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_3#1"
+                                        :hakukohdeOids               ["payment-info-test-kk-hakukohde"]})
+    :payment-info-test-non-kk-haku (merge
+                                     base-kouta-haku
+                                     {:oid                         "payment-info-test-non-kk-haku"
+                                      :kohdejoukkoKoodiUri         "haunkohdejoukko_11#1"
+                                      :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
+                                      :hakukohdeOids               ["payment-info-test-non-kk-hakukohde"]})
+    :payment-info-test-non-kk-haku-custom-form (merge
+                                                 base-kouta-haku
+                                                 {:oid                         "payment-info-test-non-kk-haku-custom-form"
+                                                  :hakulomakeAtaruId           custom-form-key
+                                                  :kohdejoukkoKoodiUri         "haunkohdejoukko_11#1"
+                                                  :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
+                                                  :hakukohdeOids               ["payment-info-test-non-kk-hakukohde"]})})
 
 (defrecord MockTarjontaKoutaService []
   component/Lifecycle

--- a/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
@@ -550,7 +550,14 @@
                        :payment-info-test-kk-hakukohde     (merge
                                                              base-kouta-hakukohde
                                                              {:oid          "payment-info-test-kk-hakukohde"
-                                                              :johtaaTutkintoon true})
+                                                              :johtaaTutkintoon true
+                                                              :opetuskieliKoodiUrit ["oppilaitoksenopetuskieli_4#2"]})
+                       :payment-info-test-kk-fisv-hakukohde (merge
+                                                             base-kouta-hakukohde
+                                                             {:oid          "payment-info-test-kk-fisv-hakukohde"
+                                                              :johtaaTutkintoon true
+                                                              :opetuskieliKoodiUrit ["oppilaitoksenopetuskieli_2#2"
+                                                                                     "oppilaitoksenopetuskieli_4#2"]})
                        :payment-info-test-kk-no-tutkinto-hakukohde (merge
                                                                      base-kouta-hakukohde
                                                                      {:oid          "payment-info-test-kk-no-tutkinto-hakukohde"

--- a/src/cljc/ataru/component_data/kk_application_payment_module.cljc
+++ b/src/cljc/ataru/component_data/kk_application_payment_module.cljc
@@ -23,6 +23,23 @@
 (def kk-application-payment-document-exempt-options
   (dissoc kk-application-payment-document-options :no-document-option-value))
 
+(def kk-application-payment-exempt-attachment-keys
+  #{"passport-attachment"
+    "eu-blue-card-attachment"
+    "eu-passport-attachment"
+    "eu-family-member-permit"
+    "eu-family-passport-attachment"
+    "continuous-residence-permit-front"
+    "continuous-residence-permit-back"
+    "continuous-residence-passport-attachment"
+    "longterm-permit-attachment"
+    "longterm-passport-attachment"
+    "brexit-permit-attachment"
+    "brexit-passport-attachment"
+    "permanent-residence-permit"
+    "permanent-residence-passport-attachment"
+    "temporary-protection-permit"})
+
 (defn- kk-option-attachment [metadata id label-key]
   (assoc (component/attachment metadata)
     :id id


### PR DESCRIPTION
Even when the exemption question is answered, making the applicant exempt from application payment, the required attachment must still be present and valid by the attachment deadline.

If one or more of the mandatory attachments in the module is marked incomplete or missing, and the attachment deadline for the admission has already passed, set payment required for the person.