### PR TITLE
OY-5079: Poista hylkäyksen syyt excelistä ja siirto-rajapinnasta, jos ei enää ei-hakukelpoinen

### DIFF
--- a/spec/ataru/applications/excel_export_spec.clj
+++ b/spec/ataru/applications/excel_export_spec.clj
@@ -97,7 +97,45 @@
                                            ["Hakukohteen käsittelyn tila" "Käsittelyssä"]
                                            ["Kielitaitovaatimus" "Tarkastamatta"]
                                            ["Tutkinnon kelpoisuus" "Tarkastamatta"]
-                                           ["Hakukelpoisuus" "Tarkastamatta"]
+                                           ["Hakukelpoisuus" "Ei hakukelpoinen"]
+                                           ["Hakukelpoisuus asetettu automaattisesti" nil]
+                                           ["Hylkäyksen syy" "2018-07-30 18:12:14 Tarkastaja Järvinen: Ei käy"]
+                                           ["Maksuvelvollisuus" "Tarkastamatta"]
+                                           ["Valinnan tila" "Hyväksytty"]
+                                           ["Ehdollinen" "ei"]
+                                           ["Pisteet" "12"]
+                                           ["Oppijanumero" nil]
+                                           ["Hakijan henkilö-OID" "1.123.345456567123"]
+                                           ["Turvakielto" "kyllä"]
+                                           ["Muistiinpanot" "2018-07-29 17:11:12 Virk Ailija: Asia kunnossa,\n2018-07-30 18:12:13 Ajilia Kriv: Muikkari"]
+                                           ["Kysymys 4" "Vastaus 4"]
+                                           ["Etunimi" "Person-etunimi"]
+                                           ["Kysymys 5" "Vastaus 5"]
+                                           ["Hakukohteet" "(1) Ajoneuvonosturinkuljettajan ammattitutkinto - Koulutuskeskus Sedu, Ilmajoki, Ilmajoentie (hakukohde.oid)"]])))))
+
+ (it "should export applications for a hakukohde with haku without uneligible reasons"
+     (with-excel-workbook
+       (export-test-excel [(assoc fixtures/application-for-hakukohde
+                                  :application-hakukohde-reviews
+                                  [{:requirement "selection-state" :state "selected" :hakukohde "hakukohde.oid"}
+                                   {:requirement "processing-state" :state "processing" :hakukohde "hakukohde.oid"}
+                                   {:requirement "eligibility-state" :state "eligible" :hakukohde "hakukohde.oid"}])]
+                          {:skip-answers? false
+                           :ids-only? false})
+       (fn [workbook]
+         (let [metadata-sheet    (.getSheetAt workbook 0)
+               application-sheet (.getSheetAt workbook 1)]
+           (verify-row metadata-sheet 0 ["Nimi" "Id" "Tunniste" "Viimeksi muokattu" "Viimeinen muokkaaja"])
+           (verify-row metadata-sheet 1 ["Form name" "321" "form_321_key" "2016-06-14 15:34:56" "IRMELI KUIKELOINEN"])
+           (verify-row metadata-sheet 2 nil)
+           (verify-cols application-sheet [["Hakemusnumero" "application_3424_key"]
+                                           ["Hakemuksen tallennusaika" "2016-06-15 15:30:00"]
+                                           ["Hakemuksen viimeisimmän muokkauksen aika" "2016-06-15 15:34:56"]
+                                           ["Hakemuksen tila" "Aktiivinen"]
+                                           ["Hakukohteen käsittelyn tila" "Käsittelyssä"]
+                                           ["Kielitaitovaatimus" "Tarkastamatta"]
+                                           ["Tutkinnon kelpoisuus" "Tarkastamatta"]
+                                           ["Hakukelpoisuus" "Hakukelpoinen"]
                                            ["Hakukelpoisuus asetettu automaattisesti" nil]
                                            ["Hylkäyksen syy" nil]
                                            ["Maksuvelvollisuus" "Tarkastamatta"]
@@ -155,9 +193,9 @@
                                                      ["Hakukohteen käsittelyn tila" "Käsittelyssä"]
                                                      ["Kielitaitovaatimus" "Tarkastamatta"]
                                                      ["Tutkinnon kelpoisuus" "Tarkastamatta"]
-                                                     ["Hakukelpoisuus" "Tarkastamatta"]
+                                                     ["Hakukelpoisuus" "Ei hakukelpoinen"]
                                                      ["Hakukelpoisuus asetettu automaattisesti" nil]
-                                                     ["Hylkäyksen syy" nil]
+                                                     ["Hylkäyksen syy" "2018-07-30 18:12:14 Tarkastaja Järvinen: Ei käy"]
                                                      ["Maksuvelvollisuus" "Tarkastamatta"]
                                                      ["Valinnan tila" "Hyväksytty"]
                                                      ["Ehdollinen" "ei"]
@@ -470,9 +508,9 @@
                                            ["Hakukohteen käsittelyn tila" "Käsittelyssä"]
                                            ["Kielitaitovaatimus" "Tarkastamatta"]
                                            ["Tutkinnon kelpoisuus" "Tarkastamatta"]
-                                           ["Hakukelpoisuus" "Tarkastamatta"]
+                                           ["Hakukelpoisuus" "Ei hakukelpoinen"]
                                            ["Hakukelpoisuus asetettu automaattisesti" nil]
-                                           ["Hylkäyksen syy" nil]
+                                           ["Hylkäyksen syy" "2018-07-30 18:12:14 Tarkastaja Järvinen: Ei käy"]
                                            ["Maksuvelvollisuus" "Tarkastamatta"]
                                            ["Valinnan tila" "Hyväksytty"]
                                            ["Ehdollinen" "ei"]

--- a/spec/ataru/fixtures/excel_fixtures.clj
+++ b/spec/ataru/fixtures/excel_fixtures.clj
@@ -159,7 +159,8 @@
                                 :person                        {:turvakielto true
                                                                 :first-name  "Person-etunimi"}
                                 :application-hakukohde-reviews [{:requirement "selection-state" :state "selected" :hakukohde "hakukohde.oid"}
-                                                                {:requirement "processing-state" :state "processing" :hakukohde "hakukohde.oid"}]
+                                                                {:requirement "processing-state" :state "processing" :hakukohde "hakukohde.oid"}
+                                                                {:requirement "eligibility-state" :state "uneligible" :hakukohde "hakukohde.oid"}]
                                 :answers                       [{:key       "first-name"
                                                                  :label     {:fi "Etunimi"}
                                                                  :value     "Lomake-etunimi"}
@@ -235,4 +236,12 @@
                             :hakukohde       nil
                             :state-name      nil
                             :first-name      "Ajilia"
-                            :last-name       "Kriv"}]})
+                            :last-name       "Kriv"}
+                           {:id              3
+                            :application-key "application_3424_key"
+                            :created-time    (c/date-time 2018 7 30 15 12 14)
+                            :notes           "Ei käy"
+                            :hakukohde       nil
+                            :state-name      "eligibility-state"
+                            :first-name      "Tarkastaja"
+                            :last-name       "Järvinen"}]})

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -419,7 +419,7 @@
   [applications]
   (map (fn [application]
          (if (and (seq (:applicationReviewNotes application))
-                  (excel/uneligible? (:hakukohdeReviews application)))
+                  (not (excel/uneligible? (:hakukohdeReviews application))))
            (update application
                    :applicationReviewNotes
                    (fn [notes]

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -415,6 +415,18 @@
      application-keys
      [:view-applications :edit-applications])))
 
+(defn- remove-uneligibility-reasons-when-not-uneligible
+  [applications]
+  (map (fn [application]
+         (if (and (seq (:applicationReviewNotes application))
+                  (excel/uneligible? (:hakukohdeReviews application)))
+           (update application
+                   :applicationReviewNotes
+                   (fn [notes]
+                     (filter #(not= (:state %) "eligibility-state") notes)))
+           application))
+       applications))
+
 (defprotocol ApplicationService
   (get-person [this application])
   (get-person-for-securelink [this application])
@@ -768,15 +780,16 @@
 
   (siirto-applications
     [_ session hakukohde-oid haku-oid application-keys modified-after return-inactivated with-unapproved-payments]
-    (if-let [applications (aac/siirto-applications
-                            tarjonta-service
-                            organization-service
-                            session
-                            hakukohde-oid
-                            haku-oid
-                            application-keys
-                            modified-after
-                            return-inactivated)]
+    (if-let [applications (-> (aac/siirto-applications
+                                tarjonta-service
+                                organization-service
+                                session
+                                hakukohde-oid
+                                haku-oid
+                                application-keys
+                                modified-after
+                                return-inactivated)
+                              (remove-uneligibility-reasons-when-not-uneligible))]
       (let [filtered-applications (if with-unapproved-payments
                                     applications
                                     (kk-application-payment/remove-kk-applications-with-unapproved-payments

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -119,6 +119,16 @@
    {:label     (:created-by excel-texts)
     :field     :created-by}])
 
+(defn uneligible?
+  [hakukohde-reviews]
+  (some #(and (= "eligibility-state" (:requirement %))
+              (= "uneligible" (:state %)))
+        hakukohde-reviews))
+
+(defn- render-when-uneligible
+  [application]
+  (uneligible? (get-in application [:application :application-hakukohde-reviews])))
+
 (def ^:private application-meta-fields-by-id
   {"application-number"            {:field     [:application :key]}
    "application-submitted-time"    {:field     [:application :submitted]
@@ -147,7 +157,8 @@
    "eligibility-set-automatically" {:field     [:application :eligibility-set-automatically]
                                     :format-fn #(clojure.string/join "\n" %)}
    "ineligibility-reason"          {:field     [:application-review-notes]
-                                    :format-fn (partial application-review-notes-formatter "eligibility-state")}
+                                    :format-fn (partial application-review-notes-formatter "eligibility-state")
+                                    :render-when-fn render-when-uneligible}
    "maksuvelvollisuus"             {:field     [:application :application-hakukohde-reviews]
                                     :lang?     true
                                     :format-fn (partial hakukohde-review-formatter "payment-obligation")}
@@ -350,12 +361,15 @@
   (let [value-candidate (get-in value-from (to-vec (:field meta-field)))
         value (if (delay? value-candidate) @value-candidate value-candidate)
         format-fn  (:format-fn meta-field)
+        render-when-fn (:render-when-fn meta-field)
         meta-value (if (some? format-fn)
                      (if (:lang? meta-field)
                        (format-fn value lang)
                        (format-fn value))
                      value)]
-    (writer 0 col meta-value)))
+    (when (or (nil? render-when-fn)
+              (render-when-fn value-from))
+      (writer 0 col meta-value))))
 
 (defn- write-form-meta!
   [writer form applications fields lang]


### PR DESCRIPTION
Vaatii alle [OY-5071](https://github.com/Opetushallitus/ataru):n muutokset, koskettu samoihin kohtiin siirto-rajapinnassa.