### PR TITLE
OK-814 use original time for attachment grace days in kk application payment logic

### DIFF
--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -439,7 +439,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-exemption} payment)))
 
-                    (it "should set payment status as not required if an unrelated attachment is missing or incomplete after deadline"
+                    (it "should set payment status as not required if only unrelated / non-triggering attachments are missing or incomplete after deadline"
                         (let [fixed-date-str-in-finland "2030-06-15T15:00:01"
                               _ (set-fixed-time fixed-date-str-in-finland)
                               application-key   (create-2030-payment-exempt-by-application) ; Hakuaika ends 2030-06-01
@@ -514,6 +514,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-exemption} payment)))
 
+                    ; Hakuaika ends at 15:00, so the attachment deadline should be at 15:00, regardless of daylight savings.
                     (it "should work correctly with daylight savings: deadline passed"
                         (let [fixed-date-str-in-finland "2030-04-08T15:00:01"
                               _ (set-fixed-time fixed-date-str-in-finland)
@@ -533,6 +534,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-awaiting
                                                      :reason nil} payment)))
 
+                    ; Hakuaika ends at 15:00, so the attachment deadline should be at 15:00, regardless of daylight savings.
                     (it "should work correctly with daylight savings: deadline not passed"
                         (let [fixed-date-str-in-finland "2030-04-08T14:59:59"
                               _ (set-fixed-time fixed-date-str-in-finland)

--- a/spec/ataru/test_utils.clj
+++ b/spec/ataru/test_utils.clj
@@ -185,3 +185,6 @@
   (let [millis (local-timestamp-to-utc-millis timestamp)]
     (println (str "Setting fixed millis " timestamp ", formatted with Helsinki timezone " (format/parse formatter timestamp) ", result millis " millis))
     (DateTimeUtils/setCurrentMillisFixed millis)))
+
+(defn reset-fixed-time! []
+  (DateTimeUtils/setCurrentMillisSystem))

--- a/src/clj/ataru/kk_application_payment/utils.clj
+++ b/src/clj/ataru/kk_application_payment/utils.clj
@@ -79,8 +79,7 @@
                                       (map :end hakuajat)
                                       [(coerce/from-long (get-in haku [:hakuaika :end]))])
         end-times-with-grace-period (map
-                                      #(time/with-time-at-start-of-day
-                                         (time/plus % (time/days grace-days)))
+                                      #(time/plus % (time/days grace-days))
                                       hakuajat-end)]
     (boolean
       (some #(not (time/before? % now)) end-times-with-grace-period))))

--- a/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
+++ b/src/clj/ataru/tarjonta_service/mock_tarjonta_service.clj
@@ -576,22 +576,22 @@
                                  :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
                                  :hakuajat                    [{:alkaa "2025-01-01T08:00:00",
                                                                 :paattyy "2025-01-01T15:00:00"}]})
-   :payment-info-test-kk-haku-future (merge
+   :payment-info-test-kk-haku-2030 (merge
                                        base-kouta-haku
-                                       {:oid                         "payment-info-test-kk-haku-future"
+                                       {:oid                         "payment-info-test-kk-haku-2030"
                                         :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
                                         :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
                                         :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
                                         :hakuajat                    [{:alkaa "2030-01-01T08:00:00",
                                                                        :paattyy "2030-06-01T15:00:00"}]})
-    :payment-info-test-kk-haku-past (merge
-                                      base-kouta-haku
-                                      {:oid                         "payment-info-test-kk-haku-past"
-                                       :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
-                                       :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
-                                       :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
-                                       :hakuajat                    [{:alkaa "2024-06-01T08:00:00",
-                                                                      :paattyy "2024-08-01T15:00:00"}]})
+   :payment-info-test-kk-haku-daylight-savings (merge
+                                                base-kouta-haku
+                                                {:oid                         "payment-info-test-kk-haku-daylight-savings"
+                                                 :kohdejoukkoKoodiUri         "haunkohdejoukko_12#1"
+                                                 :kohdejoukonTarkenneKoodiUri "haunkohdejoukontarkenne_1#1"
+                                                 :hakukohdeOids               ["payment-info-test-kk-hakukohde"]
+                                                 :hakuajat                    [{:alkaa   "2030-01-01T08:00:00",
+                                                                                :paattyy "2030-03-25T15:00:00"}]})
    :payment-info-test-kk-haku-custom-grace (merge
                                              base-kouta-haku
                                              {:oid                         "payment-info-test-kk-haku-custom-grace"


### PR DESCRIPTION
Previously the grace days for kk application payment attachment deadlines were calculated from the start of the day. This PR makes the calculation work with the actual haku end times as specified.

As a side effect, calculating how many days the payments in applications will get updated after haku end also gets adjusted a bit.

Modified the relevant tests to adjust the system clock to make sure exact deadlines are obeyed.