### PR TITLE
OPHTUTU-236 Poistetaan tutu hakemuksen lähettämisestä maakoodi turhana

### DIFF
--- a/resources/sql/tutkintojen-tunnustaminen-queries.sql
+++ b/resources/sql/tutkintojen-tunnustaminen-queries.sql
@@ -57,7 +57,7 @@ SELECT a.id
 FROM latest_applications a
 WHERE a.key = :key;
 
--- name: yesql-get-tutu-application
+-- name: yesql-get-tutu-application-details
 SELECT a.key,
        (SELECT value
         FROM answers

--- a/resources/sql/tutkintojen-tunnustaminen-queries.sql
+++ b/resources/sql/tutkintojen-tunnustaminen-queries.sql
@@ -62,10 +62,6 @@ SELECT a.key,
        (SELECT value
         FROM answers
         WHERE application_id = a.id AND
-            key = 'tutu-first-degree-country') AS "country",
-       (SELECT value
-        FROM answers
-        WHERE application_id = a.id AND
             key = 'tutu-apply-reason') AS "apply-reason"
 FROM applications AS a
          JOIN forms AS f ON f.id = a.form_id

--- a/src/clj/ataru/tutkintojen_tunnustaminen/tutkintojen_tunnustaminen_send_job.clj
+++ b/src/clj/ataru/tutkintojen_tunnustaminen/tutkintojen_tunnustaminen_send_job.clj
@@ -5,10 +5,9 @@
     [taoensso.timbre :as log]))
 
 
-(defn tutkintojen-tunnustaminen-send-handler [{:keys [key country apply-reason]} {:keys [tutu-cas-client]}]
+(defn tutkintojen-tunnustaminen-send-handler [{:keys [key apply-reason]} {:keys [tutu-cas-client]}]
   (let [url (resolve-url :tutu-service.hakemus)
         req {:hakemusOid    key
-             :maakoodi      country
              :hakemusKoskee apply-reason}
         response (cas/cas-authenticated-post tutu-cas-client url req)]
 

--- a/src/clj/ataru/tutkintojen_tunnustaminen/tutkintojen_tunnustaminen_store.clj
+++ b/src/clj/ataru/tutkintojen_tunnustaminen/tutkintojen_tunnustaminen_store.clj
@@ -78,7 +78,7 @@
 
 (defn- get-tutu-application [application-key]
   (jdbc/with-db-connection [connection {:datasource (db/get-datasource :db)}]
-                           (first (yesql-get-tutu-application {:key application-key} {:connection connection}))))
+                           (first (yesql-get-tutu-application-details {:key application-key} {:connection connection}))))
 
 (defn start-tutkintojen-tunnustaminen-send-job [job-runner  application-key]
   (when (get-in config [:tutkintojen-tunnustaminen :tutu-send-enabled?])


### PR DESCRIPTION
Liittyy TUTU hakemuksen lähettämiseen ks. https://github.com/Opetushallitus/ataru/pull/1723

Maakoodin lähettäminen osana kutsua osoittautui tarpeettomaksi, sillä saamme tarvittavat tiedot suoraan hakemukselta ja tutkinnoilta. 