### PR TITLE
OY-5143: check for malicious characters before saving application

### DIFF
--- a/spec/ataru/hakija/hakija_routes_spec.clj
+++ b/spec/ataru/hakija/hakija_routes_spec.clj
@@ -416,15 +416,9 @@
           (should= {:code "application-validation-failed-error"
                     :failures {:extra-answers ["extra-answer-key"]}} (:body resp))))
 
-    (it "should validate application for malicious input"
+    (it "should sanitize application answer for malicious input"
         (with-response :post resp application-fixtures/person-info-form-application-with-malicious-input
-          (should= 400 (:status resp))
-          (should= {:failures [{:key "kk-application-payment-option"
-                                :label {:fi "Hakemusmaksu vaihtoehdot"
-                                        :en "I have the following document\u0000'"}
-                                :value "6"
-                                :fieldType "singleChoice"}]
-                    :code "internal-server-error"} (:body resp))))
+          (should= 200 (:status resp))))
 
     (add-failing-post-spec "should not validate form with blank required field" application-blank-required-field)
 

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -330,12 +330,14 @@
         (clojure.string/replace (clojure.string/trim value) "\u0000" "")
         (sequential? value)
         (mapv trim-and-remove-null-bytes-from-value value)
+        (map? value)
+        (zipmap (keys value) (map trim-and-remove-null-bytes-from-value (vals value)))
         :else
         value))
 
 (defn- remove-null-bytes-from-answer
   [answer]
-  (update answer :value trim-and-remove-null-bytes-from-value))
+  (trim-and-remove-null-bytes-from-value answer))
 
 (defn add-application [new-application applied-hakukohteet form session audit-logger oppija-session]
   (jdbc/with-db-transaction [conn {:datasource (db/get-datasource :db)}]

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -211,24 +211,6 @@
 (def ^:private modified-time-format
   (f/formatter "dd.MM.yyyy HH:mm:ss" tz))
 
-(defn flatten-keys [m]
-  (if (not (map? m))
-    {[] m}
-    (into {}
-          (for [[k v] m
-                [ks v'] (flatten-keys v)]
-            [(cons k ks) v']))))
-
-(defn validate-answers-for-malicious-input
-  "Returns a sequence of answers containing malicious input, such as null characters"
-  [answers]
-  (filter (fn [answer]
-            (let [flat-answer (flatten-keys answer)]
-              (some #(when (string? %)
-                      (re-find #"\u0000" %))
-                    (vals flat-answer))))
-          answers))
-
 (defn- log-late-submitted-application [application submitted-at session audit-logger]
   (audit-log/log audit-logger
                  {:new       {:late-submitted-application (format "Hakija yritti palauttaa hakemuksen hakuajan päätyttyä: %s. Hakemus: %s"
@@ -272,7 +254,6 @@
                                          [false (valid-virkailija-update-secret application)])
                                        [false (valid-virkailija-create-secret application)])
         latest-application            (application-store/get-latest-version-of-application-for-edit rewrite? application)
-        malicious-input-in-answers   (validate-answers-for-malicious-input (:answers application))
         form-roles                    (cond-> []
                                         (some? virkailija-secret)
                                         (conj :virkailija)
@@ -383,12 +364,6 @@
     (when (not-empty hakeminen-tunnistautuneena-validation-errors)
       (log/error "Error(s) when validating fields from oppija-session" oppija-session ":" (pr-str hakeminen-tunnistautuneena-validation-errors)))
     (cond
-      (seq malicious-input-in-answers)
-      {:passed? false
-       :failures malicious-input-in-answers
-       :key (:key latest-application)
-       :code :internal-server-error}
-
       (not-empty hakeminen-tunnistautuneena-validation-errors)
       {:passed? false
        :failures ["Supplied application answers do not match fields from oppija-session."]


### PR DESCRIPTION
Validoidaan jsonin sisältö kaikista vastauksista null-merkin (\u0000) varalta, koska possu ei sitä hyväksy: https://www.postgresql.org/docs/9.4/release-9-4-1.html
-> siivotaan hakemusta tallennettaessa kyseiset merkit pois requestista