### PR TITLE
OPHHAMA-4: Hakemusmaksun maksutilojen manuaalimuokkaukset Swaggerissa

### DIFF
--- a/resources/ataru-oph.properties
+++ b/resources/ataru-oph.properties
@@ -137,6 +137,9 @@ maksut-service.virkailija-create = ${maksut-service}/api/lasku
 maksut-service.virkailija-list = ${maksut-service}/api/lasku/$1
 maksut-service.virkailija-receipt = ${maksut-service}/api/kuitti/$1
 maksut-service.virkailija-invalidate = ${maksut-service}/api/lasku-invalidate
+maksut-service.virkailija-force-invalidate = ${maksut-service}/api/lasku-force-invalidate
+maksut-service.virkailija-delete = ${maksut-service}/api/lasku-delete
+maksut-service.virkailija-update-due-date = ${maksut-service}/api/lasku-update-due-date
 maksut-service.background-lasku-status = ${maksut-service}/api/lasku-check
 
 valpas.baseUrl = ${url-virkailija}/valpas

--- a/resources/sql/kk-application-payment-queries.sql
+++ b/resources/sql/kk-application-payment-queries.sql
@@ -92,3 +92,30 @@ WHERE application_key = :application_key;
 UPDATE kk_application_payments
 SET reminder_sent_at = now()
 WHERE application_key = :application_key;
+
+-- name: yesql-bulk-correct-not-required-returning
+UPDATE kk_application_payments
+SET state      = 'not-required',
+    reason     = :reason,
+    approved_at = now()
+WHERE application_key IN (:application_keys)
+  AND state IN ('overdue', 'awaiting', 'not-required')
+RETURNING application_key;
+
+-- name: yesql-bulk-correct-ok-by-proxy-returning
+UPDATE kk_application_payments
+SET state      = 'ok-by-proxy',
+    reason     = NULL,
+    approved_at = now()
+WHERE application_key IN (:application_keys)
+  AND state IN ('overdue', 'awaiting')
+RETURNING application_key;
+
+-- name: yesql-bulk-correct-awaiting-returning
+UPDATE kk_application_payments
+SET state    = 'awaiting',
+    reason   = NULL,
+    due_date = :due_date::date
+WHERE application_key IN (:application_keys)
+  AND state IN ('overdue', 'awaiting')
+RETURNING application_key;

--- a/spec/ataru/kk_application_payment/kk_application_payment_maksut_poller_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_maksut_poller_job_spec.clj
@@ -42,7 +42,10 @@
                                      (remove nil?)))
   (list-laskut-by-application-key [_ key] (if (= key "1.2.246.562.8.00000000000022225300")
                                             [{:secret "1234567890"}]
-                                            [])))
+                                            []))
+  (force-invalidate-laskut [_ _] nil)
+  (delete-laskut [_ _] nil)
+  (update-laskut-due-date [_ _ _] nil))
 
 (def mock-maksut-service (->MockMaksutService))
 

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -8,6 +8,7 @@
             [speclj.core :refer [describe tags it should-throw should= should-be-nil should-not-be-nil
                                  before around]]
             [ataru.kk-application-payment.kk-application-payment :as payment]
+            [ataru.maksut.maksut-protocol :as maksut-protocol]
             [clojure.java.jdbc :as jdbc]
             [ataru.db.db :as db]
             [ataru.cache.cache-service :as cache-service]
@@ -785,6 +786,142 @@
                           (should= 0 (count changed))
                           (should-be-matching-state {:application-key application-key, :state state-overdue
                                                      :reason nil} payment)))))
+
+(defn- make-mock-maksut-service []
+  (let [calls (atom [])]
+    {:service
+     (reify maksut-protocol/MaksutServiceProtocol
+       (create-kk-application-payment-lasku [_ _] nil)
+       (create-kasittely-lasku [_ _] nil)
+       (create-paatos-lasku [_ _] nil)
+       (list-lasku-statuses [_ _] nil)
+       (list-laskut-by-application-key [_ _] nil)
+       (download-receipt [_ _] nil)
+       (invalidate-laskut [_ _] nil)
+       (force-invalidate-laskut [_ keys]
+         (swap! calls conj {:method :force-invalidate-laskut :keys keys}))
+       (delete-laskut [_ keys]
+         (swap! calls conj {:method :delete-laskut :keys keys}))
+       (update-laskut-due-date [_ keys due-date]
+         (swap! calls conj {:method :update-laskut-due-date :keys keys :due-date due-date})))
+     :calls calls}))
+
+(describe "bulk-change-overdue-payment-state"
+          (tags :unit :kk-application-payment)
+
+          (before (delete-states-and-events!))
+
+          (it "should set state to not-required with eu-citizen reason and call delete-laskut"
+              (let [application-key "1.2.3.4.5.100"
+                    _ (payment/set-application-fee-overdue application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [application-key] state-not-required reason-eu-citizen nil)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= {:updated [application-key] :skipped []} result)
+                (should= state-not-required (:state updated))
+                (should= reason-eu-citizen (:reason updated))
+                (should-not-be-nil (:approved-at updated))
+                (should= 1 (count @calls))
+                (should= :delete-laskut (:method (first @calls)))
+                (should= [application-key] (:keys (first @calls)))))
+
+          (it "should set state to not-required with exemption-field reason and call delete-laskut"
+              (let [application-key "1.2.3.4.5.101"
+                    _ (payment/set-application-fee-overdue application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    _ (payment/bulk-change-overdue-payment-state
+                        service [application-key] state-not-required reason-exemption nil)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= state-not-required (:state updated))
+                (should= reason-exemption (:reason updated))
+                (should= :delete-laskut (:method (first @calls)))))
+
+          (it "should set state to ok-by-proxy and call force-invalidate-laskut"
+              (let [application-key "1.2.3.4.5.102"
+                    _ (payment/set-application-fee-overdue application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [application-key] state-ok-by-proxy nil nil)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= {:updated [application-key] :skipped []} result)
+                (should= state-ok-by-proxy (:state updated))
+                (should-be-nil (:reason updated))
+                (should-not-be-nil (:approved-at updated))
+                (should= 1 (count @calls))
+                (should= :force-invalidate-laskut (:method (first @calls)))
+                (should= [application-key] (:keys (first @calls)))))
+
+          (it "should set state to awaiting with new due date and call update-laskut-due-date"
+              (let [application-key "1.2.3.4.5.103"
+                    new-due-date "2030-01-15"
+                    _ (payment/set-application-fee-overdue application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [application-key] state-awaiting nil new-due-date)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= {:updated [application-key] :skipped []} result)
+                (should= state-awaiting (:state updated))
+                (should-be-nil (:reason updated))
+                (should-not-be-nil (:due-date updated))
+                (should= 1 (count @calls))
+                (should= :update-laskut-due-date (:method (first @calls)))
+                (should= [application-key] (:keys (first @calls)))
+                (should= new-due-date (:due-date (first @calls)))))
+
+          (it "should handle multiple application keys in bulk"
+              (let [keys ["1.2.3.4.5.110" "1.2.3.4.5.111" "1.2.3.4.5.112"]
+                    _ (doseq [k keys] (payment/set-application-fee-overdue k nil))
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service keys state-ok-by-proxy nil nil)
+                    payments (payment/get-raw-payments keys)]
+                (should= (set keys) (set (:updated result)))
+                (should= [] (:skipped result))
+                (should= 3 (count payments))
+                (should= #{state-ok-by-proxy} (set (map :state payments)))
+                (should= 1 (count @calls))
+                (should= (set keys) (set (:keys (first @calls))))))
+
+          (it "should only send actually-updated keys to maksut, skipping keys not in overdue/awaiting state"
+              (let [overdue-key "1.2.3.4.5.130"
+                    paid-key    "1.2.3.4.5.131"
+                    _ (payment/set-application-fee-overdue overdue-key nil)
+                    _ (payment/set-application-fee-paid paid-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [overdue-key paid-key] state-ok-by-proxy nil nil)]
+                (should= {:updated [overdue-key] :skipped [paid-key]} result)
+                (should= 1 (count @calls))
+                (should= [overdue-key] (:keys (first @calls)))))
+
+          (it "should update reason when transitioning not-required to not-required"
+              (let [application-key "1.2.3.4.5.140"
+                    _ (payment/set-application-fee-not-required-for-eu-citizen application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [application-key] state-not-required reason-exemption nil)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= {:updated [application-key] :skipped []} result)
+                (should= 1 (count @calls))
+                (should= :delete-laskut (:method (first @calls)))
+                (should= state-not-required (:state updated))
+                (should= reason-exemption (:reason updated))))
+
+          (it "should throw on invalid target state"
+              (let [{:keys [service]} (make-mock-maksut-service)]
+                (should-throw
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.120"] state-paid nil nil))))
+
+          (it "should throw when not-required is given without reason"
+              (let [{:keys [service]} (make-mock-maksut-service)]
+                (should-throw
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.121"] state-not-required nil nil))))
+
+          (it "should throw when awaiting is given without due-date"
+              (let [{:keys [service]} (make-mock-maksut-service)]
+                (should-throw
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.122"] state-awaiting nil nil)))))
 
 (describe "application payment states"
           (tags :unit :kk-application-payment)

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -8,6 +8,7 @@
             [speclj.core :refer [describe tags it should-throw should= should-be-nil should-not-be-nil
                                  before around]]
             [ataru.kk-application-payment.kk-application-payment :as payment]
+            [ataru.maksut.maksut-protocol :as maksut-protocol]
             [clojure.java.jdbc :as jdbc]
             [ataru.db.db :as db]
             [ataru.cache.cache-service :as cache-service]
@@ -772,6 +773,142 @@
                           (should= 0 (count changed))
                           (should-be-matching-state {:application-key application-key, :state state-overdue
                                                      :reason nil} payment)))))
+
+(defn- make-mock-maksut-service []
+  (let [calls (atom [])]
+    {:service
+     (reify maksut-protocol/MaksutServiceProtocol
+       (create-kk-application-payment-lasku [_ _] nil)
+       (create-kasittely-lasku [_ _] nil)
+       (create-paatos-lasku [_ _] nil)
+       (list-lasku-statuses [_ _] nil)
+       (list-laskut-by-application-key [_ _] nil)
+       (download-receipt [_ _] nil)
+       (invalidate-laskut [_ _] nil)
+       (force-invalidate-laskut [_ keys]
+         (swap! calls conj {:method :force-invalidate-laskut :keys keys}))
+       (delete-laskut [_ keys]
+         (swap! calls conj {:method :delete-laskut :keys keys}))
+       (update-laskut-due-date [_ keys due-date]
+         (swap! calls conj {:method :update-laskut-due-date :keys keys :due-date due-date})))
+     :calls calls}))
+
+(describe "bulk-change-overdue-payment-state"
+          (tags :unit :kk-application-payment)
+
+          (before (delete-states-and-events!))
+
+          (it "should set state to not-required with eu-citizen reason and call delete-laskut"
+              (let [application-key "1.2.3.4.5.100"
+                    _ (payment/set-application-fee-overdue application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [application-key] state-not-required reason-eu-citizen nil)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= {:updated [application-key] :skipped []} result)
+                (should= state-not-required (:state updated))
+                (should= reason-eu-citizen (:reason updated))
+                (should-not-be-nil (:approved-at updated))
+                (should= 1 (count @calls))
+                (should= :delete-laskut (:method (first @calls)))
+                (should= [application-key] (:keys (first @calls)))))
+
+          (it "should set state to not-required with exemption-field reason and call delete-laskut"
+              (let [application-key "1.2.3.4.5.101"
+                    _ (payment/set-application-fee-overdue application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    _ (payment/bulk-change-overdue-payment-state
+                        service [application-key] state-not-required reason-exemption nil)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= state-not-required (:state updated))
+                (should= reason-exemption (:reason updated))
+                (should= :delete-laskut (:method (first @calls)))))
+
+          (it "should set state to ok-by-proxy and call force-invalidate-laskut"
+              (let [application-key "1.2.3.4.5.102"
+                    _ (payment/set-application-fee-overdue application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [application-key] state-ok-by-proxy nil nil)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= {:updated [application-key] :skipped []} result)
+                (should= state-ok-by-proxy (:state updated))
+                (should-be-nil (:reason updated))
+                (should-not-be-nil (:approved-at updated))
+                (should= 1 (count @calls))
+                (should= :force-invalidate-laskut (:method (first @calls)))
+                (should= [application-key] (:keys (first @calls)))))
+
+          (it "should set state to awaiting with new due date and call update-laskut-due-date"
+              (let [application-key "1.2.3.4.5.103"
+                    new-due-date "2030-01-15"
+                    _ (payment/set-application-fee-overdue application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [application-key] state-awaiting nil new-due-date)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= {:updated [application-key] :skipped []} result)
+                (should= state-awaiting (:state updated))
+                (should-be-nil (:reason updated))
+                (should-not-be-nil (:due-date updated))
+                (should= 1 (count @calls))
+                (should= :update-laskut-due-date (:method (first @calls)))
+                (should= [application-key] (:keys (first @calls)))
+                (should= new-due-date (:due-date (first @calls)))))
+
+          (it "should handle multiple application keys in bulk"
+              (let [keys ["1.2.3.4.5.110" "1.2.3.4.5.111" "1.2.3.4.5.112"]
+                    _ (doseq [k keys] (payment/set-application-fee-overdue k nil))
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service keys state-ok-by-proxy nil nil)
+                    payments (payment/get-raw-payments keys)]
+                (should= (set keys) (set (:updated result)))
+                (should= [] (:skipped result))
+                (should= 3 (count payments))
+                (should= #{state-ok-by-proxy} (set (map :state payments)))
+                (should= 1 (count @calls))
+                (should= (set keys) (set (:keys (first @calls))))))
+
+          (it "should only send actually-updated keys to maksut, skipping keys not in overdue/awaiting state"
+              (let [overdue-key "1.2.3.4.5.130"
+                    paid-key    "1.2.3.4.5.131"
+                    _ (payment/set-application-fee-overdue overdue-key nil)
+                    _ (payment/set-application-fee-paid paid-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [overdue-key paid-key] state-ok-by-proxy nil nil)]
+                (should= {:updated [overdue-key] :skipped [paid-key]} result)
+                (should= 1 (count @calls))
+                (should= [overdue-key] (:keys (first @calls)))))
+
+          (it "should update reason when transitioning not-required to not-required"
+              (let [application-key "1.2.3.4.5.140"
+                    _ (payment/set-application-fee-not-required-for-eu-citizen application-key nil)
+                    {:keys [service calls]} (make-mock-maksut-service)
+                    result (payment/bulk-change-overdue-payment-state
+                             service [application-key] state-not-required reason-exemption nil)
+                    updated (first (payment/get-raw-payments [application-key]))]
+                (should= {:updated [application-key] :skipped []} result)
+                (should= 1 (count @calls))
+                (should= :delete-laskut (:method (first @calls)))
+                (should= state-not-required (:state updated))
+                (should= reason-exemption (:reason updated))))
+
+          (it "should throw on invalid target state"
+              (let [{:keys [service]} (make-mock-maksut-service)]
+                (should-throw
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.120"] state-paid nil nil))))
+
+          (it "should throw when not-required is given without reason"
+              (let [{:keys [service]} (make-mock-maksut-service)]
+                (should-throw
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.121"] state-not-required nil nil))))
+
+          (it "should throw when awaiting is given without due-date"
+              (let [{:keys [service]} (make-mock-maksut-service)]
+                (should-throw
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.122"] state-awaiting nil nil)))))
 
 (describe "application payment states"
           (tags :unit :kk-application-payment)

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -3,6 +3,7 @@
             [ataru.fixtures.form :as form-fixtures]
             [ataru.forms.form-store :as form-store]
             [ataru.koodisto.koodisto :as koodisto]
+            [ataru.log.audit-log :as audit-log]
             [ataru.person-service.person-service :as person-service]
             [ataru.time :as time]
             [speclj.core :refer [describe tags it should-throw should= should-be-nil should-not-be-nil
@@ -78,6 +79,8 @@
    :ohjausparametrit-service fake-ohjausparametrit-service
    :hakukohderyhma-settings-cache fake-hakukohderyhma-settings-cache
    :get-haut-cache fake-haku-cache})
+
+(def audit-logger (audit-log/new-dummy-audit-logger))
 
 (declare conn)
 (defn- delete-states-and-events! []
@@ -816,7 +819,7 @@
                     _ (payment/set-application-fee-overdue application-key nil)
                     {:keys [service calls]} (make-mock-maksut-service)
                     result (payment/bulk-change-overdue-payment-state
-                             service [application-key] state-not-required reason-eu-citizen nil)
+                             service [application-key] state-not-required reason-eu-citizen nil nil audit-logger)
                     updated (first (payment/get-raw-payments [application-key]))]
                 (should= {:updated [application-key] :skipped []} result)
                 (should= state-not-required (:state updated))
@@ -831,7 +834,7 @@
                     _ (payment/set-application-fee-overdue application-key nil)
                     {:keys [service calls]} (make-mock-maksut-service)
                     _ (payment/bulk-change-overdue-payment-state
-                        service [application-key] state-not-required reason-exemption nil)
+                        service [application-key] state-not-required reason-exemption nil nil audit-logger)
                     updated (first (payment/get-raw-payments [application-key]))]
                 (should= state-not-required (:state updated))
                 (should= reason-exemption (:reason updated))
@@ -842,7 +845,7 @@
                     _ (payment/set-application-fee-overdue application-key nil)
                     {:keys [service calls]} (make-mock-maksut-service)
                     result (payment/bulk-change-overdue-payment-state
-                             service [application-key] state-ok-by-proxy nil nil)
+                             service [application-key] state-ok-by-proxy nil nil nil audit-logger)
                     updated (first (payment/get-raw-payments [application-key]))]
                 (should= {:updated [application-key] :skipped []} result)
                 (should= state-ok-by-proxy (:state updated))
@@ -858,7 +861,7 @@
                     _ (payment/set-application-fee-overdue application-key nil)
                     {:keys [service calls]} (make-mock-maksut-service)
                     result (payment/bulk-change-overdue-payment-state
-                             service [application-key] state-awaiting nil new-due-date)
+                             service [application-key] state-awaiting nil new-due-date nil audit-logger)
                     updated (first (payment/get-raw-payments [application-key]))]
                 (should= {:updated [application-key] :skipped []} result)
                 (should= state-awaiting (:state updated))
@@ -874,7 +877,7 @@
                     _ (doseq [k keys] (payment/set-application-fee-overdue k nil))
                     {:keys [service calls]} (make-mock-maksut-service)
                     result (payment/bulk-change-overdue-payment-state
-                             service keys state-ok-by-proxy nil nil)
+                             service keys state-ok-by-proxy nil nil nil audit-logger)
                     payments (payment/get-raw-payments keys)]
                 (should= (set keys) (set (:updated result)))
                 (should= [] (:skipped result))
@@ -890,7 +893,7 @@
                     _ (payment/set-application-fee-paid paid-key nil)
                     {:keys [service calls]} (make-mock-maksut-service)
                     result (payment/bulk-change-overdue-payment-state
-                             service [overdue-key paid-key] state-ok-by-proxy nil nil)]
+                             service [overdue-key paid-key] state-ok-by-proxy nil nil nil audit-logger)]
                 (should= {:updated [overdue-key] :skipped [paid-key]} result)
                 (should= 1 (count @calls))
                 (should= [overdue-key] (:keys (first @calls)))))
@@ -900,7 +903,7 @@
                     _ (payment/set-application-fee-not-required-for-eu-citizen application-key nil)
                     {:keys [service calls]} (make-mock-maksut-service)
                     result (payment/bulk-change-overdue-payment-state
-                             service [application-key] state-not-required reason-exemption nil)
+                             service [application-key] state-not-required reason-exemption nil nil audit-logger)
                     updated (first (payment/get-raw-payments [application-key]))]
                 (should= {:updated [application-key] :skipped []} result)
                 (should= 1 (count @calls))
@@ -911,17 +914,17 @@
           (it "should throw on invalid target state"
               (let [{:keys [service]} (make-mock-maksut-service)]
                 (should-throw
-                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.120"] state-paid nil nil))))
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.120"] state-paid nil nil nil audit-logger))))
 
           (it "should throw when not-required is given without reason"
               (let [{:keys [service]} (make-mock-maksut-service)]
                 (should-throw
-                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.121"] state-not-required nil nil))))
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.121"] state-not-required nil nil nil audit-logger))))
 
           (it "should throw when awaiting is given without due-date"
               (let [{:keys [service]} (make-mock-maksut-service)]
                 (should-throw
-                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.122"] state-awaiting nil nil)))))
+                  (payment/bulk-change-overdue-payment-state service ["1.2.3.4.5.122"] state-awaiting nil nil nil audit-logger)))))
 
 (describe "application payment states"
           (tags :unit :kk-application-payment)

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -61,7 +61,10 @@
   (list-lasku-statuses [_ _] {})
   (list-laskut-by-application-key [_ _] [])
   (download-receipt [_ _] nil)
-  (invalidate-laskut [this keys] (invalidate-laskut-fn this keys)))
+  (invalidate-laskut [this keys] (invalidate-laskut-fn this keys))
+  (force-invalidate-laskut [_ _] nil)
+  (delete-laskut [_ _] nil)
+  (update-laskut-due-date [_ _ _] nil))
 
 (def mock-maksut-service (->MockMaksutService))
 

--- a/spec/ataru/tutkintojen_tunnustaminen_spec.clj
+++ b/spec/ataru/tutkintojen_tunnustaminen_spec.clj
@@ -68,7 +68,10 @@
      :origin "tutu"}])
   (list-laskut-by-application-key [_ _] [])
   (download-receipt [_ _] nil)
-  (invalidate-laskut [_ _] nil))
+  (invalidate-laskut [_ _] nil)
+  (force-invalidate-laskut [_ _] nil)
+  (delete-laskut [_ _] nil)
+  (update-laskut-due-date [_ _ _] nil))
 
 (def mock-maksut-service (->MockMaksutService))
 

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -6,6 +6,7 @@
   (:require [ataru.cache.cache-service :as cache]
             [ataru.util.deadline-util :as deadline]
             [ataru.kk-application-payment.kk-application-payment-store :as store]
+            [ataru.maksut.maksut-protocol :as maksut-protocol]
             [ataru.applications.application-store :as application-store]
             [ataru.forms.form-store :as form-store]
             [ataru.hakija.hakija-form-service :as hakija-form-service]
@@ -566,6 +567,69 @@
            (map #(vector (:application-key %) %) payments))))
   ([applications]
    (get-kk-payment-states applications :key)))
+
+(defn bulk-change-overdue-payment-state
+  "Corrects payment states in bulk for overdue (or awaiting) applications.
+  Supported transitions:
+    - 'not-required' with reason 'eu-citizen' or 'exemption-field': deletes invoices from maksut
+      (also updates the reason field if the key is already in not-required state)
+    - 'ok-by-proxy': force-invalidates invoices in maksut
+    - 'awaiting' with due-date: updates due date in ataru and maksut
+
+  Keys in the correct target state may still be updated (e.g. reason change for not-required).
+  The returned :updated list contains the application keys actually changed; :skipped contains the rest.
+
+  WARNING: The DB write and the maksut HTTP call are not atomic. If the HTTP call fails after
+  the DB write has committed, an exception is thrown with the actually-updated keys so that
+  an operator can manually compensate in maksut."
+  [maksut-service application-keys state reason due-date]
+  (if-not (get-in config [:kk-application-payments :enabled?])
+    {:updated [] :skipped []}
+    (do
+      (when (empty? application-keys)
+        (throw (ex-info "application-keys must not be empty" {})))
+      (let [valid-states  #{(:not-required all-states) (:ok-by-proxy all-states) (:awaiting all-states)}
+            valid-reasons #{(:eu-citizen all-reasons) (:exemption-field all-reasons)}]
+        (when-not (contains? valid-states state)
+          (throw (ex-info "Invalid target state for bulk correction"
+                          {:state state :valid-states valid-states})))
+        (when (and (= state (:not-required all-states))
+                   (not (contains? valid-reasons reason)))
+          (throw (ex-info "Invalid reason for not-required state"
+                          {:reason reason :valid-reasons valid-reasons})))
+        (when (and (= state (:awaiting all-states)) (nil? due-date))
+          (throw (ex-info "due-date is required for awaiting state" {:state state})))
+        (log/info "Bulk payment state correction starting: requested" (count application-keys)
+                  "keys, target state" state (when reason (str "reason=" reason)) (when due-date (str "due-date=" due-date))
+                  "| keys:" application-keys)
+        (let [{:keys [db-fn log-action maksut-fn]}
+              (case state
+                "not-required" {:db-fn      #(store/bulk-correct-not-required! application-keys reason)
+                                :log-action "delete-laskut"
+                                :maksut-fn  #(maksut-protocol/delete-laskut maksut-service %)}
+                "ok-by-proxy"  {:db-fn      #(store/bulk-correct-ok-by-proxy! application-keys)
+                                :log-action "force-invalidate-laskut"
+                                :maksut-fn  #(maksut-protocol/force-invalidate-laskut maksut-service %)}
+                "awaiting"     {:db-fn      #(store/bulk-correct-awaiting! application-keys due-date)
+                                :log-action "update-laskut-due-date"
+                                :maksut-fn  #(maksut-protocol/update-laskut-due-date maksut-service % due-date)})
+              updated-keys (db-fn)
+              skipped-keys (vec (remove (set updated-keys) application-keys))]
+          (log/info "DB write complete: updated" (count updated-keys) "of" (count application-keys) "keys"
+                    "| updated:" updated-keys
+                    (when (seq skipped-keys) (str "| skipped (wrong state): " skipped-keys)))
+          (when (seq updated-keys)
+            (log/info "Calling maksut" log-action "for" (count updated-keys) "keys:" updated-keys)
+            (try
+              (maksut-fn updated-keys)
+              (log/info "Maksut" log-action "succeeded for keys:" updated-keys)
+              (catch Exception e
+                (log/error e "Maksut" log-action "FAILED after DB write"
+                           "- manual reconciliation required in maksut for keys:" updated-keys)
+                (throw (ex-info "Maksut call failed after DB write; manual reconciliation required"
+                                {:updated-in-db updated-keys :state state :maksut-action log-action} e)))))
+          {:updated updated-keys
+           :skipped skipped-keys})))))
 
 (defn remove-kk-applications-with-unapproved-payments
   "Filters out applications that have payment info but yet been approved (paid, exempted) for their respective admissions.

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -6,6 +6,7 @@
   (:require [ataru.cache.cache-service :as cache]
             [ataru.util.deadline-util :as deadline]
             [ataru.kk-application-payment.kk-application-payment-store :as store]
+            [ataru.maksut.maksut-protocol :as maksut-protocol]
             [ataru.applications.application-store :as application-store]
             [ataru.forms.form-store :as form-store]
             [ataru.hakija.hakija-form-service :as hakija-form-service]
@@ -565,6 +566,69 @@
            (map #(vector (:application-key %) %) payments))))
   ([applications]
    (get-kk-payment-states applications :key)))
+
+(defn bulk-change-overdue-payment-state
+  "Corrects payment states in bulk for overdue (or awaiting) applications.
+  Supported transitions:
+    - 'not-required' with reason 'eu-citizen' or 'exemption-field': deletes invoices from maksut
+      (also updates the reason field if the key is already in not-required state)
+    - 'ok-by-proxy': force-invalidates invoices in maksut
+    - 'awaiting' with due-date: updates due date in ataru and maksut
+
+  Keys in the correct target state may still be updated (e.g. reason change for not-required).
+  The returned :updated list contains the application keys actually changed; :skipped contains the rest.
+
+  WARNING: The DB write and the maksut HTTP call are not atomic. If the HTTP call fails after
+  the DB write has committed, an exception is thrown with the actually-updated keys so that
+  an operator can manually compensate in maksut."
+  [maksut-service application-keys state reason due-date]
+  (if-not (get-in config [:kk-application-payments :enabled?])
+    {:updated [] :skipped []}
+    (do
+      (when (empty? application-keys)
+        (throw (ex-info "application-keys must not be empty" {})))
+      (let [valid-states  #{(:not-required all-states) (:ok-by-proxy all-states) (:awaiting all-states)}
+            valid-reasons #{(:eu-citizen all-reasons) (:exemption-field all-reasons)}]
+        (when-not (contains? valid-states state)
+          (throw (ex-info "Invalid target state for bulk correction"
+                          {:state state :valid-states valid-states})))
+        (when (and (= state (:not-required all-states))
+                   (not (contains? valid-reasons reason)))
+          (throw (ex-info "Invalid reason for not-required state"
+                          {:reason reason :valid-reasons valid-reasons})))
+        (when (and (= state (:awaiting all-states)) (nil? due-date))
+          (throw (ex-info "due-date is required for awaiting state" {:state state})))
+        (log/info "Bulk payment state correction starting: requested" (count application-keys)
+                  "keys, target state" state (when reason (str "reason=" reason)) (when due-date (str "due-date=" due-date))
+                  "| keys:" application-keys)
+        (let [{:keys [db-fn log-action maksut-fn]}
+              (case state
+                "not-required" {:db-fn      #(store/bulk-correct-not-required! application-keys reason)
+                                :log-action "delete-laskut"
+                                :maksut-fn  #(maksut-protocol/delete-laskut maksut-service %)}
+                "ok-by-proxy"  {:db-fn      #(store/bulk-correct-ok-by-proxy! application-keys)
+                                :log-action "force-invalidate-laskut"
+                                :maksut-fn  #(maksut-protocol/force-invalidate-laskut maksut-service %)}
+                "awaiting"     {:db-fn      #(store/bulk-correct-awaiting! application-keys due-date)
+                                :log-action "update-laskut-due-date"
+                                :maksut-fn  #(maksut-protocol/update-laskut-due-date maksut-service % due-date)})
+              updated-keys (db-fn)
+              skipped-keys (vec (remove (set updated-keys) application-keys))]
+          (log/info "DB write complete: updated" (count updated-keys) "of" (count application-keys) "keys"
+                    "| updated:" updated-keys
+                    (when (seq skipped-keys) (str "| skipped (wrong state): " skipped-keys)))
+          (when (seq updated-keys)
+            (log/info "Calling maksut" log-action "for" (count updated-keys) "keys:" updated-keys)
+            (try
+              (maksut-fn updated-keys)
+              (log/info "Maksut" log-action "succeeded for keys:" updated-keys)
+              (catch Exception e
+                (log/error e "Maksut" log-action "FAILED after DB write"
+                           "- manual reconciliation required in maksut for keys:" updated-keys)
+                (throw (ex-info "Maksut call failed after DB write; manual reconciliation required"
+                                {:updated-in-db updated-keys :state state :maksut-action log-action} e)))))
+          {:updated updated-keys
+           :skipped skipped-keys})))))
 
 (defn remove-kk-applications-with-unapproved-payments
   "Filters out applications that have payment info but yet been approved (paid, exempted) for their respective admissions.

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -19,6 +19,7 @@
             [taoensso.timbre :as log]
             [ataru.kk-application-payment.utils :as utils]
             [ataru.config.core :refer [config]]
+            [ataru.log.audit-log :as audit-log]
             [ataru.time.format :as time-format]
             [ataru.time.coerce :as coerce]
             [ataru.time :as time]
@@ -582,14 +583,17 @@
   WARNING: The DB write and the maksut HTTP call are not atomic. If the HTTP call fails after
   the DB write has committed, an exception is thrown with the actually-updated keys so that
   an operator can manually compensate in maksut."
-  [maksut-service application-keys state reason due-date]
+  [maksut-service application-keys state reason due-date session audit-logger]
   (if-not (get-in config [:kk-application-payments :enabled?])
     {:updated [] :skipped []}
     (do
       (when (empty? application-keys)
         (throw (ex-info "application-keys must not be empty" {})))
       (let [valid-states  #{(:not-required all-states) (:ok-by-proxy all-states) (:awaiting all-states)}
-            valid-reasons #{(:eu-citizen all-reasons) (:exemption-field all-reasons)}]
+            valid-reasons #{(:eu-citizen all-reasons) (:exemption-field all-reasons)}
+            reason (if (= state (:not-required all-states))
+                         reason
+                         nil)]
         (when-not (contains? valid-states state)
           (throw (ex-info "Invalid target state for bulk correction"
                           {:state state :valid-states valid-states})))
@@ -602,22 +606,31 @@
         (log/info "Bulk payment state correction starting: requested" (count application-keys)
                   "keys, target state" state (when reason (str "reason=" reason)) (when due-date (str "due-date=" due-date))
                   "| keys:" application-keys)
-        (let [{:keys [db-fn log-action maksut-fn]}
+        (let [{:keys [db-fn log-action maksut-fn log-value]}
               (case state
                 "not-required" {:db-fn      #(store/bulk-correct-not-required! application-keys reason)
                                 :log-action "delete-laskut"
+                                :log-value  {:state state :reason reason}
                                 :maksut-fn  #(maksut-protocol/delete-laskut maksut-service %)}
                 "ok-by-proxy"  {:db-fn      #(store/bulk-correct-ok-by-proxy! application-keys)
                                 :log-action "force-invalidate-laskut"
+                                :log-value  {:state state}
                                 :maksut-fn  #(maksut-protocol/force-invalidate-laskut maksut-service %)}
                 "awaiting"     {:db-fn      #(store/bulk-correct-awaiting! application-keys due-date)
                                 :log-action "update-laskut-due-date"
+                                :log-value  {:state state :due-date due-date}
                                 :maksut-fn  #(maksut-protocol/update-laskut-due-date maksut-service % due-date)})
               updated-keys (db-fn)
               skipped-keys (vec (remove (set updated-keys) application-keys))]
           (log/info "DB write complete: updated" (count updated-keys) "of" (count application-keys) "keys"
                     "| updated:" updated-keys
                     (when (seq skipped-keys) (str "| skipped (wrong state): " skipped-keys)))
+          (doseq [key updated-keys]
+            (audit-log/log audit-logger
+                           {:new       log-value
+                            :id        {:applicationOid key}
+                            :session   session
+                            :operation audit-log/operation-modify}))
           (when (seq updated-keys)
             (log/info "Calling maksut" log-action "for" (count updated-keys) "keys:" updated-keys)
             (try

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
@@ -15,6 +15,9 @@
 (declare yesql-update-maksut-secret!)
 (declare yesql-mark-reminder-sent!)
 (declare yesql-get-field-deadlines)
+(declare yesql-bulk-correct-not-required-returning)
+(declare yesql-bulk-correct-ok-by-proxy-returning)
+(declare yesql-bulk-correct-awaiting-returning)
 
 (def ^:private ->kebab-case-kw (partial transform-keys ->kebab-case-keyword))
 
@@ -65,6 +68,23 @@
   (->> (exec-db :db yesql-get-kk-application-payments-for-application-keys {:application_keys application-keys})
        (map ->kebab-case-kw)
        (map due-date-to-full-time-in-finnish-tz)))
+
+(defn bulk-correct-not-required!
+  [application-keys reason]
+  (->> (exec-db :db yesql-bulk-correct-not-required-returning {:application_keys application-keys
+                                                               :reason           reason})
+       (mapv :application_key)))
+
+(defn bulk-correct-ok-by-proxy!
+  [application-keys]
+  (->> (exec-db :db yesql-bulk-correct-ok-by-proxy-returning {:application_keys application-keys})
+       (mapv :application_key)))
+
+(defn bulk-correct-awaiting!
+  [application-keys due-date]
+  (->> (exec-db :db yesql-bulk-correct-awaiting-returning {:application_keys application-keys
+                                                           :due_date         due-date})
+       (mapv :application_key)))
 
 (defn create-or-update-kk-application-payment!
   [{:keys [application-key state reason due-date total-sum maksut-secret

--- a/src/clj/ataru/maksut/maksut_protocol.clj
+++ b/src/clj/ataru/maksut/maksut_protocol.clj
@@ -13,4 +13,10 @@
 
   (download-receipt [this order-id])
 
-  (invalidate-laskut [this application-keys]))
+  (invalidate-laskut [this application-keys])
+
+  (force-invalidate-laskut [this application-keys])
+
+  (delete-laskut [this application-keys])
+
+  (update-laskut-due-date [this application-keys due-date]))

--- a/src/clj/ataru/maksut/maksut_service.clj
+++ b/src/clj/ataru/maksut/maksut_service.clj
@@ -73,6 +73,45 @@
                                          " status: " (:status result)
                                          " response body: " (:body result))))))
 
+(defn- post-force-invalidate-laskut
+  "Force-invalidates maksut invoices regardless of due date (for overdue correction: ok-by-proxy)."
+  [maksut-cas-client keys]
+  (let [url    (url/resolve-url :maksut-service.virkailija-force-invalidate)
+        req    {:keys keys}
+        result (cas/cas-authenticated-post maksut-cas-client url req)]
+    (match/match result
+                 {:status 200 :body _} nil
+
+                 :else (throw-error (str "Could not force-invalidate laskut for keys " (str/join ", " keys)
+                                         " status: " (:status result)
+                                         " response body: " (:body result))))))
+
+(defn- post-delete-laskut
+  "Deletes maksut invoices and their secrets (for overdue correction: not-required)."
+  [maksut-cas-client keys]
+  (let [url    (url/resolve-url :maksut-service.virkailija-delete)
+        req    {:keys keys}
+        result (cas/cas-authenticated-post maksut-cas-client url req)]
+    (match/match result
+                 {:status 200 :body _} nil
+
+                 :else (throw-error (str "Could not delete laskut for keys " (str/join ", " keys)
+                                         " status: " (:status result)
+                                         " response body: " (:body result))))))
+
+(defn- post-update-laskut-due-date
+  "Updates due date on maksut invoices (for overdue correction: awaiting with new due date)."
+  [maksut-cas-client keys due-date]
+  (let [url    (url/resolve-url :maksut-service.virkailija-update-due-date)
+        req    {:keys keys :due-date due-date}
+        result (cas/cas-authenticated-post maksut-cas-client url req)]
+    (match/match result
+                 {:status 200 :body _} nil
+
+                 :else (throw-error (str "Could not update due date for keys " (str/join ", " keys)
+                                         " status: " (:status result)
+                                         " response body: " (:body result))))))
+
 (defrecord MaksutService [maksut-cas-client]
   MaksutServiceProtocol
 
@@ -99,7 +138,16 @@
     (receipt-get maksut-cas-client order-id))
 
   (invalidate-laskut [_ keys]
-    (post-invalidate-laskut maksut-cas-client keys)))
+    (post-invalidate-laskut maksut-cas-client keys))
+
+  (force-invalidate-laskut [_ keys]
+    (post-force-invalidate-laskut maksut-cas-client keys))
+
+  (delete-laskut [_ keys]
+    (post-delete-laskut maksut-cas-client keys))
+
+  (update-laskut-due-date [_ keys due-date]
+    (post-update-laskut-due-date maksut-cas-client keys due-date)))
 
 (defn new-maksut-service []
   (map->MaksutService {}))

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -91,7 +91,8 @@
             [ataru.virkailija.virkailija-application-service :as virkailija-application-service]
             [ataru.background-job.job :as job]
             [ataru.kk-application-payment.kk-application-payment-status-updater-job :as kk-application-payment-status-updater-job]
-            [ataru.kk-application-payment.kk-application-payment-maksut-poller-job :as kk-application-payment-maksut-poller-job])
+            [ataru.kk-application-payment.kk-application-payment-maksut-poller-job :as kk-application-payment-maksut-poller-job]
+            [ataru.kk-application-payment.kk-application-payment :as kk-application-payment])
   (:import java.util.Locale
            java.time.ZoneId
            java.time.ZonedDateTime
@@ -1193,7 +1194,26 @@
               (response/ok result))
             (response/unauthorized {:error (str "Hakemuksen "
                                                 reference
-                                                " käsittely ei ole sallittu")})))))
+                                                " käsittely ei ole sallittu")}))))
+
+      (api/POST "/hakemusmaksu/bulk-state-change" {session :session}
+        :body [input maksut-schema/BulkPaymentStateChange]
+        :return maksut-schema/BulkPaymentStateChangeResult
+        :summary "Korjaa erääntyneiden hakemusmaksujen tiloja. Vain OPH-pääkäyttäjälle."
+        :description "Päivittää hakemusmaksun tilan annetuille hakemuksille. Vain 'overdue'- tai 'awaiting'-tilassa olevat hakemukset päivitetään; muut ohitetaan (poikkeuksena 'not-required', ks. alla). Vastauksessa 'updated' sisältää oikeasti päivittyneet avaimet ja 'skipped' ohitetut.
+
+Tuetut tilamuutokset:
+- state='not-required', reason='eu-citizen' tai 'exemption-field': poistaa laskun. Päivittää myös olemassa olevan 'not-required'-tilan reason-kentän. due-date ei käytössä.
+- state='ok-by-proxy': merkitsee laskun mitätöidyksi. reason- ja due-date-kenttiä ei käytetä.
+- state='awaiting', due-date='YYYY-MM-DD': siirtää eräpäivää eteenpäin. reason ei käytössä.
+
+Huom: Massakorjaus ei ole atominen. Jos kutsu maksut-palveluun epäonnistuu, heitetään poikkeus ja manuaalinen korjaustoimenpide maksut-palveluun voi olla tarpeen."
+        (if (get-in session [:identity :superuser])
+          (let [{:keys [application-keys state reason due-date]} input]
+            (response/ok
+              (kk-application-payment/bulk-change-overdue-payment-state
+                maksut-service application-keys state reason due-date)))
+          (response/unauthorized {}))))
 
     (api/context "/tulos-service" []
       :tags ["tulos-service-api"]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -90,7 +90,8 @@
             [ataru.virkailija.virkailija-application-service :as virkailija-application-service]
             [ataru.background-job.job :as job]
             [ataru.kk-application-payment.kk-application-payment-status-updater-job :as kk-application-payment-status-updater-job]
-            [ataru.kk-application-payment.kk-application-payment-maksut-poller-job :as kk-application-payment-maksut-poller-job])
+            [ataru.kk-application-payment.kk-application-payment-maksut-poller-job :as kk-application-payment-maksut-poller-job]
+            [ataru.kk-application-payment.kk-application-payment :as kk-application-payment])
   (:import java.util.Locale
            java.time.ZoneId
            java.time.ZonedDateTime
@@ -1192,7 +1193,26 @@
               (response/ok result))
             (response/unauthorized {:error (str "Hakemuksen "
                                                 reference
-                                                " käsittely ei ole sallittu")})))))
+                                                " käsittely ei ole sallittu")}))))
+
+      (api/POST "/hakemusmaksu/bulk-state-change" {session :session}
+        :body [input maksut-schema/BulkPaymentStateChange]
+        :return maksut-schema/BulkPaymentStateChangeResult
+        :summary "Korjaa erääntyneiden hakemusmaksujen tiloja. Vain OPH-pääkäyttäjälle."
+        :description "Päivittää hakemusmaksun tilan annetuille hakemuksille. Vain 'overdue'- tai 'awaiting'-tilassa olevat hakemukset päivitetään; muut ohitetaan (poikkeuksena 'not-required', ks. alla). Vastauksessa 'updated' sisältää oikeasti päivittyneet avaimet ja 'skipped' ohitetut.
+
+Tuetut tilamuutokset:
+- state='not-required', reason='eu-citizen' tai 'exemption-field': poistaa laskun. Päivittää myös olemassa olevan 'not-required'-tilan reason-kentän. due-date ei käytössä.
+- state='ok-by-proxy': merkitsee laskun mitätöidyksi. reason- ja due-date-kenttiä ei käytetä.
+- state='awaiting', due-date='YYYY-MM-DD': siirtää eräpäivää eteenpäin. reason ei käytössä.
+
+Huom: Massakorjaus ei ole atominen. Jos kutsu maksut-palveluun epäonnistuu, heitetään poikkeus ja manuaalinen korjaustoimenpide maksut-palveluun voi olla tarpeen."
+        (if (get-in session [:identity :superuser])
+          (let [{:keys [application-keys state reason due-date]} input]
+            (response/ok
+              (kk-application-payment/bulk-change-overdue-payment-state
+                maksut-service application-keys state reason due-date)))
+          (response/unauthorized {}))))
 
     (api/context "/tulos-service" []
       :tags ["tulos-service-api"]

--- a/src/clj/ataru/virkailija/virkailija_routes.clj
+++ b/src/clj/ataru/virkailija/virkailija_routes.clj
@@ -1211,7 +1211,7 @@ Huom: Massakorjaus ei ole atominen. Jos kutsu maksut-palveluun epäonnistuu, hei
           (let [{:keys [application-keys state reason due-date]} input]
             (response/ok
               (kk-application-payment/bulk-change-overdue-payment-state
-                maksut-service application-keys state reason due-date)))
+                maksut-service application-keys state reason due-date session audit-logger)))
           (response/unauthorized {}))))
 
     (api/context "/tulos-service" []

--- a/src/cljc/ataru/schema/maksut_schema.cljc
+++ b/src/cljc/ataru/schema/maksut_schema.cljc
@@ -83,3 +83,33 @@
 (s/defschema TutuProcessingEmailRequest
   {:application-key s/Str
    :locale Locale})
+
+(defn- valid-iso-date? [s]
+  (boolean
+    (and (string? s)
+         #?(:clj  (try (java.time.LocalDate/parse s) true
+                       (catch java.time.format.DateTimeParseException _ false))
+            :cljs (when-let [[_ y m d] (re-matches #"(\d{4})-(\d{2})-(\d{2})" s)]
+                    (let [yi (js/parseInt y 10) mi (js/parseInt m 10) di (js/parseInt d 10)
+                          date (js/Date. yi (dec mi) di)]
+                      (and (= (.getFullYear date) yi)
+                           (= (.getMonth date) (dec mi))
+                           (= (.getDate date) di))))))))
+
+(s/defschema BulkPaymentStateChange
+  (s/constrained
+    {:application-keys                    (s/constrained [s/Str] seq 'non-empty-application-keys)
+     :state                               (s/enum "not-required" "ok-by-proxy" "awaiting")
+     (s/optional-key :reason)             (s/maybe (s/enum "eu-citizen" "exemption-field"))
+     (s/optional-key :due-date)           (s/maybe s/Str)}
+    (fn [{:keys [state reason due-date]}]
+      (cond
+        (= state "not-required") (contains? #{"eu-citizen" "exemption-field"} reason)
+        (= state "awaiting")     (valid-iso-date? due-date)
+        (= state "ok-by-proxy")  (and (nil? reason) (nil? due-date))
+        :else                    true))
+    'valid-state-reason-combination))
+
+(s/defschema BulkPaymentStateChangeResult
+  {:updated [s/Str]
+   :skipped [s/Str]})


### PR DESCRIPTION
## Muutos

Lisätään OPH-pääkäyttäjälle Swagger-rajapinta hakemusmaksun maksutilojen massaluonteiseen manuaalikorjaukseen. Tarve syntyy tilanteissa, joissa hakijoiden maksutilat ovat jääneet virheellisesti tilaan `overdue` tai `awaiting` ja niitä ei voida korjata normaalin automaattisen tilapäivityksen kautta.

## Uusi endpoint

`POST /virkailija/api/hakemusmaksu/bulk-state-change` — vain OPH-pääkäyttäjälle.

### Tuetut tilamuutokset

| Kohdetila | Pakolliset kentät | Mitä tapahtuu |
|---|---|---|
| `not-required` | `reason` (`eu-citizen` tai `exemption-field`) | Päivittää tilan, poistaa laskun maksut-palvelusta (`delete-laskut`). Toimii myös `not-required → not-required` reason-kentän vaihtamiseksi. |
| `ok-by-proxy` | — | Päivittää tilan, mitätöi laskun maksut-palvelussa (`force-invalidate-laskut`, toimii myös erääntyneille). |
| `awaiting` | `due-date` (ISO 8601) | Päivittää tilan ja eräpäivän, siirtää eräpäivää maksut-palvelussa (`update-laskut-due-date`). |

Vain `overdue`- tai `awaiting`-tilassa olevat hakemukset päivitetään (poikkeuksena `not-required`-kohde, joka toimii myös olemassa olevalle `not-required`-tilalle). Muut ohitetaan hiljaisesti.

Vastaus palauttaa `updated`- ja `skipped`-listat, joista näkee mitkä avaimet oikeasti päivittyivät.

## Tekniset muutokset

- **SQL** (`kk-application-payment-queries.sql`): Kolme uutta `UPDATE ... RETURNING application_key` -kyselyä, jotka palauttavat oikeasti päivittyneet rivit.
- **Store** (`kk_application_payment_store.clj`): Kolme uutta bulk-funktiota jotka palauttavat päivittyneet application-keyt.
- **Domain** (`kk_application_payment.clj`): `bulk-change-overdue-payment-state` — validoi syötteet, kirjoittaa DB:hen, kutsuu maksut-palvelua päivittyneiden avainten perusteella. Sisältää kattavan lokituksen ja virheenkäsittelyn.
- **Protokolla** (`maksut_protocol.clj`) + **palvelu** (`maksut_service.clj`): Kolme uutta protokollametodia maksut-palvelun uusille endpointeille (`force-invalidate-laskut`, `delete-laskut`, `update-laskut-due-date`).
- **Schema** (`maksut_schema.cljc`): `BulkPaymentStateChange`-input-schema validointeineen (tila+reason+eräpäivä-kombinaatioiden tarkistus, ISO-päivämäärän validointi) sekä `BulkPaymentStateChangeResult` (`updated`- ja `skipped`-listat).
- **Reitti** (`virkailija_routes.clj`): Uusi POST-endpoint Swaggeriin pääkäyttäjätarkistuksella ja käyttöohjeella.
- **Konfiguraatio** (`ataru-oph.properties`): Kolme uutta URL-muuttujaa maksut-palvelun uusille endpointeille.

## Huomio atomittomuudesta

DB-kirjoitus ja maksut-palvelukutsu eivät ole atomiset. Jos maksut-kutsu epäonnistuu DB-kirjoituksen jälkeen, heitetään poikkeus joka sisältää päivittyneet avaimet manuaalista korjaustoimenpidettä varten.

## Riippuvuus

Vaatii maksut-palvelusta PR #62 (uudet `force-invalidate`, `delete` ja `update-due-date` endpointit).