### PR TITLE
OPHHAMA-1: kesäaikakorjaus maksuviestiin

### DIFF
--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -263,9 +263,6 @@
                   (select-keys payment [:application-key :state :maksut-secret]))))
 
           (it "should create a reminder e-mail, a sending job and a sent event"
-              ;Note! this testcase fails if executed within the timeframe of 1 or 2 days before the beginning of DST (kesäaika).
-              ;To bypass this, change the due-date of kk-application-payment below so that it is 1 day after current date,
-              ;instead of default 2 days. Or make some permanent correction to the test case.
               (with-redefs [start-runner-job (stub :start-job)]
                 (let [reminder-maksut-secret "54215421ABCDABCD"
                       application-id (unit-test-db/init-db-fixture
@@ -308,6 +305,84 @@
                     {:application-key application-key :state (:awaiting payment/all-states)
                      :maksut-secret reminder-maksut-secret}
                     (select-keys payment [:application-key :state :maksut-secret]))
+                  (should= 1 (count events)))))
+
+          (it "should show the correct due date in the reminder e-mail across the spring DST transition (kesäajan alku)"
+              ; 2025-03-30 is the day Finland's clocks are moved forward (23-hour day). The due date's time of day
+              ; must be calculated using a local time-of-day (23:59), not a 23h59m elapsed-time Duration added to
+              ; midnight - the latter overflows into the next calendar day (31.3. instead of 30.3.) on this date.
+              (with-redefs [start-runner-job (stub :start-job)]
+                (set-fixed-time "2025-03-28T10:00:00")
+                (let [reminder-maksut-secret "54215421SPRINGDST"
+                      application-id (unit-test-db/init-db-fixture
+                                       form-fixtures/payment-exemption-test-form
+                                       application-fixtures/application-without-hakemusmaksu-exemption
+                                       nil)
+                      application-key (:key (application-store/get-application application-id))
+                      check-mail-fn (fn [mail-content]
+                                      (and
+                                        (str/includes? (:body mail-content) reminder-maksut-secret)
+                                        (str/includes? (:body mail-content) "30 maalisk. 2025 23:59:00 +0300")
+                                        (not (str/includes? (:body mail-content) "31 maalisk."))))
+                      _ (payment-store/create-or-update-kk-application-payment!
+                          {:application-key      application-key
+                           :state                (:awaiting payment/all-states)
+                           :reason               nil
+                           :due-date             "2025-03-30"
+                           :total-sum            payment/kk-application-payment-amount
+                           :maksut-secret        reminder-maksut-secret
+                           :required-at          "now()"
+                           :notification-sent-at nil
+                           :approved-at          nil})
+                      _ (updater-job/update-kk-payment-status-for-person-handler
+                          {:person_oid test-person-oid :term test-term :year test-year} runner)
+                      payment (first (payment/get-raw-payments [application-key]))
+                      events (filter #(= (:event-type %) "kk-application-payment-reminder-email-sent")
+                                     (application-store/get-application-events application-key))]
+                  (should-have-invoked :start-job
+                                       {:with [:* :*
+                                               "ataru.kk-application-payment.kk-application-payment-email-job"
+                                               check-mail-fn]})
+                  (should= reminder-maksut-secret (:maksut-secret payment))
+                  (should= 1 (count events)))))
+
+          (it "should show the correct due date in the reminder e-mail across the autumn DST transition (kesäajan loppu)"
+              ; 2025-10-26 is the day Finland's clocks are moved back (25-hour day). The old Duration-based
+              ; calculation didn't shift the calendar date on this transition, but did produce the wrong time
+              ; of day (22:59 instead of 23:59).
+              (with-redefs [start-runner-job (stub :start-job)]
+                (set-fixed-time "2025-10-24T10:00:00")
+                (let [reminder-maksut-secret "54215421AUTUMNDST"
+                      application-id (unit-test-db/init-db-fixture
+                                       form-fixtures/payment-exemption-test-form
+                                       application-fixtures/application-without-hakemusmaksu-exemption
+                                       nil)
+                      application-key (:key (application-store/get-application application-id))
+                      check-mail-fn (fn [mail-content]
+                                      (and
+                                        (str/includes? (:body mail-content) reminder-maksut-secret)
+                                        (str/includes? (:body mail-content) "26 lokak. 2025 23:59:00 +0200")
+                                        (not (str/includes? (:body mail-content) "22:59:00"))))
+                      _ (payment-store/create-or-update-kk-application-payment!
+                          {:application-key      application-key
+                           :state                (:awaiting payment/all-states)
+                           :reason               nil
+                           :due-date             "2025-10-26"
+                           :total-sum            payment/kk-application-payment-amount
+                           :maksut-secret        reminder-maksut-secret
+                           :required-at          "now()"
+                           :notification-sent-at nil
+                           :approved-at          nil})
+                      _ (updater-job/update-kk-payment-status-for-person-handler
+                          {:person_oid test-person-oid :term test-term :year test-year} runner)
+                      payment (first (payment/get-raw-payments [application-key]))
+                      events (filter #(= (:event-type %) "kk-application-payment-reminder-email-sent")
+                                     (application-store/get-application-events application-key))]
+                  (should-have-invoked :start-job
+                                       {:with [:* :*
+                                               "ataru.kk-application-payment.kk-application-payment-email-job"
+                                               check-mail-fn]})
+                  (should= reminder-maksut-secret (:maksut-secret payment))
                   (should= 1 (count events)))))
 
           (it "should not create a reminder e-mail and a sending job too early"

--- a/spec/ataru/kk_application_payment/kk_application_payment_store_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_store_spec.clj
@@ -39,6 +39,27 @@
                 (should= due-date-old due-date-new)
                 (should= due-date-old due-date-fetch)))
 
+          ; Regression for OPHHAMA-1: set-application-fee-paid/set-application-fee-overdue forward an
+          ; already-read (and thus already-DST-corrected) :due-date straight back into a resave. This
+          ; proves that specific resave pattern preserves the calendar date across the spring DST
+          ; transition day, i.e. that the fix holds through a full store -> retrieve -> resave -> retrieve
+          ; round trip via the real database, not just in-memory.
+          (it "should preserve the due date across a resave on the spring DST transition day"
+              (let [application-key "1.2.3.4.5.3030"
+                    created         (store/create-or-update-kk-application-payment!
+                                      {:application-key application-key :state test-state-awaiting
+                                       :due-date        "2025-03-30"})
+                    due-date-fixed  (:due-date created)
+                    resaved         (store/create-or-update-kk-application-payment!
+                                      {:application-key application-key :state test-state-paid
+                                       :due-date        due-date-fixed})
+                    due-date-resaved   (:due-date resaved)
+                    refetched          (first (store/get-kk-application-payments [application-key]))
+                    due-date-refetched (:due-date refetched)]
+                (should= 30 (time/day due-date-fixed))
+                (should= 30 (time/day due-date-resaved))
+                (should= 30 (time/day due-date-refetched))))
+
           (it "should do nothing to due-date if it is not set."
               (let [old-data        (payment/set-application-fee-not-required-for-exemption "1.2.3.4.5.12" nil)
                     due-date        (:due-date old-data)]
@@ -129,3 +150,42 @@
                                           (:modified-at (first awaiting-history)))))
                 (should= (:created-at (first not-required-history)) (:created-at awaiting))
                 (should= (:created-at (first awaiting-history)) (:created-at not-required)))))
+
+(describe "due-date-to-full-time-in-finnish-tz"
+          (tags :unit :kk-application-payment)
+
+          (it "should do nothing when due-date is not set"
+              (should= {:foo "bar"} (store/due-date-to-full-time-in-finnish-tz {:foo "bar"})))
+
+          (it "should set due date to 23:59 Helsinki time on a normal day"
+              (let [due-date (time/date-time 2025 4 15)
+                    result   (:due-date (store/due-date-to-full-time-in-finnish-tz {:due-date due-date}))]
+                (should= 2025 (time/year result))
+                (should= 4 (time/month result))
+                (should= 15 (time/day result))
+                (should= 23 (time/hour result))
+                (should= 59 (time/minute result))))
+
+          ; Finland's clocks are moved forward on the last Sunday of March (kesäaika alkaa), so this
+          ; particular day only has 23 hours. Adding a 23h59m Duration (elapsed real time) to midnight
+          ; used to overflow into the next calendar day (due date shown as 31.3. instead of 30.3.).
+          (it "should set due date to 23:59 Helsinki time without shifting the date across the spring DST transition"
+              (let [due-date (time/date-time 2025 3 30)
+                    result   (:due-date (store/due-date-to-full-time-in-finnish-tz {:due-date due-date}))]
+                (should= 2025 (time/year result))
+                (should= 3 (time/month result))
+                (should= 30 (time/day result))
+                (should= 23 (time/hour result))
+                (should= 59 (time/minute result))))
+
+          ; Finland's clocks are moved back on the last Sunday of October (kesäaika päättyy), so this
+          ; particular day has 25 hours. The old Duration-based calculation didn't shift the date on
+          ; this transition, but did produce the wrong time of day (22:59 instead of 23:59).
+          (it "should set due date to 23:59 Helsinki time without shifting the date across the autumn DST transition"
+              (let [due-date (time/date-time 2025 10 26)
+                    result   (:due-date (store/due-date-to-full-time-in-finnish-tz {:due-date due-date}))]
+                (should= 2025 (time/year result))
+                (should= 10 (time/month result))
+                (should= 26 (time/day result))
+                (should= 23 (time/hour result))
+                (should= 59 (time/minute result)))))

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_status_updater_job.clj
@@ -39,11 +39,7 @@
 
 (defn- due-date-to-printable-datetime
   [lang due-date]
-  (let [due-at             (payment/parse-due-date due-date)
-        due-datetime       (time/date-time (time/year due-at) (time/month due-at) (time/day due-at) 23 59)
-        due-datetime-in-tz (time/from-time-zone due-datetime (time/time-zone-for-id "Europe/Helsinki"))
-        formatter          (lang formatters)]
-    (f/unparse formatter due-datetime-in-tz)))
+  (f/unparse (lang formatters) due-date))
 
 (defn- payment-reminder-email-params
   [lang suffix _]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment_store.clj
@@ -21,12 +21,15 @@
 ; Yesql converts PostgreSQL dates to datetimes automatically - and in that case the
 ; true due datetime is the last minute of the day in Helsinki time zone. This also
 ; helps to sidestep various automatic UTC conversion issues in the frontend...
+;
+; NB! The time of day must be set with an explicit local time (23:59) rather than by adding a
+; 23h59m Duration to midnight. A Duration is a fixed elapsed-time amount, so adding it across the
+; daylight saving time transition (when the day in question only has 23 hours) rolls the result
+; over to the next calendar day.
 (defn due-date-to-full-time-in-finnish-tz [payment]
   (if-let [due-date (:due-date payment)]
     (assoc payment :due-date
-                   (time/to-time-zone
-                       (time/plus due-date (time/hours 23) (time/minutes 59))
-                       (time/time-zone-for-id "Europe/Helsinki")))
+                   (time/with-time-in-zone due-date (time/local-time 23 59) (time/time-zone-for-id "Europe/Helsinki")))
     payment))
 
 (defn- exec-db

--- a/src/clj/ataru/time.clj
+++ b/src/clj/ataru/time.clj
@@ -235,6 +235,10 @@
         zone (.getZone ^ZonedDateTime zdt)]
     (ZonedDateTime/of (.toLocalDate ^ZonedDateTime zdt) local-time zone)))
 
+(defn with-time-in-zone
+  [t local-time zone]
+  (ZonedDateTime/of (.toLocalDate ^ZonedDateTime (->zoned-date-time t)) local-time zone))
+
 (defn to-instant
   [t]
   (->instant t))


### PR DESCRIPTION
## Ongelma

Hakemusmaksun eräpäivä näkyi Maksut-palvelussa oikein, mutta sähköpostitse lähetettävässä maksuviestissä (maksulinkki/muistutus) eräpäivä saattoi olla väärä kesä-/talviaikaan siirryttäessä. Esimerkiksi hakemuksen eräpäivän ollessa 30.3. maksuviestissä saattoi näkyä 31.3.

**Juurisyy:** `due-date-to-full-time-in-finnish-tz` (`kk_application_payment_store.clj`) laski eräpäivän kellonajan lisäämällä keskiyöhön 23h59m `java.time.Duration`-oliona eli kiinteänä, reaaliaikana kuluvana ajanjaksona. Kesäajan alkamispäivänä vuorokaudessa on vain 23 tuntia, joten tämä laskutapa vuoti seuraavalle kalenteripäivälle. Sähköpostiviesti luki eräpäivän suoraan tästä virheellisestä arvosta, kun taas virkailijan käyttöliittymässä bugi naamioitui frontendin UTC-pohjaisen muotoilun ansiosta.

## Korjaus

- Eräpäivän kellonaika lasketaan nyt paikallisena kellonaikana (`with-time-in-zone`) Duration-lisäyksen sijaan, jolloin kalenteripäivä säilyy oikeana riippumatta kesä-/talviaikasiirtymistä.
- `ataru.time`-nimiavaruuteen lisätty `with-time-in-zone`-apufunktio, joka lukee annetun arvon kalenteripäivän suoraan ja leimaa sen kohdeaikavyöhykkeelle ilman instant-säilyttävää vyöhykemuunnosta -> tekee korjauksesta riippumattoman siitä, mikä JVM:n oletusaikavyöhyke sattuu olemaan.
- Poistettu `kk_application_payment_status_updater_job.clj`:stä eräpäivän kellonajan turha, rinnakkainen uudelleenlaskenta (`due-date-to-printable-datetime`) -> sähköpostissa muotoillaan nyt suoraan store-tason jo oikein laskema arvo.
- Siivottu vanhentunut testikommentti, joka varoitti juuri tästä nyt korjatusta bugista.

## Testit

- Uudet yksikkötestit `due-date-to-full-time-in-finnish-tz`-funktiolle kevään ja syksyn aikasiirtymäpäiville sekä normaalille päivälle.
- Uudet integraatiotestit muistutussähköpostiketjulle (koko polku tietokannasta sähköpostin sisältöön asti) molemmille aikasiirtymille.
- Regressiotesti, joka todentaa täyden tietokantakierron kautta, että jo korjattu eräpäivä säilyy oikeana myös uudelleentallennettaessa (sama kaava jota `set-application-fee-paid`/`set-application-fee-overdue` käyttävät).
- Kaikki testit todennettu myös epäonnistuvan odotetusti edeltävällä bugisella koodilla ennen korjausta.

## Huomio

Mahdollisesti jo aiemmin virheellisesti tallentunutta historiallista dataa (eräpäiviä, jotka on tallennettu uudelleen kesä-/talviaikasiirtymän ympärillä ennen tätä korjausta) ei ole automaattisesti auditoitu tai korjattu tässä PR:ssä. Tämä vaatisi erillisen, harkitun data-auditoinnin.