### PR TITLE
Fix e-mail resend response

### DIFF
--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -1099,7 +1099,9 @@
         :path-params [hakemus-oid :- s/Str]
         :summary "Lähettää hakemusmaksu sähköpostin"
         (if (access-controlled-application/applications-access-authorized? organization-service tarjonta-service session [hakemus-oid] [:edit-applications])
-          (kk-application-payment-status-updater-job/resend-payment-email job-runner hakemus-oid)
+          (do
+            (kk-application-payment-status-updater-job/resend-payment-email job-runner hakemus-oid)
+            (response/ok))
           (response/unauthorized)))
 
       (api/POST "/maksupyynto" {session :session}


### PR DESCRIPTION
On virkailija side, the UI displays an error whenever trying to resend a payment e-mail. This was fixed earlier, but erroneously committed to another branch that's still in review. This PR fixes the specific issue. We obviously don't get real status data from the e-mail job, so just return OK whenever there was no exception up to the creation of the job.