### PR TITLE
OK-815 extend deadline whenever creating a new kk-application-payment invoice

### DIFF
--- a/spec/ataru/kk_application_payment/kk_application_payment_maksut_poller_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_maksut_poller_job_spec.clj
@@ -1,6 +1,7 @@
 (ns ataru.kk-application-payment.kk-application-payment-maksut-poller-job-spec
   (:require [ataru.fixtures.db.unit-test-db :as unit-test-db]
-            [speclj.core :refer [it describe tags should= after before stub with-stubs should-have-invoked]]
+            [speclj.core :refer [it describe tags should= after before stub with-stubs should-have-invoked
+                                 should-be-nil]]
             [ataru.kk-application-payment.kk-application-payment :as payment]
             [ataru.kk-application-payment.kk-application-payment-maksut-poller-job :as poller-job]
             [ataru.kk-application-payment.kk-application-payment-status-updater-job :as updater-job]
@@ -39,7 +40,9 @@
                                                          :else                      :active)
                                                :origin "kkhakemusmaksu"})))
                                      (remove nil?)))
-  (list-laskut-by-application-key [_ _] []))
+  (list-laskut-by-application-key [_ key] (if (= key "1.2.246.562.8.00000000000022225300")
+                                            [{:secret "1234567890"}]
+                                            [])))
 
 (def mock-maksut-service (->MockMaksutService))
 
@@ -96,6 +99,27 @@
           (after
             (unit-test-db/nuke-kk-payment-data))
 
+          (it "updates missing secret for awaiting payment"
+              (let [_ (create-awaiting-status key-with-active-status)
+                    payment-before (first (payment/get-raw-payments key-with-active-status))
+                    _ (poller-job/poll-kk-payments-handler {} runner)
+                    payment-after (first (payment/get-raw-payments key-with-active-status))]
+                (should-be-nil (:maksut-secret payment-before))
+                (should= "1234567890" (:maksut-secret payment-after))
+                (check-state-and-history key-with-active-status (:awaiting payment/all-states) 1 1)
+                (check-comparison-payments)))
+
+          (it "does not update secret for awaiting payment if it already has one"
+              (let [_ (create-awaiting-status key-with-active-status)
+                    _ (payment/set-maksut-secret key-with-active-status "0000")
+                    payment-before (first (payment/get-raw-payments key-with-active-status))
+                    _ (poller-job/poll-kk-payments-handler {} runner)
+                    payment-after (first (payment/get-raw-payments key-with-active-status))]
+                (should= "0000" (:maksut-secret payment-before))
+                (should= "0000" (:maksut-secret payment-after))
+                (check-state-and-history key-with-active-status (:awaiting payment/all-states) 1 1)
+                (check-comparison-payments)))
+
           (it "does not change status if payment not in awaiting state"
               (let [_ (create-not-required-status key-with-no-status)
                     _ (poller-job/poll-kk-payments-handler {} runner)]
@@ -105,7 +129,8 @@
           (it "does not change status if yet active payment returned from maksut"
               (let [_ (create-awaiting-status key-with-active-status)
                     _ (poller-job/poll-kk-payments-handler {} runner)]
-                (check-state-and-history key-with-active-status (:awaiting payment/all-states) 1 0)
+                ; The status should not change because the payment is still active BUT the secret is going to be updated
+                (check-state-and-history key-with-active-status (:awaiting payment/all-states) 1 1)
                 (check-comparison-payments)))
 
           (it "changes the status of newly paid awaiting payment as paid"

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -96,6 +96,7 @@
                                       :first-name "Aku Petteri"
                                       :last-name "Ankka"
                                       :email "aku@ankkalinna.com"
+                                      :extend-deadline true
                                       :metadata {:haku-name {:fi "testing2", :sv "testing3", :en "testing4"}
                                                  :alkamiskausi "kausi_s"
                                                  :alkamisvuosi 2025}}]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -107,14 +107,15 @@
                                   (filter #(= key (:key %)))
                                   (map :value)
                                   first))]
-    {:reference  (payment->maksut-reference payment)
-     :origin     kk-application-payment-origin
-     :amount     (str kk-application-payment-amount)
-     :due-days   kk-application-payment-due-days
-     :first-name (get-field "first-name")
-     :last-name  (get-field "last-name")
-     :email      (get-field "email")
-     :metadata   (create-invoice-metadata tarjonta-service application)}))
+    {:reference       (payment->maksut-reference payment)
+     :origin          kk-application-payment-origin
+     :amount          (str kk-application-payment-amount)
+     :due-days        kk-application-payment-due-days
+     :extend-deadline true ; Whenever the status is set back to awaiting, the deadline is reset to due-days from now
+     :first-name      (get-field "first-name")
+     :last-name       (get-field "last-name")
+     :email           (get-field "email")
+     :metadata        (create-invoice-metadata tarjonta-service application)}))
 
 (defn- validate-payment-data
   [{:keys [application-key state]}]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_maksut_poller_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_maksut_poller_job.clj
@@ -11,49 +11,76 @@
             [ataru.config.core :refer [config]]
             [ataru.kk-application-payment.kk-application-payment-status-updater-job :as updater-job]))
 
+(defn- get-raw-payment-data
+  [keys-states {:keys [reference status origin]}]
+  (when-let [key-match (get keys-states reference)]
+    {:maksut-status       (name status)
+     :ataru-status        (:state key-match)
+     :ataru-maksut-secret (:maksut-secret key-match)
+     :ataru-data          key-match
+     :origin              origin}))
+
+(defn- handle-terminal-payments
+  "Updates kk payment status to paid or overdue when necessary"
+  [job-runner maksut keys-states]
+  (let [terminal       (filter #(some #{(:status %)} '(:paid :overdue)) maksut)
+        raw-terminal   (map (partial get-raw-payment-data keys-states) terminal)
+        items-terminal (filter some? raw-terminal)]
+    (log/info "Out of which in terminal state are" (count terminal) "invoices")
+    (log/debug (pr-str "Invoices" items-terminal))
+    (doseq [item items-terminal]
+      (let [{:keys [origin ataru-status maksut-status ataru-data]} item
+            {:keys [application-key]} ataru-data
+            awaiting-status (:awaiting payment/all-states)
+            response (if (= payment/kk-application-payment-origin origin)
+                       (match [ataru-status maksut-status]
+                         [awaiting-status "paid"]
+                         (do
+                           (log/info "Set kk application payment paid for application key" application-key)
+                           (payment/set-application-fee-paid application-key ataru-data)
+                           (log/info "Starting kk application payment jobs for application key" application-key)
+                           (updater-job/start-update-kk-payment-status-for-application-key-job
+                            job-runner application-key))
+
+                         [awaiting-status "overdue"]
+                         (do
+                           (log/info "Set kk application payment overdue for application key" application-key)
+                           (payment/set-application-fee-overdue application-key ataru-data))
+
+                         :else (log/debug "Invalid kk payment state combo, will not do anything" item))
+                       (log/debug "Invalid origin, will not do anything" item))]
+        (when response (log/info "Process result:" response))))))
+
+(defn- handle-active-payments
+  "Updates missing secrets for awaiting payments"
+  [{:keys [maksut-service]} maksut keys-states]
+  (let [active                (filter #(some #{(:status %)} '(:active)) maksut)
+        raw-active            (map (partial get-raw-payment-data keys-states) active)
+        items-active          (filter some? raw-active)
+        items-missing-secrets (remove #(some? (:ataru-maksut-secret %)) items-active)]
+    (log/info "kk-application-payment invoices missing secrets:" (count items-missing-secrets))
+    (doseq [item items-missing-secrets]
+      (let [application-key (get-in item [:ataru-data :application-key])
+            invoice (first (maksut-protocol/list-laskut-by-application-key
+                            maksut-service application-key))
+            maksut-secret (:secret invoice)]
+        (if maksut-secret
+          (payment/set-maksut-secret application-key maksut-secret)
+          (log/error "No maksut secret found for application key" application-key))))))
+
 (defn poll-payments
-  "Polls maksut service for any open payment statuses, updates kk payment status to paid or overdue when necessary.
-   Triggers a confirmation e-mail and full payment status update for person whenever an application is marked paid."
+  "- Polls maksut service for any open payment statuses
+   - Updates kk payment status to paid or overdue when necessary
+   - Triggers a full payment status update for person whenever an application is marked paid
+   - Updates missing secrets for awaiting payments"
   [job-runner maksut-service payments]
   (let [keys-states (into {}
                           (map (fn [state] [(payment/payment->maksut-reference state) state])
                                payments))
-        ; TODO: the amount of open payments may be quite large at a given moment, should we partition the API queries here?
         maksut    (maksut-protocol/list-lasku-statuses maksut-service (keys keys-states))]
     (log/info "Received statuses for" (count maksut) "kk payment invoices")
-    (let [terminal (filter #(some #{(:status %)} '(:paid :overdue)) maksut)
-          raw      (map (fn [{:keys [reference status origin]}]
-                          (when-let [key-match (get keys-states reference)]
-                            {:maksut-status (name status)
-                             :ataru-status (:state key-match)
-                             :ataru-data key-match
-                             :origin origin}))
-                        terminal)
-          items    (filter some? raw)]
-      (log/info "Out of which in terminal-state are" (count terminal) "invoices")
-      (log/debug (pr-str "Invoices" items))
-      (doseq [item items]
-        (let [{:keys [origin ataru-status maksut-status ataru-data]} item
-              {:keys [application-key]} ataru-data
-              awaiting-status (:awaiting payment/all-states)
-              response (if (= payment/kk-application-payment-origin origin)
-                         (match [ataru-status maksut-status]
-                                [awaiting-status "paid"]
-                                (do
-                                  (log/info "Set kk application payment paid for application key" application-key)
-                                  (payment/set-application-fee-paid application-key ataru-data)
-                                  (log/info "Starting kk application payment jobs for application key" application-key)
-                                  (updater-job/start-update-kk-payment-status-for-application-key-job
-                                    job-runner application-key))
-
-                                [awaiting-status "overdue"]
-                                (do
-                                  (log/info "Set kk application payment overdue for application key" application-key)
-                                  (payment/set-application-fee-overdue application-key ataru-data))
-
-                                :else (log/debug "Invalid kk payment state combo, will not do anything" item))
-                         (log/debug "Invalid origin, will not do anything" item))]
-          (when response (log/info "Process result:" response)))))))
+    (handle-terminal-payments job-runner maksut keys-states)
+    (handle-active-payments job-runner maksut keys-states )))
 
 (defn get-payments-and-poll [{:keys [maksut-service] :as job-runner}]
   (when (get-in config [:kk-application-payments :enabled?])

--- a/src/cljc/ataru/schema/maksut_schema.cljc
+++ b/src/cljc/ataru/schema/maksut_schema.cljc
@@ -74,7 +74,8 @@
      (s/optional-key :message) (s/maybe s/Str)
      (s/optional-key :index) (s/constrained s/Int #(<= 1 % 2) 'valid-maksu-index)
      (s/optional-key :metadata) LaskuMetadataCreate
-     (s/optional-key :vat) s/Str}
+     (s/optional-key :vat) s/Str
+     (s/optional-key :extend-deadline) s/Bool}
     (fn [{:keys [due-date due-days]}]
       (or due-date due-days))
     'must-have-either-due-date-or-due-days))


### PR DESCRIPTION
- Automatically set new deadline (calculated normally from now onwards) whenever a payment moves back from eg. not required to awaiting state again, and there's already an existing payment - requires maksut https://github.com/Opetushallitus/maksut/pull/42
- Whenever an active / awaiting payment is missing maksut secret, sync and store it as part of maksut polling