### PR TITLE
OK-740 automatically mark VTJ-yksilöity EU citizen as exempt from application payment

### DIFF
--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -305,7 +305,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-awaiting
                                                      :reason nil} payment)))
 
-                    (it "should set payment status for eu citizen as not required"
+                    (it "should set payment status for Finnish citizen as not required"
                         (let [oid "1.2.3.4.5.7"                       ; FakePersonService returns Finnish nationality by default
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
                                                                            (merge
@@ -323,7 +323,43 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-eu-citizen} payment)))
 
-                    (it "should set payment status for non eu citizen without exemption as required"
+                    (it "should set payment status for VTJ-yksilöity EU citizen as not required"
+                        (let [oid "1.2.3.4.5.808"                       ; FakePersonService returns French nationality for this one
+                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                           (merge
+                                                                            application-fixtures/application-without-hakemusmaksu-exemption
+                                                                            {:person-oid oid}) nil)
+                              application-key (:key (application-store/get-application application-id))
+                              changed (:modified-payments
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
+                                                                                         fake-koodisto-cache fake-haku-cache
+                                                                                         oid term-fall year-ok))
+                              payment (first (payment/get-raw-payments [application-key]))]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-eu-citizen} payment)))
+
+                    (it "should set payment status for non VTJ-yksilöity EU citizen as not required"
+                        (let [oid "1.2.3.4.5.909"                       ; FakePersonService returns French nationality but no yksiloityVTJ
+                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                           (merge
+                                                                            application-fixtures/application-without-hakemusmaksu-exemption
+                                                                            {:person-oid oid}) nil)
+                              application-key (:key (application-store/get-application application-id))
+                              changed (:modified-payments
+                                       (payment/update-payments-for-person-term-and-year fake-ohjausparametrit-service
+                                                                                         fake-person-service fake-tarjonta-service
+                                                                                         fake-koodisto-cache fake-haku-cache
+                                                                                         oid term-fall year-ok))
+                              payment (first (payment/get-raw-payments [application-key]))]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-awaiting
+                                                     :reason nil} payment)))
+
+                    (it "should set payment status for non EU citizen without exemption as required"
                         (with-redefs [payment/exemption-in-application? (constantly false)]
                           (let [oid "1.2.3.4.5.303"                       ; FakePersonService returns non-EU nationality for this one
                                 application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -6,6 +6,7 @@
   (:require [ataru.cache.cache-service :as cache]
             [ataru.kk-application-payment.kk-application-payment-store :as store]
             [ataru.applications.application-store :as application-store]
+            [ataru.koodisto.koodisto :as koodisto]
             [ataru.ohjausparametrit.ohjausparametrit-protocol :as ohjausparametrit]
             [ataru.person-service.person-service :as person-service]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
@@ -252,15 +253,16 @@
                            (:hakukohteet haku))]
     (utils/requires-higher-education-application-fee? tarjonta-service haku hakukohde-oids)))
 
-; TODO: this may still be needed later for yksilöity EU citizen handling.
-;(defn- is-eu-citizen? [koodisto-cache person]
-;  (let [eu-area (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
-;                     (filter #(= "EU" (:value %)))
-;                     (first))
-;        eu-country-codes (set (map :value (:within eu-area)))]
-;    (if (> (count eu-country-codes) 0)
-;      (some #(contains? eu-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person))
-;      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))))
+(defn- is-vtj-yksiloity-eu-citizen? [koodisto-cache person]
+  (let [vtj-yksiloity?   (:yksiloityVTJ person)
+        eu-area          (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+                              (filter #(= "EU" (:value %)))
+                              (first))
+        eu-country-codes (set (map :value (:within eu-area)))]
+    (if (> (count eu-country-codes) 0)
+      (and vtj-yksiloity?
+           (some #(contains? eu-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person)))
+      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))))
 
 (defn- is-finnish-citizen? [person]
   (some #(= "246" (:kansalaisuusKoodi %)) (:kansalaisuus person)))
@@ -410,12 +412,13 @@
        (new-state-fn (:key application) payment)))))
 
 (defn- update-payments-for-applications
-  [applications-payments exempt-keys is-finnish-citizen? has-existing-payment?]
+  [applications-payments exempt-keys is-finnish-citizen? is-eu-citizen? has-existing-payment?]
   (let [map-payments (fn [new-state state-change-fn]
                        (doall
                          (remove nil? (map #(set-payment exempt-keys new-state state-change-fn %) applications-payments))))]
     (cond
       is-finnish-citizen?   (map-payments (:not-required all-states) set-application-fee-not-required-for-eu-citizen)
+      is-eu-citizen?        (map-payments (:not-required all-states) set-application-fee-not-required-for-eu-citizen)
       has-existing-payment? (map-payments (:ok-by-proxy all-states) set-application-fee-ok-by-proxy)
       :else                 (map-payments (:awaiting all-states) set-application-fee-required))))
 
@@ -425,7 +428,7 @@
    - Does not poll payments, they should be updated separately.
    - Does not send notification e-mails.
    Returns a vector of changed states of all applications for possible further processing."
-  [ohjausparametrit-service person-service tarjonta-service _ get-haut-cache person-oid term year]
+  [ohjausparametrit-service person-service tarjonta-service koodisto-cache get-haut-cache person-oid term year]
   (let [valid-haku-oids (get-valid-haku-oids get-haut-cache tarjonta-service term year)
         linked-oids     (get (person-service/linked-oids person-service [person-oid]) person-oid)
         master-oid      (:master-oid linked-oids)
@@ -452,13 +455,16 @@
                 payment-state-set      (->> (vals payment-by-application) (map :state) set)
                 exempt-keys            (set (map :key (filter #(exemption-in-application? tarjonta-service ohjausparametrit-service %) applications)))
                 is-finnish-citizen?    (is-finnish-citizen? person)
+                is-eu-citizen?         (is-vtj-yksiloity-eu-citizen? koodisto-cache person)
                 has-existing-payment?  (contains? payment-state-set (:paid all-states))]
             (log/info "Updating application level kk application payment status for person" person-oid "term" term "year" year
-                      "is-finnish-citizen?" (boolean is-finnish-citizen?) "has-existing-payment?" (boolean has-existing-payment?))
+                      "is-finnish-citizen?" (boolean is-finnish-citizen?)
+                      "is-eu-citizen?" (boolean is-eu-citizen?)
+                      "has-existing-payment?" (boolean has-existing-payment?))
             {:person            person
              :existing-payments applications-payments
              :modified-payments (update-payments-for-applications
-                                  applications-payments exempt-keys is-finnish-citizen? has-existing-payment?)}))))))
+                                  applications-payments exempt-keys is-finnish-citizen? is-eu-citizen? has-existing-payment?)}))))))
 
 (defn get-kk-payment-state
   "Returns higher education application fee related info to single application.

--- a/src/clj/ataru/person_service/person_integration.clj
+++ b/src/clj/ataru/person_service/person_integration.clj
@@ -95,6 +95,8 @@
   {:pre [(not (nil? application-id))
          (not (nil? person-service))]}
   (let [application (application-store/get-application application-id)]
+    (log/info "About to add applicant from application id"
+              application-id "key" (:key application) "form-id" (:form application))
     (if (muu-person-info-module? application)
       (log/info "Not adding applicant from application"
                 application-id

--- a/src/clj/ataru/person_service/person_service.clj
+++ b/src/clj/ataru/person_service/person_service.clj
@@ -149,6 +149,14 @@
                              {:kansalaisuus [{:kansalaisuusKoodi "784"}]
                               :yksiloity true
                               :yksiloityVTJ true})
+      "1.2.3.4.5.808" (merge fake-onr-person
+                             {:kansalaisuus [{:kansalaisuusKoodi "250"}]
+                              :yksiloity true
+                              :yksiloityVTJ true})
+      "1.2.3.4.5.909" (merge fake-onr-person
+                       {:kansalaisuus [{:kansalaisuusKoodi "250"}]
+                        :yksiloity true
+                        :yksiloityVTJ false})
       (merge fake-onr-person
              {:oidHenkilo oid})))
 


### PR DESCRIPTION
When the applicant is an EU citizen and identity is confirmed via VTJ, they should be automatically exempt from application payment.