### PR TITLE
OY-5726 Huomioidaan eIDAS-yksilöinnit

### DIFF
--- a/dev/clj/ataru/anonymizer/core.clj
+++ b/dev/clj/ataru/anonymizer/core.clj
@@ -121,6 +121,7 @@
                ; nämäkin ONR-datasta löytyy; pidetään tallessa jos päätetään myöhemmin käyttää anonymisoinnissa
                ;turvakielto
                ;yksiloityvtj
+               ;yksiloityEidas
                ;master_oid
                ;linkitetyt_oidit
                ]}]

--- a/spec/ataru/fixtures/application.clj
+++ b/spec/ataru/fixtures/application.clj
@@ -679,6 +679,19 @@
         (comp vec concat)
         [{:key "kk-application-payment-option" :value "8" :fieldType "dropdown"}])))
 
+(def application-eu-citizen-eidas
+  (-> person-info-form-application-without-kk-application-answer
+      (merge {:form       909909,
+              :lang       "fi"
+              :haku       "payment-info-test-kk-haku"
+              :hakukohde  ["payment-info-test-kk-hakukohde"]
+              :id         543213
+              :person-oid "1.2.3.4.5.752"})
+      (update
+        :answers
+        (comp vec concat)
+        [{:key "kk-application-payment-option" :value "8" :fieldType "dropdown"}])))
+
 (def application-finnish-citizen
   (-> person-info-form-application-without-kk-application-answer
       (merge {:form       909909,

--- a/spec/ataru/kk_application_payment/fixtures.clj
+++ b/spec/ataru/kk_application_payment/fixtures.clj
@@ -12,6 +12,9 @@
              {:uri "maatjavaltiot2_250"
               :version 1
               :value "250"}
+             {:uri "maatjavaltiot2_752"
+              :version 1
+              :value "752"}
              {:uri "maatjavaltiot2_233"
               :version 1
               :value "233"}

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -385,7 +385,20 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-eu-citizen} payment)))
 
-                    (it "should set payment status for non VTJ-yksilöity EU citizen as not required"
+                    (it "should set payment status for eIDAS-yksilöity EU citizen as not required"
+                        (let [oid "1.2.3.4.5.752"                       ; FakePersonService returns Swedish nationality with yksiloityEidas, but no yksiloityVTJ or yksiloity
+                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                           (merge
+                                                                            application-fixtures/application-without-hakemusmaksu-exemption
+                                                                            {:person-oid oid}) nil)
+                              application-key (:key (application-store/get-application application-id))
+                              [changed payment] (update-payment application-key oid)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-eu-citizen} payment)))
+
+                    (it "should set payment status for non VTJ-yksilöity EU citizen as awaiting"
                         (let [oid "1.2.3.4.5.909"                       ; FakePersonService returns French nationality but no yksiloityVTJ
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
                                                                            (merge

--- a/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_status_updater_job_spec.clj
@@ -893,6 +893,27 @@
                           :application-key application-key}
                          (select-keys obligation [:requirement :state :hakukohde :application-key]))))
 
+          (it "should automatically set kk-application-payment-obligation to 'reviewed' for eIDAS-verified EU citizen"
+              (let [application-id (unit-test-db/init-db-fixture
+                                     form-fixtures/payment-exemption-test-form
+                                     application-fixtures/application-eu-citizen-eidas
+                                     nil)
+                    eu-person-oid (:person-oid application-fixtures/application-eu-citizen-eidas)
+                    _ (updater-job/update-kk-payment-status-for-person-handler
+                        {:person_oid eu-person-oid :term test-term :year test-year} runner)
+                    application-key (:key (application-store/get-application application-id))
+                    payment (first (payment/get-raw-payments [application-key]))
+                    obligation (first (payment/get-kk-application-payment-obligation-reviews application-key))]
+                (should= {:application-key application-key
+                          :state (:not-required payment/all-states)
+                          :reason (:eu-citizen payment/all-reasons)}
+                         (select-keys payment [:application-key :state :reason]))
+                (should= {:requirement "kk-application-payment-obligation"
+                          :state "reviewed"
+                          :hakukohde "payment-info-test-kk-hakukohde"
+                          :application-key application-key}
+                         (select-keys obligation [:requirement :state :hakukohde :application-key]))))
+
           (it "should automatically set kk-application-payment-obligation to 'reviewed' for Finnish citizen"
               (let [application-id (unit-test-db/init-db-fixture
                                      form-fixtures/payment-exemption-test-form

--- a/src/clj/ataru/applications/application_service.clj
+++ b/src/clj/ataru/applications/application_service.clj
@@ -263,8 +263,7 @@
                  (distinct (keep :person-oid applications)))]
     (map (fn [application]
            (let [onr-person (get persons (:person-oid application))
-                 person     (if (or (:yksiloity onr-person)
-                                    (:yksiloityVTJ onr-person))
+                 person     (if (person-util/is-yksiloity? onr-person)
                               (merge {:oid            (:oidHenkilo onr-person)
                                       :preferred-name (:kutsumanimi onr-person)
                                       :last-name      (:sukunimi onr-person)
@@ -921,8 +920,7 @@
                                  (person-service/get-persons person-service))
             yksiloimattomat (->> henkilot
                                  vals
-                                 (remove #(or (:yksiloity %)
-                                              (:yksiloityVTJ %)))
+                                 (remove #(person-util/is-yksiloity? %))
                                  (map :oidHenkilo)
                                  distinct
                                  seq)
@@ -968,8 +966,7 @@
                                  (person-service/get-persons person-service))
             yksiloimattomat (->> henkilot
                                  (keep (fn [[oid h]]
-                                         (when-not (or (:yksiloity h)
-                                                       (:yksiloityVTJ h))
+                                         (when-not (person-util/is-yksiloity? h)
                                            oid)))
                                  distinct
                                  seq)]

--- a/src/clj/ataru/applications/automatic_payment_obligation.clj
+++ b/src/clj/ataru/applications/automatic_payment_obligation.clj
@@ -4,6 +4,7 @@
             [ataru.db.db :as db]
             [ataru.koodisto.koodisto-codes :as codes]
             [ataru.person-service.person-service :as person-service]
+            [ataru.person-service.person-util :as person-util]
             [ataru.applications.application-store :as application-store]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
             [taoensso.timbre :as log]
@@ -23,8 +24,7 @@
    {:keys [person-service tarjonta-service henkilo-cache]}]
   (cache/remove-from henkilo-cache person-oid)
   (let [person (person-service/get-person person-service person-oid)]
-    (when (or (:yksiloity person)
-              (:yksiloityVTJ person))
+    (when (person-util/is-yksiloity? person)
       (let [finnish-nationality? (nationality-finland-or-aland? person)
             applications         (->> (application-store/get-application-keys-for-person-oid person-oid)
                                       (map :key)

--- a/src/clj/ataru/harkinnanvaraisuus/harkinnanvaraisuus_job.clj
+++ b/src/clj/ataru/harkinnanvaraisuus/harkinnanvaraisuus_job.clj
@@ -16,6 +16,7 @@
             [ataru.config.core :refer [config]]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta-protocol]
             [ataru.person-service.person-service :as person-service]
+            [ataru.person-service.person-util :as person-util]
             [ataru.email.application-email :as application-email]
             [ataru.email.email-util :as email-util]
             [clojure.java.jdbc :as jdbc]
@@ -168,8 +169,7 @@
                                     distinct
                                     (person-service/get-persons person-service)
                                     vals
-                                    (remove #(or (:yksiloity %)
-                                                 (:yksiloityVTJ %)))
+                                    (remove #(person-util/is-yksiloity? %))
                                     (map :oidHenkilo)
                                     distinct
                                     set)]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -257,7 +257,8 @@
   (:maksullinen-kk-haku? haku))
 
 (defn- is-vtj-yksiloity-eu-citizen? [koodisto-cache person]
-  (let [vtj-yksiloity?   (:yksiloityVTJ person)
+  (let [vtj-yksiloity?   (or (:yksiloityVTJ person)
+                             (:yksiloityEidas person))
         eu-area          (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
                               (filter #(= "EU" (:value %)))
                               (first))

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -257,14 +257,14 @@
   (:maksullinen-kk-haku? haku))
 
 (defn- is-vtj-yksiloity-eu-citizen? [koodisto-cache person]
-  (let [vtj-yksiloity?   (or (:yksiloityVTJ person)
-                             (:yksiloityEidas person))
-        eu-area          (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
-                              (filter #(= "EU" (:value %)))
-                              (first))
+  (let [vahvasti-yksiloity? (or (:yksiloityVTJ person)
+                                (:yksiloityEidas person))
+        eu-area             (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+                                 (filter #(= "EU" (:value %)))
+                                 (first))
         eu-country-codes (set (map :value (:within eu-area)))]
     (if (> (count eu-country-codes) 0)
-      (and vtj-yksiloity?
+      (and vahvasti-yksiloity?
            (some #(contains? eu-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person)))
       (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))))
 

--- a/src/clj/ataru/odw/odw_service.clj
+++ b/src/clj/ataru/odw/odw_service.clj
@@ -8,6 +8,7 @@
             [ataru.applications.suoritus-filter :as suoritus-filter]
             [ataru.koodisto.koodisto-codes :refer [finland-country-code]]
             [ataru.person-service.person-service :as person-service]
+            [ataru.person-service.person-util :as person-util]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta-protocol]
             [taoensso.timbre :as log]
             [ataru.valintalaskentakoostepalvelu.valintalaskentakoostepalvelu-protocol :as valintalaskentakoostepalvelu]
@@ -30,7 +31,7 @@
 
 (defn get-yksiloimaton-tai-aidinkieleton-henkilo-oids
   [persons]
-  (set (map :oidHenkilo (filter (fn [person] (or (and (not (:yksiloity person)) (not (:yksiloityVTJ person)))
+  (set (map :oidHenkilo (filter (fn [person] (or (not (person-util/is-yksiloity? person))
                                                  (empty? (get-in person [:aidinkieli :kieliKoodi]))))
                                 (vals persons)))))
 

--- a/src/clj/ataru/person_service/person_integration.clj
+++ b/src/clj/ataru/person_service/person_integration.clj
@@ -14,6 +14,7 @@
    [ataru.cache.cache-service :as cache]
    [ataru.db.db :as db]
    [ataru.person-service.person-service :as person-service]
+   [ataru.person-service.person-util :as person-util]
    [ataru.kk-application-payment.kk-application-payment-status-updater-job :as kk-payment-job]
    [yesql.core :refer [defqueries]])
   (:import [java.util.concurrent Executors TimeUnit]
@@ -123,8 +124,7 @@
   (log/info "Checking person info of" person-oid)
   (cache/remove-from henkilo-cache person-oid)
   (let [person (person-service/get-person person-service person-oid)]
-    (if (or (:yksiloity person)
-            (:yksiloityVTJ person))
+    (if (ataru.person-service.person-util/is-yksiloity? person)
       (when (update-person-info-as-in-person person-oid person)
         (log/info "Updated person info of" person-oid
                   "to that on oppijanumerorekisteri"))

--- a/src/clj/ataru/person_service/person_service.clj
+++ b/src/clj/ataru/person_service/person_service.clj
@@ -45,8 +45,7 @@
              {:language aidinkieli}))))
 
 (defn parse-person [application person-from-onr]
-  (let [yksiloity   (or (-> person-from-onr :yksiloity)
-                        (-> person-from-onr :yksiloityVTJ))
+  (let [yksiloity   (person-util/is-yksiloity? person-from-onr)
         person-info (if yksiloity
                       (person-info-from-onr-person person-from-onr)
                       (person-util/person-info-from-application application))]
@@ -103,20 +102,21 @@
   (linked-oids [_ oids]
     (person-client/linked-oids oppijanumerorekisteri-cas-client oids)))
 
-(def fake-onr-person {:oidHenkilo   "1.2.3.4.5.6"
-                      :hetu         "020202A0202"
-                      :etunimet     "Testi"
-                      :kutsumanimi  "Testi"
-                      :sukunimi     "Ihminen"
-                      :syntymaaika  "1941-06-16"
-                      :sukupuoli    "2"
-                      :kansalaisuus [{:kansalaisuusKoodi "246"}]
-                      :aidinkieli   {:id          "742310"
-                                     :kieliKoodi  "fi"
-                                     :kieliTyyppi "suomi"}
-                      :turvakielto  false
-                      :yksiloity    false
-                      :yksiloityVTJ false})
+(def fake-onr-person {:oidHenkilo     "1.2.3.4.5.6"
+                      :hetu           "020202A0202"
+                      :etunimet       "Testi"
+                      :kutsumanimi    "Testi"
+                      :sukunimi       "Ihminen"
+                      :syntymaaika    "1941-06-16"
+                      :sukupuoli      "2"
+                      :kansalaisuus   [{:kansalaisuusKoodi "246"}]
+                      :aidinkieli     {:id          "742310"
+                                       :kieliKoodi  "fi"
+                                       :kieliTyyppi "suomi"}
+                      :turvakielto    false
+                      :yksiloity      false
+                      :yksiloityVTJ   false
+                      :yksiloityEidas false})
 
 (defrecord FakePersonService []
   component/Lifecycle
@@ -162,6 +162,11 @@
                              {:kansalaisuus [{:kansalaisuusKoodi "248"}]
                               :yksiloity true
                               :yksiloityVTJ true})
+      "1.2.3.4.5.752" (merge fake-onr-person  ; Swedish
+                             {:kansalaisuus [{:kansalaisuusKoodi "752"}]
+                              :yksiloity false
+                              :yksiloityVTJ false
+                              :yksiloityEidas true})
       (merge fake-onr-person
              {:oidHenkilo oid})))
 

--- a/src/clj/ataru/person_service/person_util.clj
+++ b/src/clj/ataru/person_service/person_util.clj
@@ -21,3 +21,6 @@
              {:gender (-> answers :gender :value)})
            (when-not (cs/blank? (-> answers :language :value))
              {:language (-> answers :language :value)}))))
+
+(defn is-yksiloity? [onr-person]
+  (or (:yksiloity onr-person) (:yksiloityVTJ onr-person) (:yksiloityEidas onr-person)))

--- a/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
+++ b/src/cljs/ataru/virkailija/application/kevyt_valinta/virkailija_kevyt_valinta_subs.cljs
@@ -48,7 +48,8 @@
   (fn [[application]]
     (let [person (:person application)]
       (or (:yksiloity person)
-          (:yksiloityVTJ person)))))
+          (:yksiloityVTJ person)
+          (:yksiloityEidas person)))))
 
 (re-frame/reg-sub
   :virkailija-kevyt-valinta/kevyt-valinta-enabled-for-application-and-hakukohde?


### PR DESCRIPTION
Rinnastetaan eIDAS-yksilöinnit VTJ-yksilöinteihin koodissa. eIDAS-yksilöintitieto tulee omassa kentässään oppijanumerorekisterissä, joten se pitää lukea ja käsitellä erikseen.

Suurimmassa osassa tapauksista riittää tieto, että oppija on yksilöity joko manuaalisesti, VTJ:stä tai eIDAS:sta. Lisätään siis util-funktio, joka tarkistaa onko oppijalla joku näistä true.

KK-hakemusmaksuissa on huomioitu vain VTJ-yksilöinti, joten siihen lisätään vain eIDAS-yksilöinti rinnalle.