### PR TITLE
OY-5239: fix NullPointerExceptions in `automatic-eligibility-if-ylioppilas`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ npm-debug.log*
 .java
 .lsp/.cache
 .calva/
+/tags
 /test-results/
 /playwright-report/
 /blob-report/

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,10 @@ check-ports:
 help:
 	@cat Makefile.md
 
+tags::
+	ctags -R --exclude=@.gitignore --exclude=node_modules \
+		--exclude='*.min.js' --exclude=/out .
+
 # ----------------
 # Test db management
 # ----------------

--- a/src/clj/ataru/applications/automatic_eligibility.clj
+++ b/src/clj/ataru/applications/automatic_eligibility.clj
@@ -161,8 +161,8 @@
   (if (is-tarjonta-haku? haku)
     (log/info "Haku " (:oid haku) " on tarjonta-haku, ei tarkisteta hakemuksen " application " hakukelpoisuutta automaattisesti.")
     (when (automatic-eligibility-if-ylioppilas-or-ammatillinen-in-use? haku ohjausparametrit application now)
+      (log/info "Haku " (:oid haku) " on kouta-haku, tarkistetaan hakemuksen " application " hakukelpoisuus automaattisesti.")
       (doall
-        (log/info "Haku " (:oid haku) " on kouta-haku, tarkistetaan hakemuksen " application " hakukelpoisuus automaattisesti.")
         (map (fn [hakukohde]
                (if (and ylioppilas-tai-ammatillinen? (automatic-eligibility-if-yo-amm-in-hakukohderyhma? hakukohde hakukohderyhmapalvelu-service hakukohderyhma-settings-cache))
                  (do

--- a/src/clj/ataru/applications/automatic_eligibility.clj
+++ b/src/clj/ataru/applications/automatic_eligibility.clj
@@ -159,20 +159,31 @@
    hakukohderyhmapalvelu-service
    hakukohderyhma-settings-cache]
   (if (is-tarjonta-haku? haku)
-    (log/info "Haku " (:oid haku) " on tarjonta-haku, ei tarkisteta hakemuksen " application " hakukelpoisuutta automaattisesti.")
-    (when (automatic-eligibility-if-ylioppilas-or-ammatillinen-in-use? haku ohjausparametrit application now)
-      (log/info "Haku " (:oid haku) " on kouta-haku, tarkistetaan hakemuksen " application " hakukelpoisuus automaattisesti.")
+    (log/info "Haku" (:oid haku) "on tarjonta-haku, ei tarkisteta"
+              "hakemuksen" application "hakukelpoisuutta automaattisesti.")
+    (when (automatic-eligibility-if-ylioppilas-or-ammatillinen-in-use?
+            haku ohjausparametrit application now)
+      (log/info "Haku" (:oid haku) "on kouta-haku, tarkistetaan"
+                "hakemuksen" application "hakukelpoisuus automaattisesti.")
       (doall
         (map (fn [hakukohde]
-               (if (and ylioppilas-tai-ammatillinen? (automatic-eligibility-if-yo-amm-in-hakukohderyhma? hakukohde hakukohderyhmapalvelu-service hakukohderyhma-settings-cache))
-                 (do
-                   (log/info "Haun " (:oid haku) " hakukohde " (:oid hakukohde) " on yo-amm-hakukelpoisuushakukohde, päivitetään hakemuksen " application " hakukelpoisuus automaattisesti.")
-                   {:from        "unreviewed"
-                    :to          "eligible"
-                    :application application
-                    :hakukohde   hakukohde})
-                 {:from        "eligible"
-                  :to          "unreviewed"
+               (let [yo-amm-hakukelpoisuushakukohde?
+                     (and ylioppilas-tai-ammatillinen?
+                          (automatic-eligibility-if-yo-amm-in-hakukohderyhma?
+                            hakukohde
+                            hakukohderyhmapalvelu-service
+                            hakukohderyhma-settings-cache))
+                     from-state (if yo-amm-hakukelpoisuushakukohde?
+                                  "unreviewed" "eligible")
+                     to-state (if yo-amm-hakukelpoisuushakukohde?
+                                "eligible" "unreviewed")]
+                 (when yo-amm-hakukelpoisuushakukohde?
+                   (log/info "Haun" (:oid haku) "hakukohde" (:oid hakukohde)
+                             "on yo-amm-hakukelpoisuushakukohde,"
+                             "päivitetään hakemuksen" application
+                             "hakukelpoisuus automaattisesti."))
+                 {:from        from-state
+                  :to          to-state
                   :application application
                   :hakukohde   hakukohde}))
              hakukohteet)))))


### PR DESCRIPTION
The `log/info` is probably written in the wrong place by accident.  `doall` expects its first argument to be (return) a number.  What happens with current code is an equivalent of:

```
atehwa@polokku:~/proj/ataru$ clojure
Clojure 1.10.2
(doall nil [1 2 3 4 5])
Execution error (NullPointerException) at user/eval1 (REPL:1).
null
```
