### PR TITLE
OY-5712/OY-5653: vaihda url: maksut-ui -> maksut

### DIFF
--- a/resources/ataru-oph.properties
+++ b/resources/ataru-oph.properties
@@ -130,7 +130,7 @@ url.valintojen-toteuttaminen.hakemus = ${url-virkailija}/valintojen-toteuttamine
 
 maksut-service = ${url-virkailija}/maksut
 
-maksut-service.hakija-get-by-secret = ${url-hakija}/maksut-ui/$2?secret=$1
+maksut-service.hakija-get-by-secret = ${url-hakija}/maksut/$2?secret=$1
 maksut-service.hakija-create = ${url-hakija}/maksut/api/lasku
 
 maksut-service.virkailija-create = ${maksut-service}/api/lasku

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -157,7 +157,7 @@
     (str/includes? (:subject mail-content) (str "(Hakemusnumero: " application-key ")"))
     (str/includes? (:body mail-content) "Voit maksaa hakemusmaksun alla olevan linkin kautta:")
     (str/includes? (:body mail-content) (str "Hakemusnumerosi on: " application-key))
-    (str/includes? (:body mail-content) (str "maksut-ui/fi?secret=" test-maksut-secret))
+    (str/includes? (:body mail-content) (str "maksut/fi?secret=" test-maksut-secret))
     (str/includes? (:body mail-content) "Olet hakenut haussa: testing2")
     (str/includes? (:body mail-content) "https://opintopolku.fi/konfo/fi/sivu/hakemusmaksu")))
 
@@ -425,7 +425,7 @@
                                         (str/includes? (:body mail-content) (str "Your application number is: " application-key))
                                         (str/includes? (:body mail-content) "You can find more information about the application fee and exemptions from the fee on our")
                                         (str/includes? (:body mail-content) "https://opintopolku.fi/konfo/en/sivu/application-fee")
-                                        (str/includes? (:body mail-content) (str "maksut-ui/en?secret=" test-maksut-secret))))
+                                        (str/includes? (:body mail-content) (str "maksut/en?secret=" test-maksut-secret))))
                       _ (updater-job/update-kk-payment-status-for-person-handler
                           {:person_oid test-person-oid :term test-term :year test-year} runner)
                       payment (first (payment/get-raw-payments [application-key]))]
@@ -454,7 +454,7 @@
                                         (str/includes? (:body mail-content) (str "Ditt ansökningsnummer är: " application-key))
                                         (str/includes? (:body mail-content) "Du hittar mer information om ansökningsavgiften och grunderna för befrielse från avgiften på vår")
                                         (str/includes? (:body mail-content) "https://opintopolku.fi/konfo/sv/sivu/ansoekningsavgift")
-                                        (str/includes? (:body mail-content) (str "maksut-ui/sv?secret=" test-maksut-secret))))
+                                        (str/includes? (:body mail-content) (str "maksut/sv?secret=" test-maksut-secret))))
                       _ (updater-job/update-kk-payment-status-for-person-handler
                           {:person_oid test-person-oid :term test-term :year test-year} runner)
                       payment (first (payment/get-raw-payments [application-key]))]


### PR DESCRIPTION
## Muutos

Päivitetään maksut-ui:hin osoittava URL `/maksut-ui/` → `/maksut/` maksut-repon migraation (OY-5653) johdosta.

## Muutetut tiedostot

- `resources/ataru-oph.properties`: `maksut-service.hakija-get-by-secret`-URL päivitetty
- `spec/.../kk_application_payment_status_updater_job_spec.clj`: testien URL-assertiot päivitetty (fi, en, sv)

## Riippuvuudet

Vaatii, että maksut PR #61 ja nginx PR #150 on deployattu ensin. Nginx-tasolla on 302-redirect `/maksut-ui/` → `/maksut/`, joten tämä muutos ei ole kriittinen ennen kuin nginx-muutos on voimassa.