### PR TITLE
OK-843 mark overdue application form fields as non-editable

### DIFF
--- a/spec/ataru/hakija/hakija_form_service_spec.clj
+++ b/spec/ataru/hakija/hakija_form_service_spec.clj
@@ -30,17 +30,17 @@
 (describe "flag-uneditable-and-unviewable-field"
   (describe "when role is hakija"
     (it "should mark field with sensitive-answer as not viewable and not editable"
-      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false nil false sensitive-answer-field)]
+      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false nil false false sensitive-answer-field)]
         (should-be true? (:cannot-view new-field))
         (should-be true? (:cannot-edit new-field))))
 
     (it "should mark ssn field as not viewable and not editable"
-      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false nil false ssn-field)]
+      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false nil false false ssn-field)]
         (should-be true? (:cannot-view new-field))
         (should-be true? (:cannot-edit new-field))))
 
     (it "should mark normal field as viewable and editable"
-      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false nil false normal-field)]
+      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false nil false false normal-field)]
         (should-be false? (:cannot-view new-field))
         (should-be false? (:cannot-edit new-field))))
 
@@ -48,38 +48,48 @@
       (let [field normal-field
             field-deadlines {(:id field) {:field-id (:id field)
                                           :deadline past-date}}
-            new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false field-deadlines false normal-field)]
+            new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false field-deadlines false false normal-field)]
         (should-be false? (:cannot-view new-field))
-        (should-be true? (:cannot-edit new-field)))))
+        (should-be true? (:cannot-edit new-field))))
+
+    (it "should mark normal field with overdue kk payment as viewable but not editable"
+        (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:hakija] false nil false true normal-field)]
+          (should-be false? (:cannot-view new-field))
+          (should-be true? (:cannot-edit new-field)))))
 
   (describe "when role is virkailija"
     (it "should mark field with sensitive-answer as viewable and editable"
-      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil false sensitive-answer-field)]
+      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil false false sensitive-answer-field)]
         (should-be false? (:cannot-view new-field))
         (should-be false? (:cannot-edit new-field))))
 
     (it "should mark ssn field as viewable and editable"
-      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil false ssn-field)]
+      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil false false ssn-field)]
         (should-be false? (:cannot-view new-field))
         (should-be false? (:cannot-edit new-field))))
 
-    (it "should not mark normal field as viewable and editable"
-      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil false normal-field)]
+    (it "should mark normal field as viewable and editable"
+      (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil false false normal-field)]
         (should-be false? (:cannot-view new-field))
         (should-be false? (:cannot-edit new-field))))
+
+    (it "should mark normal field with overdue kk payment as viewable and editable"
+        (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil false true normal-field)]
+          (should-be false? (:cannot-view new-field))
+          (should-be false? (:cannot-edit new-field))))
 
     (describe "when using toisen asteen yhteishaku restrictions"
       (it "should mark normal field as viewable but not editable"
-        (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil true normal-field)]
+        (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil true false normal-field)]
           (should-be false? (:cannot-view new-field))
           (should-be true? (:cannot-edit new-field))))
 
       (it "should mark lupatieto field as viewable and editable"
-        (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil true lupatieto-field)]
+        (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil true false lupatieto-field)]
           (should-be false? (:cannot-view new-field))
           (should-be false? (:cannot-edit new-field))))
 
       (it "should mark allowed person info field as viewable and editable"
-        (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil true allowed-to-edit-person-field)]
+        (let [new-field (hfs/flag-uneditable-and-unviewable-field now nil [:virkailija] false nil true false allowed-to-edit-person-field)]
           (should-be false? (:cannot-view new-field))
           (should-be false? (:cannot-edit new-field)))))))

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -271,6 +271,9 @@
                                                      form-roles
                                                      rewrite?
                                                      haku)
+        kk-payment                 (kk-application-payment/get-kk-payment-state application false)
+        has-overdue-payment?       (= (get-in kk-payment [:payment :state])
+                                      (:overdue kk-application-payment/all-states))
         form                          (cond (some? (:haku application))
                                             (hakija-form-service/fetch-form-by-haku-oid-and-id
                                              form-by-id-cache
@@ -284,7 +287,8 @@
                                              (util/application-in-processing? application-hakukohde-reviews)
                                              field-deadlines
                                              form-roles
-                                              use-toisen-asteen-yhteishaku-restrictions?)
+                                             use-toisen-asteen-yhteishaku-restrictions?
+                                             has-overdue-payment?)
                                             (some? (:form application))
                                             (hakija-form-service/fetch-form-by-id
                                              (:form application)
@@ -735,7 +739,9 @@
                                      (application-store/application-exists-with-secret? secret))
         application-in-processing? (util/application-in-processing? (:application-hakukohde-reviews application))
         inactivated?               (is-inactivated? application)
-        kk-payment                 (future (kk-application-payment/get-kk-payment-state application false))
+        kk-payment                 (kk-application-payment/get-kk-payment-state application false)
+        has-overdue-payment?       (= (get-in kk-payment [:payment :state])
+                                      (:overdue kk-application-payment/all-states))
         lang-override              (when (or secret-expired? inactivated?) (application-store/get-application-language-by-secret secret))
         field-deadlines            (or (some->> application
                                                 :key
@@ -754,7 +760,8 @@
                                                                       application-in-processing?
                                                                       field-deadlines
                                                                       form-roles
-                                                                      is-rewrite-secret-valid?)
+                                                                      is-rewrite-secret-valid?
+                                                                      has-overdue-payment?)
                                          (some? (:form application)) (hakija-form-service/fetch-form-by-key
                                                                       (->> application
                                                                            :form
@@ -783,7 +790,7 @@
        {:application full-application
         :person      filtered-person
         :form        form
-        :kk-payment  @kk-payment})
+        :kk-payment  kk-payment})
      secret-expired?
      lang-override
      inactivated?]))


### PR DESCRIPTION
Includes some refactoring for the current non-editable field logic as suggested.