### PR TITLE
Otetaan hakukohdekohtaisen kysymyksen alkuperäinen tunniste vastaukse…

### DIFF
--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -327,10 +327,11 @@
             answer-key             (:key answer)
             field-descriptor       (cond
                                      (some? (:duplikoitu-kysymys-hakukohde-oid answer))
-                                     (:original-question answer)
+                                      (get form-fields-by-key (:original-question answer))
                                      (some? (:duplikoitu-followup-hakukohde-oid answer))
-                                     (:original-followup answer)
-                                     :else (get form-fields-by-key answer-key))
+                                      (get form-fields-by-key (:original-followup answer))
+                                     :else
+                                      (get form-fields-by-key answer-key))
             value-or-values        (cond
                                      (contains? person (keyword answer-key))
                                      (get person (keyword answer-key))

--- a/src/clj/ataru/applications/excel_export.clj
+++ b/src/clj/ataru/applications/excel_export.clj
@@ -325,9 +325,12 @@
     (try
       (let [column                 (:column header)
             answer-key             (:key answer)
-            field-descriptor       (if (or (:duplikoitu-kysymys-hakukohde-oid answer) (:duplikoitu-followup-hakukohde-oid answer))
-                                     (get form-fields-by-key (first (string/split answer-key #"_")))
-                                     (get form-fields-by-key answer-key))
+            field-descriptor       (cond
+                                     (some? (:duplikoitu-kysymys-hakukohde-oid answer))
+                                     (:original-question answer)
+                                     (some? (:duplikoitu-followup-hakukohde-oid answer))
+                                     (:original-followup answer)
+                                     :else (get form-fields-by-key answer-key))
             value-or-values        (cond
                                      (contains? person (keyword answer-key))
                                      (get person (keyword answer-key))


### PR DESCRIPTION
…n tiedoista eikä tallennetun vastauksen tunnisteesta splittaamalla