### PR TITLE
Optimize get-latest-applications-for-kk-payment-processing not to use latest applications view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ npm-debug.log*
 /blob-report/
 /playwright/.cache/
 .testcontainers.properties
-.vscode
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ npm-debug.log*
 /blob-report/
 /playwright/.cache/
 .testcontainers.properties
-.vscode/
+.vscode

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -1372,16 +1372,21 @@ WHERE a.id in (:ids);
 
 --name: yesql-get-latest-applications-for-kk-payment-processing
 SELECT
-  la.key,
-  la.submitted,
-  la.haku,
-  la.hakukohde,
-  la.person_oid AS "person-oid",
+  a.key,
+  a.submitted,
+  a.haku,
+  a.hakukohde,
+  a.person_oid AS "person-oid",
   (SELECT content
-   FROM answers_as_content
-   WHERE application_id = la.id) AS content
-FROM latest_applications AS la
-LEFT JOIN application_reviews AS ar ON ar.application_key = la.key
-WHERE la.haku in (:haku_oids) AND
-      la.person_oid in (:person_oids) AND
+  FROM answers_as_content
+  WHERE application_id = a.id) AS content
+FROM applications AS a
+LEFT JOIN applications AS la
+   ON la.key = a.key AND
+      la.id > a.id
+LEFT JOIN application_reviews AS ar
+  ON ar.application_key = a.key
+WHERE la.id IS NULL AND
+      a.haku in (:haku_oids) AND
+      a.person_oid in (:person_oids) AND
       ar.state <> 'inactivated';


### PR DESCRIPTION
Queries that use latest_applications view end up being needlessly complicated and hard for psql query optimizer. This one ought to speed up a critical oft repeated query from ~6 sec to the 10-100ms bracket with a normal production-like database.