### PR TITLE
OY-5673: muuta linkkiohjeistusta

### DIFF
--- a/playwright/tests/virkailija-editor.spec.ts
+++ b/playwright/tests/virkailija-editor.spec.ts
@@ -488,6 +488,26 @@ test.describe('Editori', () => {
     await expect(dropdownKoodisto).toBeHidden()
   })
 
+  test('infotekstin markdown-ohje näyttää linkkiesimerkin tooltip-muodossa', async () => {
+    const toolbar = componentToolbar(page)
+    await toolbar.hover()
+    await toolbar.getByText('Infoteksti', { exact: true }).click()
+
+    const infoElement = page.getByTestId(
+      'editor-form__infoElement-component-wrapper'
+    )
+    await expect(infoElement).toBeVisible()
+    const markdownHelpText = await infoElement
+      .locator('.editor-form__markdown-help-content')
+      .textContent()
+    expect(markdownHelpText).toContain(
+      '[linkin teksti](http://linkin osoite "kerro mihin linkki vie")'
+    )
+
+    await clickRemoveAndConfirm(infoElement)
+    await expect(infoElement).toBeHidden()
+  })
+
   test('lomakkeen lukitseminen ja lukituksen avaaminen', async () => {
     await page.locator('#lock-form').click()
 

--- a/src/cljc/ataru/translations/texts.cljc
+++ b/src/cljc/ataru/translations/texts.cljc
@@ -1982,9 +1982,9 @@
    :md-help-cursive                                          {:fi "*kursivoitava sisältö*"
                                                               :sv "*med kursiv stil*"
                                                               :en "*cursive content*"}
-   :md-help-link                                             {:fi "[linkin teksti](http://linkin osoite)"
-                                                              :sv "[länkens text](http://länkens adress)"
-                                                              :en "[link text](http://link address)"}
+   :md-help-link                                             {:fi "[linkin teksti](http://linkin osoite \"kerro mihin linkki vie\")"
+                                                              :sv "[länkens text](http://länkens adress \"berätta vart länken leder\")"
+                                                              :en "[link text](http://link address \"describe where the link goes\")"}
    :md-help-more                                             {:fi "Lisää muotoiluohjeita"
                                                               :sv "Lägg till anvisningar för utformning"
                                                               :en "More instructions"}

--- a/src/cljs/ataru/virkailija/editor/components/info_component.cljs
+++ b/src/cljs/ataru/virkailija/editor/components/info_component.cljs
@@ -37,6 +37,7 @@
     (fn [initial-content path]
       (let [applying-as-identified-enabled? (subscribe [:editor/allow-hakeminen-tunnistautuneena?])]
         [:div.editor-form__component-wrapper
+         {:data-test-id "editor-form__infoElement-component-wrapper"}
          [text-header-component/text-header (:id initial-content) @(subscribe [:editor/virkailija-translation :info-element]) path (:metadata initial-content)
           :sub-header @sub-header]
          [component-content/component-content


### PR DESCRIPTION
Päivitetään markdown-ohjesyntaksin linkkiesimerkki lisäämällä tooltip-parametri käännöksiin. Lisätään myös playwright-testi, joka varmistaa ohjetekstin sisällön.