### PR TITLE
OK-801 mass inactivation UI

### DIFF
--- a/resources/less/virkailija-application.less
+++ b/resources/less/virkailija-application.less
@@ -128,7 +128,7 @@
 }
 
 .application-handling__popup {
-  .arrow(top, white);
+  .arrow(top, white, 8px, 40%);
   filter: drop-shadow(0 1px 3px rgba(0,0,0,0.30));
   box-sizing: border-box;
   display: block;
@@ -139,7 +139,7 @@
   left: -56px;
   text-align: start;
   background-color: white;
-  min-width: 300px;
+  min-width: 400px;
   padding: 15px;
   font-size: 13px;
   line-height: 21px;
@@ -185,6 +185,35 @@
   margin-bottom: 10px;
 }
 
+.application-handling__mass-edit-review-states-tabs {
+  display: flex;
+  border-bottom: 2px solid @neutral-grey-200;
+  gap: 10px;
+  flex-wrap: nowrap;
+}
+
+.application-handling__mass-edit-review-states-radio {
+  display: inline-flex;
+  align-items: center;
+  line-height: 30px;
+  gap: 7px;
+  padding-right: 2px;
+
+  &>* {
+    cursor: pointer;
+  }
+
+  input {
+    margin: 0;
+    accent-color: @link-color;
+  }
+
+  &:has(> input:checked) {
+    border-bottom: 2px solid @link-color;
+    margin-bottom: -2px;
+  }
+}
+
 .application-handling__popup-close-button {
   font-size: 18px;
   color: @sg-color-gray-2;
@@ -207,7 +236,7 @@
 }
 
 .application-handling__mass-edit-review-states-heading {
-  margin: 0px 0px 10px 0px;
+  margin: 10px 0px 10px 0px;
   color: @text-color;
 }
 
@@ -1546,7 +1575,7 @@ i.arkistoitu {
 }
 
 .application-handling__review-state-row--mass-update {
-  width: 270px;
+  width: 370px;
 }
 
 .application-handling__review-state-row--enabled {

--- a/spec/ataru/virkailija/virkailija_routes_spec.clj
+++ b/spec/ataru/virkailija/virkailija_routes_spec.clj
@@ -31,8 +31,7 @@
             [speclj.core :refer [after-all around before before-all describe
                                  it run-specs should should-be-nil should-not-be-nil should=
                                  tags with]]
-            [yesql.core :as sql]
-            [clojure.string :as str]))
+            [yesql.core :as sql]))
 
 (declare yesql-get-latest-application-by-key)
 (declare yesql-get-application-by-id)
@@ -248,18 +247,18 @@
       (update :body (comp (fn [content] (json/parse-string content true)) slurp))))
 
 (defn- post-mass-inactivate-applications [application-keys reason-of-inactivation]
-  (-> (mock/request :post (str "/lomake-editori/api/applications/mass-inactivate?reason-of-inactivation=" 
-                               (str/replace reason-of-inactivation " " "+"))
-                    (json/generate-string {:application-keys application-keys}))
+  (-> (mock/request :post "/lomake-editori/api/applications/mass-inactivate"
+                    (json/generate-string {:application-keys application-keys
+                                           :message reason-of-inactivation}))
       (update-in [:headers] assoc "cookie" (login @virkailija-routes "SUPERUSER"))
       (mock/content-type "application/json")
       ((deref virkailija-routes))
       (update :body (comp (fn [content] (json/parse-string content true)) slurp))))
 
 (defn- post-mass-reactivate-applications [application-keys reason-of-reactivation]
-  (-> (mock/request :post (str "/lomake-editori/api/applications/mass-reactivate?reason-of-reactivation=" 
-                               (str/replace reason-of-reactivation " " "+"))
-                    (json/generate-string {:application-keys application-keys}))
+  (-> (mock/request :post "/lomake-editori/api/applications/mass-reactivate"
+                    (json/generate-string {:application-keys application-keys
+                                           :message reason-of-reactivation}))
       (update-in [:headers] assoc "cookie" (login @virkailija-routes "SUPERUSER"))
       (mock/content-type "application/json")
       ((deref virkailija-routes))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -1737,7 +1737,9 @@
         (save-application-review {:application-key application-key :state "inactivated"} session audit-logger)
         (add-review-note {:application-key application-key :notes reason-of-inactivation} session)
         nil
-        (catch Exception e (log/error e "Inactivation failed for application key" application-key "exception:" e))))
+        (catch Exception e
+          (log/error e "Inactivation failed for application key" application-key "exception:" e)
+          application-key)))
     (do
       (log/warn "Application" application-key "was not found or active - inactivation skipped.")
       application-key)))
@@ -1753,7 +1755,9 @@
                                  session audit-logger)
         (add-review-note {:application-key application-key :notes reason-of-reactivation} session)
         nil
-        (catch Exception e (log/error e "Reactivation failed for application key" application-key "exception:" e))))
+        (catch Exception e
+          (log/error e "Reactivation failed for application key" application-key "exception:" e)
+          application-key)))
     (do
       (log/warn "Application" application-key "was not inactivated or found - reactivation skipped.")
       application-key)))
@@ -1765,8 +1769,10 @@
   (let [not-inactivated-keys (conj [] (doall
                                        (map (partial inactivate-application session reason-of-inactivation audit-logger)
                                             application-keys)))
-        not-inactivated-filtered (remove nil? (vec (flatten not-inactivated-keys)))]
-    (log/info "Inactivated" (count not-inactivated-filtered) "applications")
+        not-inactivated-filtered (remove nil? (vec (flatten not-inactivated-keys)))
+        inactivated-keys (remove (set not-inactivated-filtered) application-keys)]
+    (log/info "Inactivated" (count inactivated-keys) "applications:" inactivated-keys)
+    (log/info "Failed to inactivate" (count not-inactivated-filtered) "applications:" not-inactivated-filtered)
     not-inactivated-filtered))
 
 (defn mass-reactivate-applications
@@ -1776,8 +1782,10 @@
   (let [not-reactivated-keys (conj [] (doall
                                         (map (partial reactivate-application session reason-of-reactivation audit-logger)
                                              application-keys)))
-        not-reactivated-filtered (remove nil? (vec (flatten not-reactivated-keys)))]
-    (log/info "Reactivated" (count not-reactivated-filtered) "applications")
+        not-reactivated-filtered (remove nil? (vec (flatten not-reactivated-keys)))
+        reactivated-keys (remove (set not-reactivated-filtered) application-keys)]
+    (log/info "Reactivated" (count reactivated-keys) "applications:" reactivated-keys)
+    (log/info "Failed to reactivate" (count not-reactivated-filtered) "applications:" not-reactivated-filtered)
     not-reactivated-filtered))
 
 (defn get-latest-applications-for-kk-payment-processing

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -1771,8 +1771,8 @@
                                             application-keys)))
         not-inactivated-filtered (remove nil? (vec (flatten not-inactivated-keys)))
         inactivated-keys (remove (set not-inactivated-filtered) application-keys)]
-    (log/info "Inactivated" (count inactivated-keys) "applications:" inactivated-keys)
-    (log/info "Failed to inactivate" (count not-inactivated-filtered) "applications:" not-inactivated-filtered)
+    (log/info "Inactivated" (count inactivated-keys) "applications, failed to inactivate" (count not-inactivated-filtered)
+              "applications. Inactivated keys:" inactivated-keys "not inactivated keys:" not-inactivated-filtered)
     not-inactivated-filtered))
 
 (defn mass-reactivate-applications
@@ -1784,8 +1784,8 @@
                                              application-keys)))
         not-reactivated-filtered (remove nil? (vec (flatten not-reactivated-keys)))
         reactivated-keys (remove (set not-reactivated-filtered) application-keys)]
-    (log/info "Reactivated" (count reactivated-keys) "applications:" reactivated-keys)
-    (log/info "Failed to reactivate" (count not-reactivated-filtered) "applications:" not-reactivated-filtered)
+    (log/info "Reactivated" (count reactivated-keys) "applications, failed to reactivate" (count not-reactivated-filtered)
+              "applications. Reactivated keys:" reactivated-keys "not reactivated keys:" not-reactivated-filtered)
     not-reactivated-filtered))
 
 (defn get-latest-applications-for-kk-payment-processing

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -934,28 +934,28 @@
                                               " poisto ei ole sallittu")})))
 
     (api/POST "/mass-inactivate" {session :session}
-      :query-params [reason-of-inactivation :- s/Str]
-      :body [body {:application-keys [s/Str]}]
+      :body [body {:application-keys [s/Str]
+                   :message s/Str}]
       :summary "Inactivate applications by list of application keys. Returns list of application keys that were not inactivated."
       (if-let [result (application-service/mass-inactivate-applications
                        application-service
                        session
                        (:application-keys body)
-                       reason-of-inactivation)]
+                       (:message body))]
         (response/ok {:not-inactivated-keys result})
         (response/unauthorized {:error (str "Hakemusten "
                                             (clojure.string/join ", " (:application-keys body))
                                             " passivointi ei ole sallittu")})))
 
     (api/POST "/mass-reactivate" {session :session}
-       :query-params [reason-of-reactivation :- s/Str]
-       :body [body {:application-keys [s/Str]}]
+       :body [body {:application-keys [s/Str]
+                    :message s/Str}]
        :summary "Reactivate inactive applications by list of application keys. Returns list of application keys that were not reactivated."
        (if-let [result (application-service/mass-reactivate-applications
                         application-service
                         session
                         (:application-keys body)
-                        reason-of-reactivation)]
+                        (:message body))]
          (response/ok {:not-reactivated-keys result})
          (response/unauthorized {:error (str "Hakemusten "
                                              (clojure.string/join ", " (:application-keys body))

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1809,10 +1809,10 @@
                                                               :sv "Ändra behandlingsstatus"
                                                               :en "Change processing status"}
    :mass-inactivation-header                                 {:fi "Passivoi hakemukset"
-                                                              :sv "Passivisera ansökningar"
+                                                              :sv "Passivera ansökningar"
                                                               :en "Inactivate applications"}
    :mass-inactivation-n-applications                         {:fi "Olet passivoimassa %d hakemusta"
-                                                              :sv "Du är på väg att passivisera %d ansökningar"
+                                                              :sv "Du är på väg att passivera %d ansökningar"
                                                               :en "You're about to inactivate %d applications"}
    :mass-inactivation-note-title                             {:fi "Muistiinpano"
                                                               :sv "Anteckning"

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1439,6 +1439,12 @@
    :compare                                                  {:fi "Vertaile"
                                                               :sv "Jämför"
                                                               :en "Compare"}
+   :inactivate                                               {:fi "Passivoi hakemukset"
+                                                              :sv "Passivera ansökningar"
+                                                              :en "Inactivate applications"}
+   :confirm-inactivation                                     {:fi "Vahvista passivointi"
+                                                              :sv "Bekräfta passiveringen"
+                                                              :en "Confirm inactivation"}
    :confirm-change                                           {:fi "Vahvista muutos"
                                                               :sv "Bekräfta ändringen"
                                                               :en "Confirm the change"}
@@ -1799,6 +1805,18 @@
    :mass-edit                                                {:fi "Massamuutos"
                                                               :sv "Massändring"
                                                               :en "Mass editing"}
+   :mass-edit-header                                         {:fi "Muuta käsittelyvaihetta"
+                                                              :sv "Ändra behandlingsstatus"
+                                                              :en "Change processing status"}
+   :mass-inactivation-header                                 {:fi "Passivoi hakemukset"
+                                                              :sv "Passivisera ansökningar"
+                                                              :en "Inactivate applications"}
+   :mass-inactivation-n-applications                         {:fi "Olet passivoimassa %d hakemusta"
+                                                              :sv "Du är på väg att passivisera %d ansökningar"
+                                                              :en "You're about to inactivate %d applications"}
+   :mass-inactivation-note-title                             {:fi "Muistiinpano"
+                                                              :sv "Anteckning"
+                                                              :en "Note"}
    :mass-review-notes                                        {:fi "Massamuistiinpano"
                                                               :sv "SV: Massanteckningar"
                                                               :en "EN: Mass notes"}

--- a/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_handlers.cljs
@@ -102,7 +102,6 @@
 (reg-event-fx
  :application/handle-mass-inactivate-applications
  (fn [_ _]
-   (println "handle-mass-inactivate-applications")
    {:dispatch-n [[:application/set-mass-inactivation-message ""]
                  [:application/reload-applications]]}))
 

--- a/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_handlers.cljs
@@ -8,6 +8,11 @@
     (assoc-in db [:application :mass-update :visible?] visible?)))
 
 (reg-event-db
+ :application/set-mass-update-popup-tab
+ (fn [db [_ tab-name]]
+   (assoc-in db [:application :mass-update :open-tab] tab-name)))
+
+(reg-event-db
  :application/set-mass-review-notes-popup-visibility
  (fn [db [_ visible?]]
    (assoc-in db [:application :mass-review-notes :visible?] visible?)))
@@ -24,6 +29,15 @@
                                   :hakukohde-oids-for-hakukohderyhma (hakukohde-oids-from-selected-hakukohde-or-hakukohderyhma db)}
             :path                "/lomake-editori/api/applications/mass-update"
             :handler-or-dispatch :application/handle-mass-update-application-reviews}}))
+
+(reg-event-fx
+ :application/mass-inactivate-applications
+ (fn [{:keys [db]} _]
+   {:http {:method              :post
+           :params              {:application-keys (map :key (get-in db [:application :applications]))
+                                 :message          (get-in db [:application :mass-inactivation :message])}
+           :path                "/lomake-editori/api/applications/mass-inactivate"
+           :handler-or-dispatch :application/handle-mass-inactivate-applications}}))
 
 (reg-event-db
  :application/set-mass-review-notes
@@ -85,3 +99,15 @@
     :db         (update-in db [:application :applications]
                            (partial map #(assoc % :new-application-modifications 0)))}))
 
+(reg-event-fx
+ :application/handle-mass-inactivate-applications
+ (fn [_ _]
+   (println "handle-mass-inactivate-applications")
+   {:dispatch-n [[:application/set-mass-inactivation-message ""]
+                 [:application/reload-applications]]}))
+
+
+(reg-event-db
+ :application/set-mass-inactivation-message
+ (fn [db [_ message]]
+   (assoc-in db [:application :mass-inactivation :message] message)))

--- a/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_view.cljs
+++ b/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_view.cljs
@@ -3,6 +3,7 @@
     [ataru.application.review-states :as review-states]
     [ataru.virkailija.application.view.virkailija-application-icons :as icons]
     [reagent.core :as r]
+    [clojure.string :as str]
     [re-frame.core :refer [subscribe dispatch]]))
 
 (defn- selected-or-default-mass-review-state
@@ -58,10 +59,84 @@
   [current-state states review-state-counts disable-empty-rows?]
   (mapv (partial mass-review-state-row current-state states review-state-counts disable-empty-rows?) (map first states)))
 
-(defn mass-update-applications-link
+(defn- mass-update-application-title
   []
-  (let [visible?                   (subscribe [:state-query [:application :mass-update :visible?]])
-        from-list-open?            (r/atom false)
+  (fn []
+    [:div.application-handling__mass-edit-review-states-title-container
+     [:h4.application-handling__mass-edit-review-states-title
+      @(subscribe [:editor/virkailija-translation :mass-edit])]
+     [:button.virkailija-close-button
+      {:on-click #(dispatch [:application/set-mass-update-popup-visibility false])}
+      [:i.zmdi.zmdi-close]]]))
+
+(defn- mass-update-application-tabs
+  []
+  (let [open-tab (subscribe [:state-query [:application :mass-update :open-tab]])]
+   (fn []
+    [:div.application-handling__mass-edit-review-states-tabs
+     [:div.application-handling__mass-edit-review-states-radio
+      [:input {:type "radio"
+               :id "mass-edit-input"
+               :name "mass-update-tab"
+               :checked (or (= @open-tab :mass-update) (nil? @open-tab))
+               :on-change #(dispatch [:application/set-mass-update-popup-tab :mass-update])}]
+      [:label {:for "mass-edit-input"}
+       @(subscribe [:editor/virkailija-translation :mass-edit-header])]]
+     [:div.application-handling__mass-edit-review-states-radio
+      [:input {:type "radio"
+               :id "mass-inactivation-input"
+               :name "mass-update-tab"
+               :checked (= @open-tab :mass-inactivation)
+               :on-change #(dispatch [:application/set-mass-update-popup-tab :mass-inactivation])}]
+      [:label {:for "mass-inactivation-input"}
+       @(subscribe [:editor/virkailija-translation :mass-inactivation-header])]]])))
+
+(defn mass-update-inactivation-view
+  []
+  (let [haku-header         (subscribe [:application/list-heading-data-for-haku])
+        applications-count  (subscribe [:application/loaded-applications-count])
+        message             (subscribe [:state-query [:application :mass-inactivation :message]])
+        submit-button-state (r/atom :submit)
+        loading?            (subscribe [:application/fetching-applications?])]
+    (fn []
+      [:div.application-handling__mass-edit-review-states-popup.application-handling__popup
+       [mass-update-application-title]
+       (when-let [[haku-oid hakukohde-oid _ _ _] @haku-header]
+         [:p
+          @(subscribe [:application/haku-name haku-oid])
+          (when hakukohde-oid
+            (str ", " @(subscribe [:application/hakukohde-name hakukohde-oid])))])
+       [mass-update-application-tabs]
+       [:p
+        @(subscribe [:editor/virkailija-translation :mass-inactivation-n-applications @applications-count])]
+       [:h4.application-handling__mass-edit-review-states-heading
+        @(subscribe [:editor/virkailija-translation :mass-inactivation-note-title])]
+       [:div.application-handling__information-request-row
+        [:textarea.application-handling__information-request-message-area.application-handling__information-request-message-area--large
+         {:value     @message
+          :on-change #(dispatch [:application/set-mass-inactivation-message (-> % .-target .-value)])}]]
+       (case @submit-button-state
+         :submit
+         (let [button-disabled? (or @loading? (str/blank? @message))]
+           [:a.application-handling__link-button.application-handling__mass-edit-review-states-submit-button
+            {:on-click #(when-not button-disabled? (reset! submit-button-state :confirm))
+             :disabled button-disabled?}
+            [:span
+             (str @(subscribe [:editor/virkailija-translation :inactivate])
+                  (when @loading? " "))
+             (when @loading?
+               [:i.zmdi.zmdi-spinner.spin])]])
+
+         :confirm
+         [:a.application-handling__link-button.application-handling__mass-edit-review-states-submit-button--confirm
+          {:on-click (fn []
+                       (dispatch [:application/mass-inactivate-applications])
+                       (dispatch [:application/set-mass-update-popup-visibility false]))}
+          @(subscribe [:editor/virkailija-translation :confirm-inactivation])])])))
+
+(defn- mass-update-applications-view
+  []
+  (let [from-list-open?            (r/atom false)
         to-list-open?              (r/atom false)
         submit-button-state        (r/atom :submit)
         selected-from-review-state (r/atom nil)
@@ -70,86 +145,95 @@
         review-state-counts        (subscribe [:state-query [:application :review-state-counts]])
         loading?                   (subscribe [:application/fetching-applications?])
         tutu-form-visible?         (subscribe [:payment/tutu-form-selected?])
-        allowed?                   (subscribe [:application/mass-information-request-allowed?])
         processing-states          (if @tutu-form-visible?
-                                       review-states/application-hakukohde-processing-states
-                                       review-states/application-hakukohde-processing-states-normal)
+                                     review-states/application-hakukohde-processing-states
+                                     review-states/application-hakukohde-processing-states-normal)
         all-states                 (reduce (fn [acc [state _]]
                                              (assoc acc state 0))
                                            {}
-                                           processing-states)]
+                                           processing-states)
+        from-states (merge all-states @review-state-counts)]
     (fn []
-      (let [from-states (merge all-states @review-state-counts)]
-        [:span.application-handling__mass-edit-review-states-container
+      [:div.application-handling__mass-edit-review-states-popup.application-handling__popup
+       [mass-update-application-title]
+
+       (when-let [[haku-oid hakukohde-oid _ _ _] @haku-header]
+         [:p
+          @(subscribe [:application/haku-name haku-oid])
+          (when hakukohde-oid
+            (str ", " @(subscribe [:application/hakukohde-name hakukohde-oid])))])
+
+       [mass-update-application-tabs]
+
+       [:h4.application-handling__mass-edit-review-states-heading @(subscribe [:editor/virkailija-translation :from-state])]
+
+       (if @from-list-open?
+         (into [:div.application-handling__review-state-list.application-handling__review-state-list--opened
+                {:on-click #(swap! from-list-open? not)}]
+               (opened-mass-review-state-list selected-from-review-state from-states @review-state-counts true))
+         (mass-review-state-selected-row
+          (fn []
+            (swap! from-list-open? not)
+            (reset! submit-button-state :submit))
+          (selected-or-default-mass-review-state-label selected-from-review-state from-states @review-state-counts)))
+
+       [:h4.application-handling__mass-edit-review-states-heading @(subscribe [:editor/virkailija-translation :to-state])]
+
+       (if @to-list-open?
+         (into [:div.application-handling__review-state-list.application-handling__review-state-list--opened
+                {:on-click #(when (-> from-states (keys) (count) (pos?)) (swap! to-list-open? not))}]
+               (opened-mass-review-state-list selected-to-review-state all-states @review-state-counts false))
+         (mass-review-state-selected-row
+          (fn []
+            (swap! to-list-open? not)
+            (reset! submit-button-state :submit))
+          (selected-or-default-mass-review-state-label selected-to-review-state all-states @review-state-counts)))
+
+       (case @submit-button-state
+         :submit
+         (let [button-disabled? (or (= (selected-or-default-mass-review-state selected-from-review-state from-states)
+                                       (selected-or-default-mass-review-state selected-to-review-state all-states))
+                                    @loading?)]
+           [:a.application-handling__link-button.application-handling__mass-edit-review-states-submit-button
+            {:on-click #(when-not button-disabled? (reset! submit-button-state :confirm))
+             :disabled button-disabled?}
+            [:span
+             (str @(subscribe [:editor/virkailija-translation :change])
+                  (when @loading? " "))
+             (when @loading?
+               [:i.zmdi.zmdi-spinner.spin])]])
+
+         :confirm
+         [:a.application-handling__link-button.application-handling__mass-edit-review-states-submit-button--confirm
+          {:on-click (fn []
+                       (let [from-state-name (selected-or-default-mass-review-state selected-from-review-state from-states)
+                             to-state-name   (selected-or-default-mass-review-state selected-to-review-state all-states)]
+                         (dispatch [:application/mass-update-application-reviews
+                                    from-state-name
+                                    to-state-name])
+                         (dispatch [:application/set-mass-update-popup-visibility false])
+                         (reset! selected-from-review-state nil)
+                         (reset! selected-to-review-state nil)
+                         (reset! from-list-open? false)
+                         (reset! to-list-open? false)))}
+          @(subscribe [:editor/virkailija-translation :confirm-change])])])))
+
+(defn mass-update-applications-link
+  []
+  (let [visible? (subscribe [:state-query [:application :mass-update :visible?]])
+        allowed? (subscribe [:application/mass-information-request-allowed?])
+        open-tab (subscribe [:state-query [:application :mass-update :open-tab]])]
+    (fn []
+      [:span.application-handling__mass-edit-review-states-container
          [:a.application-handling__mass-edit-review-states-link.editor-form__control-button.editor-form__control-button--enabled.editor-form__control-button--variable-width
           {:on-click (when @allowed? #(dispatch [:application/set-mass-update-popup-visibility true]))
            :class (when (not @allowed?) "application-handling__button--disabled")}
           @(subscribe [:editor/virkailija-translation :mass-edit])]
          (when @visible?
-           [:div.application-handling__mass-edit-review-states-popup.application-handling__popup
-            [:div.application-handling__mass-edit-review-states-title-container
-             [:h4.application-handling__mass-edit-review-states-title
-              @(subscribe [:editor/virkailija-translation :mass-edit])]
-             [:button.virkailija-close-button
-              {:on-click #(dispatch [:application/set-mass-update-popup-visibility false])}
-              [:i.zmdi.zmdi-close]]]
-            (when-let [[haku-oid hakukohde-oid _ _ _] @haku-header]
-              [:p
-               @(subscribe [:application/haku-name haku-oid])
-               (when hakukohde-oid
-                 (str ", " @(subscribe [:application/hakukohde-name hakukohde-oid])))])
-            [:h4.application-handling__mass-edit-review-states-heading @(subscribe [:editor/virkailija-translation :from-state])]
-
-            (if @from-list-open?
-              (into [:div.application-handling__review-state-list.application-handling__review-state-list--opened
-                     {:on-click #(swap! from-list-open? not)}]
-                    (opened-mass-review-state-list selected-from-review-state from-states @review-state-counts true))
-              (mass-review-state-selected-row
-                (fn []
-                  (swap! from-list-open? not)
-                  (reset! submit-button-state :submit))
-                (selected-or-default-mass-review-state-label selected-from-review-state from-states @review-state-counts)))
-
-            [:h4.application-handling__mass-edit-review-states-heading @(subscribe [:editor/virkailija-translation :to-state])]
-
-            (if @to-list-open?
-              (into [:div.application-handling__review-state-list.application-handling__review-state-list--opened
-                     {:on-click #(when (-> from-states (keys) (count) (pos?)) (swap! to-list-open? not))}]
-                    (opened-mass-review-state-list selected-to-review-state all-states @review-state-counts false))
-              (mass-review-state-selected-row
-                (fn []
-                  (swap! to-list-open? not)
-                  (reset! submit-button-state :submit))
-                (selected-or-default-mass-review-state-label selected-to-review-state all-states @review-state-counts)))
-
-            (case @submit-button-state
-              :submit
-              (let [button-disabled? (or (= (selected-or-default-mass-review-state selected-from-review-state from-states)
-                                            (selected-or-default-mass-review-state selected-to-review-state all-states))
-                                         @loading?)]
-                [:a.application-handling__link-button.application-handling__mass-edit-review-states-submit-button
-                 {:on-click #(when-not button-disabled? (reset! submit-button-state :confirm))
-                  :disabled button-disabled?}
-                 [:span
-                  (str @(subscribe [:editor/virkailija-translation :change])
-                       (when @loading? " "))
-                  (when @loading?
-                    [:i.zmdi.zmdi-spinner.spin])]])
-
-              :confirm
-              [:a.application-handling__link-button.application-handling__mass-edit-review-states-submit-button--confirm
-               {:on-click (fn []
-                            (let [from-state-name (selected-or-default-mass-review-state selected-from-review-state from-states)
-                                  to-state-name   (selected-or-default-mass-review-state selected-to-review-state all-states)]
-                              (dispatch [:application/mass-update-application-reviews
-                                         from-state-name
-                                         to-state-name])
-                              (dispatch [:application/set-mass-update-popup-visibility false])
-                              (reset! selected-from-review-state nil)
-                              (reset! selected-to-review-state nil)
-                              (reset! from-list-open? false)
-                              (reset! to-list-open? false)))}
-               @(subscribe [:editor/virkailija-translation :confirm-change])])])]))))
+           (case @open-tab
+             :mass-update       [mass-update-applications-view]
+             :mass-inactivation [mass-update-inactivation-view]
+             [mass-update-applications-view]))])))
 
 (defn- mass-review-notes-popup
   []


### PR DESCRIPTION
UI part for mass inactivation tool according to Figma prototype. Built on top of OK-712 which contains the backend logic, with some slight changes to the API in this PR.