### PR TITLE
OY-5548: Massamuutos - toiminnan parannus:

### DIFF
--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -673,6 +673,14 @@ ON CONFLICT (application_key, requirement, hakukohde)
   WHERE hakukohde IS NOT NULL
   DO UPDATE SET state = :state, modified_time = :modified_time;
 
+-- name: yesql-get-bulk-processing-state-reviews
+SELECT application_key, hakukohde
+FROM application_hakukohde_reviews
+WHERE application_key IN (:application_keys)
+  AND requirement = 'processing-state'
+  AND state = :from_state
+  AND hakukohde IN (:hakukohde_oids);
+
 -- name: yesql-get-existing-application-hakukohde-review
 SELECT id
 FROM application_hakukohde_reviews

--- a/resources/sql/application-queries.sql
+++ b/resources/sql/application-queries.sql
@@ -681,6 +681,57 @@ WHERE application_key IN (:application_keys)
   AND state = :from_state
   AND hakukohde IN (:hakukohde_oids);
 
+-- name: yesql-bulk-update-processing-state-reviews!
+UPDATE application_hakukohde_reviews
+SET state = :to_state,
+    modified_time = :modified_time
+WHERE application_key IN (:application_keys)
+  AND requirement = 'processing-state'
+  AND state = :from_state
+  AND hakukohde IN (:hakukohde_oids);
+
+-- name: yesql-get-missing-processing-state-reviews-for-latest-applications
+WITH latest_applications AS (
+  SELECT a.key, unnest(a.hakukohde) AS hakukohde
+  FROM applications AS a
+  LEFT JOIN applications AS la ON la.key = a.key AND la.id > a.id
+  WHERE la.id IS NULL
+    AND a.key IN (:application_keys)
+)
+SELECT la.key AS application_key, la.hakukohde
+FROM latest_applications AS la
+LEFT JOIN application_hakukohde_reviews AS ahr
+  ON ahr.application_key = la.key
+ AND ahr.requirement = 'processing-state'
+ AND ahr.hakukohde = la.hakukohde
+WHERE la.hakukohde IN (:hakukohde_oids)
+  AND ahr.application_key IS NULL;
+
+-- name: yesql-create-missing-processing-state-reviews!
+INSERT INTO application_hakukohde_reviews (application_key, requirement, state, hakukohde, modified_time)
+SELECT missing.application_key,
+       'processing-state',
+       :to_state,
+       missing.hakukohde,
+       :modified_time
+FROM (
+  WITH latest_applications AS (
+    SELECT a.key, unnest(a.hakukohde) AS hakukohde
+    FROM applications AS a
+    LEFT JOIN applications AS la ON la.key = a.key AND la.id > a.id
+    WHERE la.id IS NULL
+      AND a.key IN (:application_keys)
+  )
+  SELECT la.key AS application_key, la.hakukohde
+  FROM latest_applications AS la
+  LEFT JOIN application_hakukohde_reviews AS ahr
+    ON ahr.application_key = la.key
+   AND ahr.requirement = 'processing-state'
+   AND ahr.hakukohde = la.hakukohde
+  WHERE la.hakukohde IN (:hakukohde_oids)
+    AND ahr.application_key IS NULL
+) AS missing;
+
 -- name: yesql-get-existing-application-hakukohde-review
 SELECT id
 FROM application_hakukohde_reviews

--- a/spec/ataru/applications/application_service_spec.clj
+++ b/spec/ataru/applications/application_service_spec.clj
@@ -1,5 +1,6 @@
 (ns ataru.applications.application-service-spec
   (:require [ataru.applications.application-service :as application-service]
+            [ataru.applications.application-access-control :as aac]
             [ataru.person-service.person-service :as person-service]
             [ataru.applications.application-store :as application-store]
             [speclj.core :refer [describe tags it should== should=]]
@@ -141,3 +142,31 @@
     )
   )
 )
+
+(describe "Mass update application states"
+  (tags :unit)
+
+  (it "returns the actual number of updated application states"
+    (let [session {:identity {:oid "1.2.3"}}
+          service (application-service/map->CommonApplicationService
+                   {:organization-service nil
+                    :tarjonta-service     nil
+                    :audit-logger         nil})]
+      (with-redefs [aac/applications-access-authorized? (constantly true)
+                    application-store/mass-update-application-states (fn [passed-session application-keys hakukohde-oids from-state to-state audit-logger]
+                                                                       (should= session passed-session)
+                                                                       (should= ["application-1" "application-2"] application-keys)
+                                                                       (should= ["hakukohde-1"] hakukohde-oids)
+                                                                       (should= "unprocessed" from-state)
+                                                                       (should= "processing" to-state)
+                                                                       (should= nil audit-logger)
+                                                                       0)]
+        (should=
+          0
+          (application-service/mass-update-application-states
+           service
+           session
+           ["application-1" "application-2"]
+           ["hakukohde-1"]
+           "unprocessed"
+           "processing"))))))

--- a/spec/ataru/applications/application_store_db_spec.clj
+++ b/spec/ataru/applications/application_store_db_spec.clj
@@ -474,7 +474,57 @@
           :requirement     "processing-state"
           :state           "processing"}]
         (mapv #(select-keys % [:application-key :hakukohde :requirement :state])
-              (store/get-application-hakukohde-reviews application-key-3))))))
+              (store/get-application-hakukohde-reviews application-key-3)))))
+
+  (it "treats missing processing-state reviews as unprocessed in mass update"
+    (let [application-ids (unit-test-db/init-db-fixture
+                            form-fixtures/minimal-form
+                            [{:form       (:id form-fixtures/minimal-form)
+                              :lang       "fi"
+                              :person-oid "1.2.3.4.5.201"
+                              :hakukohde  ["1.2.246.562.29.11111111110"]
+                              :answers    []}
+                             {:form       (:id form-fixtures/minimal-form)
+                              :lang       "fi"
+                              :person-oid "1.2.3.4.5.202"
+                              :hakukohde  ["1.2.246.562.29.11111111110"]
+                              :answers    []}])
+          [application-key-1 application-key-2] (mapv find-application-key-by-id application-ids)
+          audit-logger      (audit-log/new-dummy-audit-logger)
+          session           {:identity {:oid                      "1.2.246.562.11.11111111111"
+                                        :user-right-organizations {:edit-applications [{:oid "1.2.246.562.10.00000000001"}]}}}]
+      (db/exec :db yesql-upsert-virkailija<! {:oid        "1.2.246.562.11.11111111111"
+                                              :first_name "Testi"
+                                              :last_name  "Virkailija"})
+      (unit-test-db/init-db-application-hakukohde-review-fixture
+        {:hakukohde          "1.2.246.562.29.11111111110"
+         :review-requirement "processing-state"
+         :review-state       "unprocessed"}
+        application-key-1
+        audit-logger)
+      (should=
+        2
+        (store/mass-update-application-states
+          session
+          [application-key-1 application-key-2]
+          ["1.2.246.562.29.11111111110"]
+          "unprocessed"
+          "processing"
+          audit-logger))
+      (should==
+        [{:application-key application-key-1
+          :hakukohde       "1.2.246.562.29.11111111110"
+          :requirement     "processing-state"
+          :state           "processing"}]
+        (mapv #(select-keys % [:application-key :hakukohde :requirement :state])
+              (store/get-application-hakukohde-reviews application-key-1)))
+      (should==
+        [{:application-key application-key-2
+          :hakukohde       "1.2.246.562.29.11111111110"
+          :requirement     "processing-state"
+          :state           "processing"}]
+        (mapv #(select-keys % [:application-key :hakukohde :requirement :state])
+              (store/get-application-hakukohde-reviews application-key-2))))))
 
 
 (def ^:dynamic *tutu-application-key-1* (atom nil))

--- a/spec/ataru/applications/application_store_db_spec.clj
+++ b/spec/ataru/applications/application_store_db_spec.clj
@@ -9,7 +9,11 @@
             [ataru.fixtures.form :as form-fixtures]
             [ataru.util :as util]
             [clojure.java.jdbc :as jdbc]
-            [speclj.core :refer [after around around-all context describe it should-be-nil should= should== tags]]))
+            [speclj.core :refer [after around around-all context describe it should-be-nil should= should== tags]]
+            [yesql.core :as sql]))
+
+(declare yesql-upsert-virkailija<!)
+(sql/defqueries "sql/virkailija-queries.sql")
 
 (def ^:private form (atom nil))
 
@@ -395,6 +399,82 @@
                                     (should== 1 (store/delete-orphan-attachment-reviews (:key application)
                                                                                         [(first new-reviews)]
                                                                                         connection)))))))
+
+(describe "mass update application states"
+  (tags :unit :database)
+
+  (it "updates only matching processing-state reviews and returns the updated count"
+    (let [application-ids (unit-test-db/init-db-fixture
+                            form-fixtures/minimal-form
+                            [{:form       (:id form-fixtures/minimal-form)
+                              :lang       "fi"
+                              :person-oid "1.2.3.4.5.101"
+                              :hakukohde  ["1.2.246.562.29.11111111110"]
+                              :answers    []}
+                             {:form       (:id form-fixtures/minimal-form)
+                              :lang       "fi"
+                              :person-oid "1.2.3.4.5.102"
+                              :hakukohde  ["1.2.246.562.29.11111111110"]
+                              :answers    []}
+                             {:form       (:id form-fixtures/minimal-form)
+                              :lang       "fi"
+                              :person-oid "1.2.3.4.5.103"
+                              :hakukohde  ["1.2.246.562.29.11111111119"]
+                              :answers    []}])
+          [application-key-1 application-key-2 application-key-3] (mapv find-application-key-by-id application-ids)
+          session {:identity {:oid                      "1.2.246.562.11.11111111111"
+                              :user-right-organizations {:edit-applications [{:oid "1.2.246.562.10.00000000001"}]}}}]
+      (db/exec :db yesql-upsert-virkailija<! {:oid        "1.2.246.562.11.11111111111"
+                                              :first_name "Testi"
+                                              :last_name  "Virkailija"})
+      (unit-test-db/init-db-application-hakukohde-review-fixture
+        {:hakukohde          "1.2.246.562.29.11111111110"
+         :review-requirement "processing-state"
+         :review-state       "processing"}
+        application-key-1
+        audit-logger)
+      (unit-test-db/init-db-application-hakukohde-review-fixture
+        {:hakukohde          "1.2.246.562.29.11111111110"
+         :review-requirement "processing-state"
+         :review-state       "unprocessed"}
+        application-key-2
+        audit-logger)
+      (unit-test-db/init-db-application-hakukohde-review-fixture
+        {:hakukohde          "1.2.246.562.29.11111111119"
+         :review-requirement "processing-state"
+         :review-state       "processing"}
+        application-key-3
+        audit-logger)
+      (should=
+        1
+        (store/mass-update-application-states
+          session
+          [application-key-1 application-key-2 application-key-3]
+          ["1.2.246.562.29.11111111110"]
+          "processing"
+          "unprocessed"
+          audit-logger))
+      (should==
+        [{:application-key application-key-1
+          :hakukohde       "1.2.246.562.29.11111111110"
+          :requirement     "processing-state"
+          :state           "unprocessed"}]
+        (mapv #(select-keys % [:application-key :hakukohde :requirement :state])
+              (store/get-application-hakukohde-reviews application-key-1)))
+      (should==
+        [{:application-key application-key-2
+          :hakukohde       "1.2.246.562.29.11111111110"
+          :requirement     "processing-state"
+          :state           "unprocessed"}]
+        (mapv #(select-keys % [:application-key :hakukohde :requirement :state])
+              (store/get-application-hakukohde-reviews application-key-2)))
+      (should==
+        [{:application-key application-key-3
+          :hakukohde       "1.2.246.562.29.11111111119"
+          :requirement     "processing-state"
+          :state           "processing"}]
+        (mapv #(select-keys % [:application-key :hakukohde :requirement :state])
+              (store/get-application-hakukohde-reviews application-key-3))))))
 
 
 (def ^:dynamic *tutu-application-key-1* (atom nil))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -1436,27 +1436,44 @@
         (jdbc/with-db-transaction [connection {:datasource (db/get-datasource :db)}]
           (let [modified-time  (time/now)
                 reviews-to-update (queries/yesql-get-bulk-processing-state-reviews
-                                  {:application_keys application-keys
-                                   :hakukohde_oids   hakukohde-oids
-                                   :from_state       from-state}
-                                  {:connection connection})
-                grouped-updates (group-by :application_key reviews-to-update)
+                                    {:application_keys application-keys
+                                     :hakukohde_oids   hakukohde-oids
+                                     :from_state       from-state}
+                                    {:connection connection})
+                missing-unprocessed-reviews (if (= "unprocessed" from-state)
+                                             (queries/yesql-get-missing-processing-state-reviews-for-latest-applications
+                                               {:application_keys application-keys
+                                                :hakukohde_oids   hakukohde-oids}
+                                               {:connection connection})
+                                             [])
+                changed-reviews (into (vec reviews-to-update) missing-unprocessed-reviews)
+                grouped-updates (group-by :application_key changed-reviews)
                 application-event-base {:event_type               "hakukohde-review-state-change"
                                         :new_review_state         to-state
                                         :virkailija_oid           (-> session :identity :oid)
                                         :virkailija_organizations (edit-application-right-organizations->json session)
                                         :review_key               "processing-state"}]
-            (doseq [{:keys [application_key hakukohde]} reviews-to-update]
-              (queries/yesql-upsert-application-hakukohde-review! {:application_key application_key
-                                                                   :requirement    "processing-state"
-                                                                   :state          to-state
-                                                                   :hakukohde      hakukohde
-                                                                   :modified_time  modified-time}
-                                                                  {:connection connection})
-              (queries/yesql-add-application-event<! (assoc application-event-base
-                                                            :application_key application_key
-                                                            :hakukohde hakukohde)
-                                                     {:connection connection}))
+            (when (seq reviews-to-update)
+              (queries/yesql-bulk-update-processing-state-reviews!
+                {:application_keys application-keys
+                 :hakukohde_oids   hakukohde-oids
+                 :from_state       from-state
+                 :to_state         to-state
+                 :modified_time    modified-time}
+                {:connection connection})
+              )
+            (when (seq missing-unprocessed-reviews)
+              (queries/yesql-create-missing-processing-state-reviews!
+                {:application_keys application-keys
+                 :hakukohde_oids   hakukohde-oids
+                 :to_state         to-state
+                 :modified_time    modified-time}
+                {:connection connection}))
+            (doseq [{:keys [application_key hakukohde]} changed-reviews]
+                (queries/yesql-add-application-event<! (assoc application-event-base
+                                                              :application_key application_key
+                                                              :hakukohde hakukohde)
+                                                       {:connection connection}))
             {:audit-log-entries (mapv (fn [[application-key reviews]]
                                         (create-processing-state-change-audit-log-entry
                                           session
@@ -1464,7 +1481,7 @@
                                           (map :hakukohde reviews)
                                           to-state))
                                       grouped-updates)
-             :updated-count     (count reviews-to-update)}))]
+             :updated-count     (count changed-reviews)}))]
     (doseq [audit-log-entry audit-log-entries]
       (audit-log/log audit-logger audit-log-entry))
     updated-count))

--- a/src/clj/ataru/applications/application_store.clj
+++ b/src/clj/ataru/applications/application_store.clj
@@ -1403,38 +1403,21 @@
   ([haku-oid]
   (get-person-and-application-oids haku-oid nil)))
 
-(defn- update-hakukohde-process-state!
-  [connection session hakukohde-oids from-state to-state application-key]
-  (let [application      (get-latest-application-by-key-in-tx connection
-                                                              application-key)
-        existing-reviews (filter
-                          #(= (:state %) from-state)
-                          (application-states/get-all-reviews-for-requirement "processing-state" application hakukohde-oids))
-        new-reviews      (map
-                          #(-> %
-                               (assoc :state to-state)
-                               (assoc :modified_time (time/now))
-                               (assoc :application_key application-key))
-                          existing-reviews)
-        new-event        {:application_key          application-key
-                          :event_type               "hakukohde-review-state-change"
-                          :new_review_state         to-state
-                          :virkailija_oid           (-> session :identity :oid)
-                          :virkailija_organizations (edit-application-right-organizations->json session)
-                          :first_name               (:first-name session)
-                          :last_name                (:last-name session)
-                          :review_key               "processing-state"}]
-    (doseq [new-review new-reviews]
-      (queries/yesql-upsert-application-hakukohde-review! new-review {:connection connection})
-      (queries/yesql-add-application-event<! (assoc new-event :hakukohde (:hakukohde new-review))
-                                             {:connection connection}))
-    (when new-reviews
-      {:new       new-event
-       :id        {:applicationOid application-key
-                   :hakukohdeOids (clojure.string/join ", " (set (map :hakukohde existing-reviews)))
-                   :requirement    "processing-state"}
-       :operation audit-log/operation-modify
-       :session   session})))
+(defn- create-processing-state-change-audit-log-entry
+  [session application-key hakukohde-oids to-state]
+  {:new       {:application_key          application-key
+               :event_type               "hakukohde-review-state-change"
+               :new_review_state         to-state
+               :virkailija_oid           (-> session :identity :oid)
+               :virkailija_organizations (edit-application-right-organizations->json session)
+               :first_name               (:first-name session)
+               :last_name                (:last-name session)
+               :review_key               "processing-state"}
+   :id        {:applicationOid application-key
+               :hakukohdeOids (clojure.string/join ", " (set hakukohde-oids))
+               :requirement    "processing-state"}
+   :operation audit-log/operation-modify
+   :session   session})
 
 (defn applications-authorization-data [application-keys]
   (map ->kebab-case-kw
@@ -1449,13 +1432,42 @@
 (defn mass-update-application-states
   [session application-keys hakukohde-oids from-state to-state audit-logger]
   (log/info "Mass updating" (count application-keys) "applications from" from-state "to" to-state "with hakukohtees" hakukohde-oids)
-  (let [audit-log-entries (jdbc/with-db-transaction [connection {:datasource (db/get-datasource :db)}]
-                            (mapv
-                             (partial update-hakukohde-process-state! connection session hakukohde-oids from-state to-state)
-                             application-keys))]
-    (doseq [audit-log-entry (filter some? audit-log-entries)]
+  (let [{:keys [audit-log-entries updated-count]}
+        (jdbc/with-db-transaction [connection {:datasource (db/get-datasource :db)}]
+          (let [modified-time  (time/now)
+                reviews-to-update (queries/yesql-get-bulk-processing-state-reviews
+                                  {:application_keys application-keys
+                                   :hakukohde_oids   hakukohde-oids
+                                   :from_state       from-state}
+                                  {:connection connection})
+                grouped-updates (group-by :application_key reviews-to-update)
+                application-event-base {:event_type               "hakukohde-review-state-change"
+                                        :new_review_state         to-state
+                                        :virkailija_oid           (-> session :identity :oid)
+                                        :virkailija_organizations (edit-application-right-organizations->json session)
+                                        :review_key               "processing-state"}]
+            (doseq [{:keys [application_key hakukohde]} reviews-to-update]
+              (queries/yesql-upsert-application-hakukohde-review! {:application_key application_key
+                                                                   :requirement    "processing-state"
+                                                                   :state          to-state
+                                                                   :hakukohde      hakukohde
+                                                                   :modified_time  modified-time}
+                                                                  {:connection connection})
+              (queries/yesql-add-application-event<! (assoc application-event-base
+                                                            :application_key application_key
+                                                            :hakukohde hakukohde)
+                                                     {:connection connection}))
+            {:audit-log-entries (mapv (fn [[application-key reviews]]
+                                        (create-processing-state-change-audit-log-entry
+                                          session
+                                          application-key
+                                          (map :hakukohde reviews)
+                                          to-state))
+                                      grouped-updates)
+             :updated-count     (count reviews-to-update)}))]
+    (doseq [audit-log-entry audit-log-entries]
       (audit-log/log audit-logger audit-log-entry))
-    true))
+    updated-count))
 
 (defn add-application-event-in-tx [conn event session]
   (-> {:event_type               nil

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -560,16 +560,17 @@
                      :from-state       (apply s/enum (map first review-states/application-hakukohde-processing-states))
                      :to-state         (apply s/enum (map first review-states/application-hakukohde-processing-states))}]
         :summary "Update list of application-hakukohde with given state to new state"
-        (if (application-service/mass-update-application-states
-              application-service
-              session
-              (:application-keys body)
-              (if-let [hakukohde-oid (:hakukohde-oid body)]
-                  [hakukohde-oid]
-                  (:hakukohde-oids-for-hakukohderyhma body))
-              (:from-state body)
-              (:to-state body))
-          (response/ok {:updated-count (count (:application-keys body))})
+        (if-some [updated-count
+                  (application-service/mass-update-application-states
+                    application-service
+                    session
+                    (:application-keys body)
+                    (if-let [hakukohde-oid (:hakukohde-oid body)]
+                      [hakukohde-oid]
+                      (:hakukohde-oids-for-hakukohderyhma body))
+                    (:from-state body)
+                    (:to-state body))]
+          (response/ok {:updated-count updated-count})
           (response/unauthorized {:error (str "Hakemusten "
                                               (clojure.string/join ", " (:application-keys body))
                                               " käsittely ei ole sallittu")})))

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1853,6 +1853,12 @@
    :mass-edit                                                {:fi "Massamuutos"
                                                               :sv "Massändring"
                                                               :en "Mass editing"}
+   :mass-edit-updating                                       {:fi "Massamuutos käynnissä"
+                                                              :sv "Massändring pågår"
+                                                              :en "Mass update in progress"}
+   :mass-edit-updated                                        {:fi "Massamuutos valmis"
+                                                              :sv "Massändring klar"
+                                                              :en "Mass update completed"}
    :mass-edit-header                                         {:fi "Muuta käsittelyvaihetta"
                                                               :sv "Ändra behandlingsstatus"
                                                               :en "Change processing status"}

--- a/src/cljs/ataru/virkailija/application/application_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/application_subs.cljs
@@ -342,6 +342,14 @@
      (get-in db [:application :mass-review-notes :form-status]))))
 
 (re-frame/reg-sub
+ :application/mass-update-form-status
+ (fn [db]
+   (cond (get-in db [:application :fetching-applications?])
+         :loading-applications
+         :else
+         (get-in db [:application :mass-update :form-status]))))
+
+(re-frame/reg-sub
   :application/mass-information-request-only-guardian-enabled?
   (fn [_ _]
     [(re-frame/subscribe [:application/selected-haku-oid])
@@ -1123,5 +1131,4 @@
   :application/forms
   (fn forms [db _]
     (get-in db [:forms])))
-
 

--- a/src/cljs/ataru/virkailija/application/handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/handlers.cljs
@@ -986,9 +986,14 @@
 
 (reg-event-fx
  :application/handle-mass-update-application-reviews
- (fn [_ _]
-   {:delayed-dispatch {:dispatch-vec [:application/reload-applications]
-                       :delay        500}}))
+ (fn [{:keys [db]} _]
+   {:db             (assoc-in db [:application :mass-update :form-status] :submitted)
+    :dispatch-later [{:ms 500
+                      :dispatch [:application/reload-applications]}
+                     {:ms 1500
+                      :dispatch [:application/set-mass-update-popup-visibility false]}
+                     {:ms 1500
+                      :dispatch [:application/set-mass-update-form-state :enabled]}]}))
 
 (reg-event-fx
  :application/resend-modify-application-link
@@ -1290,4 +1295,3 @@
  :application/select-application-tab
  (fn select-application-tab [db [_ tab]]
    (assoc-in db [:application :tab] tab)))
-

--- a/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_handlers.cljs
+++ b/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_handlers.cljs
@@ -8,6 +8,11 @@
     (assoc-in db [:application :mass-update :visible?] visible?)))
 
 (reg-event-db
+ :application/set-mass-update-form-state
+ (fn [db [_ state]]
+   (assoc-in db [:application :mass-update :form-status] state)))
+
+(reg-event-db
  :application/set-mass-update-popup-tab
  (fn [db [_ tab-name]]
    (assoc-in db [:application :mass-update :open-tab] tab-name)))
@@ -20,7 +25,8 @@
 (reg-event-fx
   :application/mass-update-application-reviews
   (fn [{:keys [db]} [_ from-state to-state]]
-    {:http {:method              :post
+    {:dispatch [:application/set-mass-update-form-state :submitting]
+     :http {:method              :post
             :params              {:application-keys (map :key (get-in db [:application :applications]))
                                   :from-state       from-state
                                   :to-state         to-state
@@ -28,7 +34,8 @@
                                                         (-> db :application :selected-hakukohde))
                                   :hakukohde-oids-for-hakukohderyhma (hakukohde-oids-from-selected-hakukohde-or-hakukohderyhma db)}
             :path                "/lomake-editori/api/applications/mass-update"
-            :handler-or-dispatch :application/handle-mass-update-application-reviews}}))
+            :handler-or-dispatch :application/handle-mass-update-application-reviews
+            :override-args       {:error-handler #(dispatch [:application/handle-mass-update-application-reviews-error])}}}))
 
 (reg-event-fx
  :application/mass-inactivate-applications
@@ -104,6 +111,11 @@
  (fn [_ _]
    {:dispatch-n [[:application/set-mass-inactivation-message ""]
                  [:application/reload-applications]]}))
+
+(reg-event-fx
+ :application/handle-mass-update-application-reviews-error
+ (fn [_ _]
+   {:dispatch [:application/set-mass-update-form-state :enabled]}))
 
 
 (reg-event-db

--- a/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_view.cljs
+++ b/src/cljs/ataru/virkailija/application/mass_review/virkailija_mass_review_view.cljs
@@ -144,6 +144,7 @@
         haku-header                (subscribe [:application/list-heading-data-for-haku])
         review-state-counts        (subscribe [:state-query [:application :review-state-counts]])
         loading?                   (subscribe [:application/fetching-applications?])
+        form-status                (subscribe [:application/mass-update-form-status])
         form-key                   @(subscribe [:application/selected-form-key])
         tutu-form?                 @(subscribe [:payment/tutu-form? form-key])
         astu-form?                 @(subscribe [:payment/astu-form? form-key])
@@ -192,7 +193,18 @@
               (reset! submit-button-state :submit))
             (selected-or-default-mass-review-state-label selected-to-review-state processing-states-with-counts @review-state-counts)))]
 
-       (case @submit-button-state
+       (case @form-status
+         :submitting
+         [:div.application-handling__mass-review-notes-status
+          [:i.zmdi.zmdi-hc-lg.zmdi-spinner.spin.application-handling__mass-review-notes-status-icon]
+          @(subscribe [:editor/virkailija-translation :mass-edit-updating])]
+
+         :submitted
+         [:div.application-handling__mass-review-notes-status
+          [:i.zmdi.zmdi-hc-lg.zmdi-check-circle.application-handling__mass-review-notes-status-icon.application-handling__mass-review-notes-status-icon--sent]
+          @(subscribe [:editor/virkailija-translation :mass-edit-updated])]
+
+         (case @submit-button-state
          :submit
          (let [button-disabled? (or (= (selected-or-default-mass-review-state selected-from-review-state processing-states-with-counts)
                                        (selected-or-default-mass-review-state selected-to-review-state processing-states-with-counts))
@@ -214,12 +226,9 @@
                          (dispatch [:application/mass-update-application-reviews
                                     from-state-name
                                     to-state-name])
-                         (dispatch [:application/set-mass-update-popup-visibility false])
-                         (reset! selected-from-review-state nil)
-                         (reset! selected-to-review-state nil)
                          (reset! from-list-open? false)
                          (reset! to-list-open? false)))}
-          @(subscribe [:editor/virkailija-translation :confirm-change])])])))
+          @(subscribe [:editor/virkailija-translation :confirm-change])]))])))
 
 (defn mass-update-applications-link
   []


### PR DESCRIPTION
- modaaliin lisätty spinneri ja teksti "Massamuutos käynnissä" napin painalluksen jälkeen + modaali on auki kun backend-pyyntö on vielä "pending" tilassa
- backendissä: tilan päivtystä optimoitu hakemalla kaikki review-rivit yhdellä bulk-kyselyllä, päivitys nyt kohdistuu vain hakemuksiin, jotka täsmää annettuun tilaan
- lisätty uusi db-spec - "mass update application states"