### PR TITLE
OY-5550 Viive hakukelpoisuuteen ja harkinnanvaraisuuteen

### DIFF
--- a/resources/db/migration/V20260324000000__add_check_after_to_harkinnanvaraisuus_process.sql
+++ b/resources/db/migration/V20260324000000__add_check_after_to_harkinnanvaraisuus_process.sql
@@ -1,0 +1,7 @@
+ALTER TABLE harkinnanvaraisuus_process
+    ADD COLUMN IF NOT EXISTS check_after TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
+
+ALTER TABLE harkinnanvaraisuus_process
+    ALTER COLUMN check_after DROP DEFAULT;
+
+COMMENT ON COLUMN harkinnanvaraisuus_process.check_after IS 'Milloin harkinnanvaraisuus voidaan tarkistaa. Tähän voi lisätä viivettä, että muut järjestelmät ovat päivittyneet.';

--- a/resources/sql/harkinnanvaraisuus-process-queries.sql
+++ b/resources/sql/harkinnanvaraisuus-process-queries.sql
@@ -1,8 +1,15 @@
 -- name: yesql-upsert-harkinnanvaraisuus-process!
-INSERT INTO harkinnanvaraisuus_process (application_id, application_key, haku_oid)
-VALUES (:application_id, :application_key, :haku_oid)
+INSERT INTO harkinnanvaraisuus_process (application_id, application_key, haku_oid, check_after)
+VALUES (:application_id, :application_key, :haku_oid, :check_after)
 ON CONFLICT (application_key)
-    DO UPDATE SET harkinnanvarainen_only = NULL, last_checked = NULL, skip_check = false, application_id = :application_id;
+    DO UPDATE SET harkinnanvarainen_only = NULL,
+                  last_checked           = NULL,
+                  skip_check             = false,
+                  application_id         = :application_id,
+                  check_after            =
+                      CASE
+                          WHEN harkinnanvaraisuus_process.check_after <= now() THEN EXCLUDED.check_after
+                          ELSE harkinnanvaraisuus_process.check_after END;
 
 -- name: yesql-fetch-harkinnanvaraisuus-unprocessed
 SELECT
@@ -10,7 +17,7 @@ SELECT
     application_key,
     haku_oid
 FROM harkinnanvaraisuus_process
-WHERE last_checked is NULL AND skip_check = false
+WHERE last_checked is NULL AND skip_check = false AND check_after < now()
 ORDER BY application_id ASC LIMIT 250;
 
 -- name: yesql-skip-checking-harkinnanvaraisuus-processes!

--- a/spec/ataru/harkinnanvaraisuus/harkinnanvaraisuus_job_spec.clj
+++ b/spec/ataru/harkinnanvaraisuus/harkinnanvaraisuus_job_spec.clj
@@ -157,12 +157,15 @@
                             (jdbc/delete! conn :forms
                                           ["id = ?" id])))
 
-(defn- init [application]
-  (let [form (form-store/create-new-form! form-fixtures/person-info-form)
-        stored (application-store/add-application (assoc application :form (:id form)) [] form {} audit-logger nil)]
-    (reset! test-form-id (:id form))
-    (reset! test-application-id (:id stored))
-    (store/upsert-harkinnanvaraisuus-process (:id stored) (:key stored) haku-key)))
+(defn- init
+  ([application]
+   (init application (time/now)))
+  ([application check-after]
+   (let [form (form-store/create-new-form! form-fixtures/person-info-form)
+         stored (application-store/add-application (assoc application :form (:id form)) [] form {} audit-logger nil)]
+     (reset! test-form-id (:id form))
+     (reset! test-application-id (:id stored))
+     (store/upsert-harkinnanvaraisuus-process (:id stored) (:key stored) haku-key check-after))))
 
 (defn- init-with-check [application runner]
   (init application)
@@ -207,6 +210,12 @@
                         (let [ops (->MockOhjausparametritServiceWithFuture)]
                           (check-harkinnanvaraisuus-handler {} {:ohjausparametrit-service ops :organization-service os :koodisto-cache fake-koodisto-cache :tarjonta-service ts :suoritus-service mock-suoritus-service :person-service fps})
                           (should= true (:skip_check (get-stored-process)))))
+
+                    (it "doesn't check application if check_after is in the future"
+                        (init (create-application) (time/plus (time/now) (time/minutes 1)))
+                        (let [ops (->MockOhjausparametritServiceWithFuture)]
+                          (check-harkinnanvaraisuus-handler {} {:ohjausparametrit-service ops :tarjonta-service ts :suoritus-service mock-suoritus-service :person-service fps})
+                          (should= nil (:last_checked (get-stored-process)))))
 
                     (it "checks application"
                         (init (create-application))

--- a/src/clj/ataru/hakija/background_jobs/hakija_jobs.clj
+++ b/src/clj/ataru/hakija/background_jobs/hakija_jobs.clj
@@ -25,9 +25,11 @@
                                                         :queue   default-retry-strategy}
    (:type attachment-finalizer-job/job-definition)     (merge attachment-finalizer-job/job-definition
                                                               {:queue default-retry-strategy})
-   "automatic-eligibility-if-ylioppilas-job"           {:handler automatic-eligibility/automatic-eligibility-if-ylioppilas-job-handler
-                                                        :type    "automatic-eligibility-if-ylioppilas-job"
-                                                        :queue   default-retry-strategy}
+   "automatic-eligibility-if-ylioppilas-job"           {:handler    automatic-eligibility/automatic-eligibility-if-ylioppilas-job-handler
+                                                        :type       "automatic-eligibility-if-ylioppilas-job"
+                                                        :queue      default-retry-strategy
+                                                        ; 20min viive, jotta Supa ehtii hakea tiedot Koskesta
+                                                        :process-in (Duration/ofMinutes 20)}
    "start-automatic-eligibility-if-ylioppilas-job-job" {:handler  automatic-eligibility/start-automatic-eligibility-if-ylioppilas-job-job-handler
                                                         :type     "start-automatic-eligibility-if-ylioppilas-job-job"
                                                         :schedule "0 7 * * *"

--- a/src/clj/ataru/hakija/hakija_application_service.clj
+++ b/src/clj/ataru/hakija/hakija_application_service.clj
@@ -365,7 +365,7 @@
                                        (get latest-application :key "NEW_APPLICATION_KEY"))
         harkinnanvaraisuus-process-fn (when (and haku (h/toisen-asteen-yhteishaku? haku))
                                         (fn [application-id application-key]
-                                          (harkinnanvaraisuus-store/upsert-harkinnanvaraisuus-process application-id application-key (:haku application))))]
+                                          (harkinnanvaraisuus-store/upsert-harkinnanvaraisuus-process application-id application-key (:haku application) (time/plus (time/now) (time/minutes 20)))))]
     (when (not-empty cannot-edit-fields)
       (log/warnf "Skipping uneditable updated answers in application %s: %s" (:key latest-application) (str (vec cannot-edit-fields))))
     (when (not-empty hakeminen-tunnistautuneena-validation-errors)

--- a/src/clj/ataru/harkinnanvaraisuus/harkinnanvaraisuus_process_store.clj
+++ b/src/clj/ataru/harkinnanvaraisuus/harkinnanvaraisuus_process_store.clj
@@ -14,10 +14,11 @@
 (defn- execute [yesql-query-fn params]
   (exec :db yesql-query-fn params))
 
-(defn upsert-harkinnanvaraisuus-process [application-id application-key haku-oid]
+(defn upsert-harkinnanvaraisuus-process [application-id application-key haku-oid check-after]
   (execute yesql-upsert-harkinnanvaraisuus-process! {:application_id application-id
-                                                    :application_key application-key
-                                                    :haku_oid haku-oid}))
+                                                     :application_key application-key
+                                                     :haku_oid haku-oid
+                                                     :check_after check-after}))
 
 (defn fetch-unprocessed-harkinnanvaraisuus-processes []
   (execute yesql-fetch-harkinnanvaraisuus-unprocessed nil))


### PR DESCRIPTION
Lisätään 20 minuutin viive hakukelpoisuuden ja harkinnanvaraisuuden tarkistuksiin. Supa tarvitsee aikaa saadakseen tiedot koskesta.

Hakukelpoisuuden tarkistukseen voi laittaa jobiin 20 minuutin viiveen suoraan, mutta harkinnanvaraisuudessa on käytössä oma systeeminsä. Tähän lisätään uusi kenttä, joka pitää kirjaa koska tarkastus tulisi tehdä. Jos tarkastus on jo alkamassa, aikaa ei siirretä myöhempään.