### PR TITLE
OY-5454 Siirretään string-normalizer tänne

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>ataru</groupId>
   <artifactId>ataru</artifactId>
@@ -11,7 +11,7 @@
     <url>https://github.com/Opetushallitus/ataru</url>
     <connection>scm:git:git://github.com/Opetushallitus/ataru.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/ataru.git</developerConnection>
-    <tag>33aeb7a57f0a9bf0fc2e96a4354cc56f693b6ecc</tag>
+    <tag>221028dedd0e4ab189e777f65fb940797e832859</tag>
   </scm>
   <build>
     <sourceDirectory>src/clj</sourceDirectory>
@@ -1012,25 +1012,6 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
       <version>2.25.2</version>
-    </dependency>
-    <dependency>
-      <groupId>oph</groupId>
-      <artifactId>clj-string-normalizer</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>jboss-logging</artifactId>
-          <groupId>org.jboss.logging</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>guava</artifactId>
-          <groupId>com.google.guava</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>commons-io</artifactId>
-          <groupId>commons-io</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/project.clj
+++ b/project.clj
@@ -170,7 +170,6 @@
                  [com.fzakaria/slf4j-timbre "0.4.0" :exclusions [io.aviso/pretty]]
                  [org.slf4j/log4j-over-slf4j "2.0.9"]   ;; Log4j 1.x
                  [org.apache.logging.log4j/log4j-to-slf4j "2.25.2"]  ;; Log4j 2.x
-                 [oph/clj-string-normalizer "0.1.0-SNAPSHOT" :exclusions [org.jboss.logging/jboss-logging com.google.guava/guava commons-io]]
                  [com.google.guava/guava "31.1-jre"]
                  [msolli/proletarian "1.0.68-alpha"]
                  [jarohen/chime "0.3.3"]

--- a/src/clj/ataru/hakija/hakija_routes.clj
+++ b/src/clj/ataru/hakija/hakija_routes.clj
@@ -37,7 +37,7 @@
             [ataru.hakija.resumable-file-transfer :as resumable-file]
             [ataru.hakija.signed-direct-upload :as signed-upload]
             [taoensso.timbre :as log]
-            [string-normalizer.filename-normalizer-middleware :as normalizer]
+            [ataru.middleware.filename-normalizer-middleware :as normalizer]
             [ataru.util.http-util :as http]
             [ataru.cas-oppija.cas-oppija-session-store :as oss]
             [ataru.cas-oppija.cas-oppija-utils :as cas-oppija-utils]

--- a/src/clj/ataru/hakija/resumable_file_transfer.clj
+++ b/src/clj/ataru/hakija/resumable_file_transfer.clj
@@ -4,7 +4,7 @@
             [ataru.cas.client :as cas]
             [ataru.config.url-helper :refer [resolve-url]]
             [taoensso.timbre :as log]
-            [string-normalizer.filename-normalizer :as normalizer]))
+            [ataru.filename-normalizer :as normalizer]))
 
 (def max-part-size (get-in config [:public-config :attachment-file-part-max-size-bytes] (* 1024 1024)))
 (def origin-system "ataru")

--- a/src/clj/ataru/middleware/filename_normalizer_middleware.clj
+++ b/src/clj/ataru/middleware/filename_normalizer_middleware.clj
@@ -1,0 +1,10 @@
+(ns ataru.middleware.filename-normalizer-middleware
+  (:require [ataru.filename-normalizer :as normalizer]))
+
+(defn wrap-query-params-filename-normalizer [handler]
+  (fn normalize-query-params-filename [request]
+    (let [filename (-> request :query-params (get "file-name"))
+          request  (cond-> request
+                           (some? filename)
+                           (update-in [:query-params "file-name"] normalizer/normalize-filename))]
+      (handler request))))

--- a/src/cljc/ataru/filename_normalizer.cljc
+++ b/src/cljc/ataru/filename_normalizer.cljc
@@ -1,0 +1,24 @@
+(ns ataru.filename-normalizer
+  (:require [clojure.string :as string]
+            [schema.core :as s])
+  #?(:clj (:import [java.text Normalizer Normalizer$Form])))
+
+;; See UTF codes mapped to characters at https://unicode-table.com/en/
+
+(def ^:private remove-pattern #"[^\u0030-\u0039\u0041-\u005a\u0061-\u007a\.\-_]")
+
+(def ^:private underscore-pattern #"[\s\u0021-\u002c\/\u003a-\u0040\u005b-\u005e\u007b-\u007e]")
+
+(defn- normalize [input]
+  #?(:cljs (.normalize input "NFD")
+     :clj  (Normalizer/normalize input Normalizer$Form/NFD)))
+
+(s/defn normalize-filename :- s/Str
+  "Normalizes filename, removing all characters except a-z, A-Z, 0-9 and converting
+   various other characters to underscore (_)."
+  [input :- s/Str]
+  (->> (string/split input #"")
+       (transduce (comp (map normalize)
+                        (map #(string/replace % underscore-pattern "_"))
+                        (map #(string/replace % remove-pattern "")))
+                  str)))

--- a/src/cljs/ataru/hakija/resumable_upload.cljs
+++ b/src/cljs/ataru/hakija/resumable_upload.cljs
@@ -4,7 +4,7 @@
             [goog.crypt :as crypt]
             [goog.crypt.Md5]
             [cljs-time.core :as c]
-            [string-normalizer.filename-normalizer :as normalizer]
+            [ataru.filename-normalizer :as normalizer]
             [ataru.cljs-util :as util]
             [clojure.string]))
 


### PR DESCRIPTION
Siirretään vanhan clj-utilsin string-normalizer -kirjaston toiminnot tähän projektiin. Ataru on ainoa, joka tuota kirjastoa on käyttänyt, ja se on lähinnä pari funktiota.

Clj-utilsin versiolla oli turhia riippuvuuksia, joiden mukana tuli kriittisesti haavoittuvakin riippuvuus. Oikeasti se ei mitä todennäköisimmin ollut mahdollinen haavoittuvuus Atarussa, kun sitä ei käytetty ollenkaan, mutta parempi ilman.