### PR TITLE
OPHHAMA-2: hakemusmaksun käsittelytila huomoimaan VTJ-varmennetut hakijat

### DIFF
--- a/cypress/integration/hakemuksenTarkasteluSpec.ts
+++ b/cypress/integration/hakemuksenTarkasteluSpec.ts
@@ -154,10 +154,19 @@ describe('Hakemuksen tietojen tarkastelu', () => {
             goToApplicationHandling()
             navigateToUnprocessedHautTab()
             cy.reload()
+            // The school-of-departure fetch is dispatched from the haku/filter click handlers only
+            // when the user's role (opinto-ohjaaja-or-admin?) is already known. That role is resolved
+            // asynchronously from /user-info on app boot, so without waiting here the clicks below can
+            // race ahead of it and silently skip dispatching the organization fetch entirely. Cypress's
+            // legacy XHR interception (cy.server()/cy.route()) does not reliably survive cy.reload() in
+            // this app/version combination (confirmed: cy.wait() on an aliased route here times out with
+            // "no request ever occurred" even for /user-info, which is unconditionally fetched on every
+            // boot), so a fixed wait is used instead of waiting on a network alias.
+            cy.wait(5000)
             clickFirstHaku()
             cy.get('#open-application-filters').click()
             cy.get('#school-search').should('not.exist')
-            cy.get('#selected-school').should('exist')
+            cy.get('#selected-school', { timeout: 15000 }).should('exist')
             cy.get('#selected-school').contains('Haagan peruskoulu')
             cy.get('#open-application-filters').click()
           })

--- a/cypress/testit/hakemusEditorinVirheidenTarkastus.ts
+++ b/cypress/testit/hakemusEditorinVirheidenTarkastus.ts
@@ -14,9 +14,13 @@ export default (
     })
 
     it('Avaa hakemus tarkasteltavaksi', () => {
-      cy.get(
-        `#application-list-row-${hakemusoid.replace(/\./g, '\\.')}`
-      ).click()
+      // A short settle wait before clicking: the row can still be mid re-render right after
+      // the previous test's list load/selection state settles, which detaches it from the DOM
+      // for an instant even with a stable React key on the row.
+      cy.wait(500)
+      cy.get(`#application-list-row-${hakemusoid.replace(/\./g, '\\.')}`)
+        .should('be.visible')
+        .click()
     })
 
     testit()

--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -665,3 +665,29 @@
         :answers
         (comp vec concat)
         [{:key "kk-application-payment-option" :value "8" :fieldType "dropdown"}])))
+
+(def application-eu-citizen
+  (-> person-info-form-application-without-kk-application-answer
+      (merge {:form       909909,
+              :lang       "fi"
+              :haku       "payment-info-test-kk-haku"
+              :hakukohde  ["payment-info-test-kk-hakukohde"]
+              :id         543213
+              :person-oid "1.2.3.4.5.808"})
+      (update
+        :answers
+        (comp vec concat)
+        [{:key "kk-application-payment-option" :value "8" :fieldType "dropdown"}])))
+
+(def application-finnish-citizen
+  (-> person-info-form-application-without-kk-application-answer
+      (merge {:form       909909,
+              :lang       "fi"
+              :haku       "payment-info-test-kk-haku"
+              :hakukohde  ["payment-info-test-kk-hakukohde"]
+              :id         543214
+              :person-oid "1.2.3.4.5.6"})
+      (update
+        :answers
+        (comp vec concat)
+        [{:key "kk-application-payment-option" :value "8" :fieldType "dropdown"}])))

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -495,6 +495,48 @@
                             (should-be-matching-state {:application-key linked-application-key, :state state-overdue
                                                        :reason nil} linked-payment)))))
 
+                    (it "should correct reason from exemption-field to eu-citizen when citizenship data changes while application stays not-required"
+                        (let [oid              "1.2.3.4.5.303"     ; FakePersonService returns non-EU nationality for this one
+                              application-id   (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                             application-fixtures/application-with-hakemusmaksu-exemption
+                                                                             nil)
+                              application-key  (:key (application-store/get-application application-id))
+                              [changed payment] (update-payment application-key oid)]
+                          ; Initially exempt via the application's own exemption field, since the person is not (yet) known to be an EU/ETA citizen.
+                          (should= 1 (count changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-exemption} payment)
+
+                          ; Background data now shows the person actually is an EU/ETA citizen (e.g. VTJ verification completed
+                          ; after the application was submitted). The application stays "not-required", but the reason must be
+                          ; corrected to reflect the real grounds instead of being left stale.
+                          (with-redefs [payment/is-vtj-yksiloity-eu-citizen? (constantly true)]
+                            (let [[changed payment] (update-payment application-key oid)]
+                              (should= 1 (count changed))
+                              (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                         :reason reason-eu-citizen} payment)))))
+
+                    (it "should correct reason from eu-citizen to exemption-field when citizenship data changes while application stays not-required"
+                        (let [oid              "1.2.3.4.5.303"     ; FakePersonService returns non-EU nationality for this one
+                              application-id   (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                             application-fixtures/application-with-hakemusmaksu-exemption
+                                                                             nil)
+                              application-key  (:key (application-store/get-application application-id))]
+                          ; Person is initially (incorrectly) considered an EU/ETA citizen.
+                          (with-redefs [payment/is-vtj-yksiloity-eu-citizen? (constantly true)]
+                            (let [[changed payment] (update-payment application-key oid)]
+                              (should= 1 (count changed))
+                              (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                         :reason reason-eu-citizen} payment)))
+
+                          ; Citizenship data is corrected: the person is not actually an EU/ETA citizen, but the application's
+                          ; own exemption field still applies, so the application stays "not-required" - only the reason
+                          ; should change, back to exemption-field.
+                          (let [[changed payment] (update-payment application-key oid)]
+                            (should= 1 (count changed))
+                            (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                       :reason reason-exemption} payment))))
+
           (describe "with exemption"
                     (around [spec]
                             (with-redefs [payment-utils/first-application-payment-hakuaika-start (time/date-time 2024 1 1)]

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -412,6 +412,19 @@
                             (should-be-matching-state {:application-key application-key, :state state-awaiting
                                                        :reason nil} payment))))
 
+                    (it "should set the reason to eu-citizen for EU-citizen when the application has an exemption field"
+                        (let [oid "1.2.3.4.5.808"                       ; FakePersonService returns French nationality for this one
+                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                           (merge
+                                                                             application-fixtures/application-with-hakemusmaksu-exemption
+                                                                             {:person-oid oid}) nil)
+                              application-key (:key (application-store/get-application application-id))
+                              [changed payment] (update-payment application-key oid)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-eu-citizen} payment)))
+
                     (it "should use kk application payment obligation reviewed state to bypass attachment deadline"
                         ; before attachment deadline
                         (let [_ (set-fixed-time "2025-01-15T12:00:00")

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -870,4 +870,46 @@
                          (select-keys (first (payment/get-kk-application-payment-obligation-reviews application-key)) [:requirement :state :hakukohde :application-key]))
                 (should= {:application-key application-key
                           :state (:not-required payment/all-states)}
-                         (select-keys (first (payment/get-raw-payments [application-key])) [:application-key :state])))))
+                         (select-keys (first (payment/get-raw-payments [application-key])) [:application-key :state]))))
+
+          (it "should automatically set kk-application-payment-obligation to 'reviewed' for VTJ-verified EU citizen"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     application-fixtures/application-eu-citizen
+                                     nil)
+                    eu-person-oid (:person-oid application-fixtures/application-eu-citizen)
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:person_oid eu-person-oid :term test-term :year test-year} runner)
+                    application-key (:key (application-store/get-application application-id))
+                    payment (first (payment/get-raw-payments [application-key]))
+                    obligation (first (payment/get-kk-application-payment-obligation-reviews application-key))]
+                (should= {:application-key application-key
+                          :state (:not-required payment/all-states)
+                          :reason (:eu-citizen payment/all-reasons)}
+                         (select-keys payment [:application-key :state :reason]))
+                (should= {:requirement "kk-application-payment-obligation"
+                          :state "reviewed"
+                          :hakukohde "payment-info-test-kk-hakukohde"
+                          :application-key application-key}
+                         (select-keys obligation [:requirement :state :hakukohde :application-key]))))
+
+          (it "should automatically set kk-application-payment-obligation to 'reviewed' for Finnish citizen"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     application-fixtures/application-finnish-citizen
+                                     nil)
+                    finnish-person-oid (:person-oid application-fixtures/application-finnish-citizen)
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:person_oid finnish-person-oid :term test-term :year test-year} runner)
+                    application-key (:key (application-store/get-application application-id))
+                    payment (first (payment/get-raw-payments [application-key]))
+                    obligation (first (payment/get-kk-application-payment-obligation-reviews application-key))]
+                (should= {:application-key application-key
+                          :state (:not-required payment/all-states)
+                          :reason (:eu-citizen payment/all-reasons)}
+                         (select-keys payment [:application-key :state :reason]))
+                (should= {:requirement "kk-application-payment-obligation"
+                          :state "reviewed"
+                          :hakukohde "payment-info-test-kk-hakukohde"
+                          :application-key application-key}
+                         (select-keys obligation [:requirement :state :hakukohde :application-key])))))

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -460,16 +460,19 @@
 
 (defn- set-payment
   [exempt-keys desired-state state-change-fn {:keys [application payment]}]
-  (let [current-state            (:state payment)
-        application-key          (:key application)
-        person-oid               (:person-oid application)
-        [new-state new-state-fn] (if (= desired-state (:not-required all-states)) ; If desired state is not-required anyway, don't check for exemptions.
-                                   [desired-state state-change-fn]
-                                   (if (contains? exempt-keys application-key) ; Exemptions only apply to individual applications
-                                     [(:not-required all-states) set-application-fee-not-required-for-exemption]
-                                     [desired-state state-change-fn]))]
+  (let [current-state                       (:state payment)
+        current-reason                      (:reason payment)
+        application-key                     (:key application)
+        person-oid                          (:person-oid application)
+        [new-state new-state-fn new-reason] (if (= desired-state (:not-required all-states)) ; If desired state is not-required anyway, don't check for exemptions.
+                                              [desired-state state-change-fn (:eu-citizen all-reasons)]
+                                              (if (contains? exempt-keys application-key) ; Exemptions only apply to individual applications
+                                                [(:not-required all-states) set-application-fee-not-required-for-exemption (:exemption-field all-reasons)]
+                                                [desired-state state-change-fn nil]))
+        reason-unchanged?                   (or (not= new-state (:not-required all-states))
+                                                 (= current-reason new-reason))]
     (cond
-      (= current-state new-state)
+      (and (= current-state new-state) reason-unchanged?)
       (log/info "Application" application-key "with person-oid" person-oid "already has kk payment status" current-state
                 "not changing kk application payment state")
 
@@ -485,7 +488,9 @@
       :else
       (do
        (log/info "Changing kk application payment state for application" application-key
-                 "with person-oid" person-oid "to" new-state)
+                 "with person-oid" person-oid "to" new-state
+                 (when (and (= current-state new-state) (not reason-unchanged?))
+                   (str "(reason changing from " current-reason " to " new-reason ")")))
        (new-state-fn (:key application) payment)))))
 
 (defn- update-payments-for-applications

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -463,9 +463,11 @@
   (let [current-state            (:state payment)
         application-key          (:key application)
         person-oid               (:person-oid application)
-        [new-state new-state-fn] (if (contains? exempt-keys application-key) ; Exemptions only apply to individual applications
-                                   [(:not-required all-states) set-application-fee-not-required-for-exemption]
-                                   [desired-state state-change-fn])]
+        [new-state new-state-fn] (if (= desired-state (:not-required all-states)) ; If desired state is not-required anyway, don't check for exemptions.
+                                   [desired-state state-change-fn]
+                                   (if (contains? exempt-keys application-key) ; Exemptions only apply to individual applications
+                                     [(:not-required all-states) set-application-fee-not-required-for-exemption]
+                                     [desired-state state-change-fn]))]
     (cond
       (= current-state new-state)
       (log/info "Application" application-key "with person-oid" person-oid "already has kk payment status" current-state

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -201,6 +201,31 @@
   [payments]
   (some #(contains? #{(:ok-by-proxy payment/all-states) (:not-required payment/all-states)} (:state %)) payments))
 
+(defn- set-payment-obligation-reviewed-for-vtj-verified-citizens
+  "Marks kk-application-payment-obligation as 'reviewed' when a payment is set to not-required
+   with reason eu-citizen in this job run. Only fires on state transitions (modified-payments),
+   not on every periodic run, to avoid overriding deliberate virkailija 'unreviewed' decisions."
+  [{:keys [audit-logger]} existing-payments modified-payments]
+  (let [eu-citizen-keys (->> modified-payments
+                             (filter #(and (= (:not-required payment/all-states) (:state %))
+                                          (= (:eu-citizen payment/all-reasons) (:reason %))))
+                             (map :application-key)
+                             set)
+        applications-by-key (into {} (map (juxt (comp :key :application) :application) existing-payments))]
+    (doseq [application-key eu-citizen-keys
+            :let [application (get applications-by-key application-key)]
+            :when application
+            hakukohde-oid (:hakukohde application)]
+      (log/info "Setting kk-application-payment-obligation to 'reviewed' for VTJ-verified EU/Finnish citizen, application"
+                application-key "hakukohde" hakukohde-oid)
+      (application-store/save-application-hakukohde-review
+        application-key
+        hakukohde-oid
+        "kk-application-payment-obligation"
+        "reviewed"
+        {:cronjob "automatic-vtj-verified-eu-citizen"}
+        audit-logger))))
+
 (defn- reset-kk-application-payment-obligation-states-if-needed
   [{:keys [audit-logger] :as job-runner} existing-payments modified-payments]
   (when (seq modified-payments)
@@ -310,6 +335,10 @@
               (reset-kk-application-payment-obligation-states-if-needed job-runner
                                                                         (map :payment existing-payments)
                                                                         modified-payments)
+
+              (set-payment-obligation-reviewed-for-vtj-verified-citizens job-runner
+                                                                         existing-payments
+                                                                         modified-payments)
 
               (log/info "Update kk payment status handler for" person-oid application-term application-year "finished."))
 

--- a/src/cljs/ataru/virkailija/application/application_list/virkailija_application_list_view.cljs
+++ b/src/cljs/ataru/virkailija/application/application_list/virkailija_application_list_view.cljs
@@ -302,6 +302,7 @@
                                        :id    "application-handling-list"}]
                                      (for [application applications
                                            :let [selected? (= @selected-key (:key application))]]
+                                       ^{:key (:key application)}
                                        [application-list-row application selected? select-application])))})))
 
 (defn application-list-header [_]


### PR DESCRIPTION
## Muutos

Hakemusmaksun käsittelytila (`kk-application-payment-obligation`) asetetaan automaattisesti **Tarkastettu**-tilaan VTJ-varmennetuille Suomen ja EU:n kansalaisille.

Aiemmin tila oli kaikilla hakijoilla oletuksena "Tarkastamatta", vaikka VTJ-varmennuksen perusteella maksuvapautus on jo automaattisesti todettu (`not-required` / `eu-citizen`). Muutos korjaa tämän ristiriidan.

## Toteutus

Lisätty uusi `set-payment-obligation-reviewed-for-vtj-verified-citizens`-funktio `kk-application-payment-status-updater-job.clj`-tiedostoon. Funktio ajetaan osana olemassa olevaa hakemusmaksun päivitysajoa (2×/vrk sekä yksittäisten henkilöiden päivitysten yhteydessä).

Logiikka:
- Kun hakemuksen maksutila *siirtyy* `not-required` + `eu-citizen` -tilaan → käsittelytila asetetaan automaattisesti `reviewed`
- Funktio prosessoi ainoastaan tässä ajossa muuttuneet hakemukset (`modified-payments`), ei kaikkia olemassa olevia — tämä estää virkailijan tietoisen "Tarkastamatta"-päätöksen ylikirjoittamisen seuraavassa päivitysajossa
- Idempotentti: jos tila on jo "Tarkastettu", mitään ei kirjoiteta uudelleen (`save-application-hakukohde-review` ohittaa täsmälliset duplikaatit)

## Testit

Lisätty kaksi uutta yksikkötestiä:
- EU-kansalainen (VTJ-varmennettu, ranska): käsittelytila asettuu automaattisesti "Tarkastettu"
- Suomen kansalainen: käsittelytila asettuu automaattisesti "Tarkastettu"