### PR TITLE
OPHHAMA-21 Vapautus kk-hakemusmaksusta ETA-maille ja Sveitsille

### DIFF
--- a/spec/ataru/kk_application_payment/fixtures.clj
+++ b/spec/ataru/kk_application_payment/fixtures.clj
@@ -6,6 +6,12 @@
     :value "EU"
     :label {}
     :valid { :start "2015-09-03T00:00:00+03:00" }
+    :within {}}
+   {:uri "valtioryhmat_2"
+    :version 1
+    :value "ETA"
+    :label {}
+    :valid { :start "2015-09-03T00:00:00+03:00" }
     :within [{:uri "maatjavaltiot2_246"
               :version 1
               :value "246"}
@@ -20,30 +26,10 @@
               :value "233"}
              {:uri "maatjavaltiot2_056"
               :version 1
-              :value "056"}]}
-   {:uri "valtioryhmat_2"
-    :version 1
-    :value "ETA"
-    :label {}
-    :valid { :start "2015-09-03T00:00:00+03:00" }
-    :within {}}
-   {:uri "valtioryhmat_2"
-    :version 1
-    :value "EFTA"
-    :label {}
-    :valid { :start "2015-09-03T00:00:00+03:00" }
-    :within [{:uri "maatjavaltiot2_352"
-              :version 1
-              :value "352"}
-             {:uri "maatjavaltiot2_438"
-              :version 1
-              :value "438"}
+              :value "056"}
              {:uri "maatjavaltiot2_578"
               :version 1
-              :value "578"}
-             {:uri "maatjavaltiot2_756"
-              :version 1
-              :value "756"}]}])
+              :value "578"}]}])
 
 (defn haku-with-hakuajat
   [hakuaika-start hakuaika-end]

--- a/spec/ataru/kk_application_payment/fixtures.clj
+++ b/spec/ataru/kk_application_payment/fixtures.clj
@@ -26,7 +26,24 @@
     :value "ETA"
     :label {}
     :valid { :start "2015-09-03T00:00:00+03:00" }
-    :within {}}])
+    :within {}}
+   {:uri "valtioryhmat_2"
+    :version 1
+    :value "EFTA"
+    :label {}
+    :valid { :start "2015-09-03T00:00:00+03:00" }
+    :within [{:uri "maatjavaltiot2_352"
+              :version 1
+              :value "352"}
+             {:uri "maatjavaltiot2_438"
+              :version 1
+              :value "438"}
+             {:uri "maatjavaltiot2_578"
+              :version 1
+              :value "578"}
+             {:uri "maatjavaltiot2_756"
+              :version 1
+              :value "756"}]}])
 
 (defn haku-with-hakuajat
   [hakuaika-start hakuaika-end]

--- a/spec/ataru/kk_application_payment/kk_application_payment_maksut_poller_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_maksut_poller_job_spec.clj
@@ -54,7 +54,7 @@
   application-key)
 
 (defn create-not-required-status [application-key]
-  (payment/set-application-fee-not-required-for-eu-citizen application-key nil)
+  (payment/set-application-fee-not-required-for-eta-citizen application-key nil)
   application-key)
 
 (defn check-state-and-history
@@ -85,7 +85,7 @@
           ; Add some other states that are checked during every test
           (before
             ; The first three ones should always stay as is
-            (payment/set-application-fee-not-required-for-eu-citizen
+            (payment/set-application-fee-not-required-for-eta-citizen
               "1.2.246.562.8.00000000000022225500" nil)
             (payment/set-application-fee-overdue
               "1.2.246.562.8.00000000000022225600" nil)

--- a/spec/ataru/kk_application_payment/kk_application_payment_maksut_poller_job_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_maksut_poller_job_spec.clj
@@ -57,7 +57,7 @@
   application-key)
 
 (defn create-not-required-status [application-key]
-  (payment/set-application-fee-not-required-for-eu-citizen application-key nil)
+  (payment/set-application-fee-not-required-for-eta-citizen application-key nil)
   application-key)
 
 (defn check-state-and-history
@@ -88,7 +88,7 @@
           ; Add some other states that are checked during every test
           (before
             ; The first three ones should always stay as is
-            (payment/set-application-fee-not-required-for-eu-citizen
+            (payment/set-application-fee-not-required-for-eta-citizen
               "1.2.246.562.8.00000000000022225500" nil)
             (payment/set-application-fee-overdue
               "1.2.246.562.8.00000000000022225600" nil)

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -389,6 +389,19 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-eu-citizen} payment)))
 
+                    (it "should set payment status for eIDAS-yksilöity EFTA citizen as not required"
+                        (let [oid "1.2.3.4.5.756"                       ; FakePersonService returns Swiss nationality with yksiloityEidas and yksiloity
+                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                           (merge
+                                                                            application-fixtures/application-without-hakemusmaksu-exemption
+                                                                            {:person-oid oid}) nil)
+                              application-key (:key (application-store/get-application application-id))
+                              [changed payment] (update-payment application-key oid)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-eu-citizen} payment)))
+
                     (it "should set payment status for non VTJ-yksilöity EU citizen as awaiting"
                         (let [oid "1.2.3.4.5.909"                       ; FakePersonService returns French nationality but no yksiloityVTJ
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
@@ -900,7 +913,7 @@
 
           (it "should update reason when transitioning not-required to not-required"
               (let [application-key "1.2.3.4.5.140"
-                    _ (payment/set-application-fee-not-required-for-eu-citizen application-key nil)
+                    _ (payment/set-application-fee-not-required-for-eta-citizen application-key nil)
                     {:keys [service calls]} (make-mock-maksut-service)
                     result (payment/bulk-change-overdue-payment-state
                              service [application-key] state-not-required reason-exemption nil nil audit-logger)
@@ -942,7 +955,7 @@
 
                     (it "should set and get application fee not required for eu citizen"
                         (save-and-check-single-state
-                          "1.2.3.4.5.7" payment/set-application-fee-not-required-for-eu-citizen
+                          "1.2.3.4.5.7" payment/set-application-fee-not-required-for-eta-citizen
                           state-not-required reason-eu-citizen))
 
                     (it "should set and get application fee not required due to exemption"
@@ -1004,7 +1017,7 @@
 
                     (it "should reset payment data when setting payment as not required for eu citizen"
                         (let [initial-data (payment/set-application-fee-required "1.2.3.4.5.12" nil)
-                              updated-data (payment/set-application-fee-not-required-for-eu-citizen "1.2.3.4.5.12" initial-data)]
+                              updated-data (payment/set-application-fee-not-required-for-eta-citizen "1.2.3.4.5.12" initial-data)]
                           (should-be-nil     (:approved-at initial-data))
                           (should-not-be-nil (:required-at initial-data))
                           (should-not-be-nil (:due-date    initial-data))

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -385,6 +385,19 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-eu-citizen} payment)))
 
+                    (it "should set payment status for eIDAS-yksilöity EFTA citizen as not required"
+                        (let [oid "1.2.3.4.5.756"                       ; FakePersonService returns Swiss nationality with yksiloityEidas and yksiloity
+                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                           (merge
+                                                                            application-fixtures/application-without-hakemusmaksu-exemption
+                                                                            {:person-oid oid}) nil)
+                              application-key (:key (application-store/get-application application-id))
+                              [changed payment] (update-payment application-key oid)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-not-required
+                                                     :reason reason-eu-citizen} payment)))
+
                     (it "should set payment status for non VTJ-yksilöity EU citizen as awaiting"
                         (let [oid "1.2.3.4.5.909"                       ; FakePersonService returns French nationality but no yksiloityVTJ
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
@@ -802,7 +815,7 @@
 
                     (it "should set and get application fee not required for eu citizen"
                         (save-and-check-single-state
-                          "1.2.3.4.5.7" payment/set-application-fee-not-required-for-eu-citizen
+                          "1.2.3.4.5.7" payment/set-application-fee-not-required-for-eta-citizen
                           state-not-required reason-eu-citizen))
 
                     (it "should set and get application fee not required due to exemption"
@@ -864,7 +877,7 @@
 
                     (it "should reset payment data when setting payment as not required for eu citizen"
                         (let [initial-data (payment/set-application-fee-required "1.2.3.4.5.12" nil)
-                              updated-data (payment/set-application-fee-not-required-for-eu-citizen "1.2.3.4.5.12" initial-data)]
+                              updated-data (payment/set-application-fee-not-required-for-eta-citizen "1.2.3.4.5.12" initial-data)]
                           (should-be-nil     (:approved-at initial-data))
                           (should-not-be-nil (:required-at initial-data))
                           (should-not-be-nil (:due-date    initial-data))

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -1,4 +1,4 @@
-(ns ataru.kk-application-payment.kk-application-payment-spec
+(ns ^:focus ataru.kk-application-payment.kk-application-payment-spec
   (:require [ataru.fixtures.application :as application-fixtures]
             [ataru.fixtures.form :as form-fixtures]
             [ataru.forms.form-store :as form-store]
@@ -385,7 +385,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-eu-citizen} payment)))
 
-                    (it "should set payment status for eIDAS-yksilöity EFTA citizen as not required"
+                    (it "should set payment status for eIDAS-yksilöity Swiss citizen as not required"
                         (let [oid "1.2.3.4.5.756"                       ; FakePersonService returns Swiss nationality with yksiloityEidas and yksiloity
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
                                                                            (merge
@@ -400,6 +400,19 @@
 
                     (it "should set payment status for non VTJ-yksilöity EU citizen as awaiting"
                         (let [oid "1.2.3.4.5.909"                       ; FakePersonService returns French nationality but no yksiloityVTJ
+                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                           (merge
+                                                                            application-fixtures/application-without-hakemusmaksu-exemption
+                                                                            {:person-oid oid}) nil)
+                              application-key (:key (application-store/get-application application-id))
+                              [changed payment] (update-payment application-key oid)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-awaiting
+                                                     :reason nil} payment)))
+
+                    (it "should set payment status for non VTJ-yksilöity Swiss citizen as awaiting"
+                        (let [oid "1.2.3.4.5.555"                       ; FakePersonService returns Swiss nationality but no yksiloityVTJ
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
                                                                            (merge
                                                                             application-fixtures/application-without-hakemusmaksu-exemption

--- a/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
+++ b/spec/ataru/kk_application_payment/kk_application_payment_spec.clj
@@ -389,7 +389,7 @@
                           (should-be-matching-state {:application-key application-key, :state state-not-required
                                                      :reason reason-eu-citizen} payment)))
 
-                    (it "should set payment status for eIDAS-yksilöity EFTA citizen as not required"
+                    (it "should set payment status for eIDAS-yksilöity Swiss citizen as not required"
                         (let [oid "1.2.3.4.5.756"                       ; FakePersonService returns Swiss nationality with yksiloityEidas and yksiloity
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
                                                                            (merge
@@ -404,6 +404,19 @@
 
                     (it "should set payment status for non VTJ-yksilöity EU citizen as awaiting"
                         (let [oid "1.2.3.4.5.909"                       ; FakePersonService returns French nationality but no yksiloityVTJ
+                              application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
+                                                                           (merge
+                                                                            application-fixtures/application-without-hakemusmaksu-exemption
+                                                                            {:person-oid oid}) nil)
+                              application-key (:key (application-store/get-application application-id))
+                              [changed payment] (update-payment application-key oid)]
+                          (should= 1 (count changed))
+                          (should= payment (first changed))
+                          (should-be-matching-state {:application-key application-key, :state state-awaiting
+                                                     :reason nil} payment)))
+
+                    (it "should set payment status for non VTJ-yksilöity Swiss citizen as awaiting"
+                        (let [oid "1.2.3.4.5.555"                       ; FakePersonService returns Swiss nationality but no yksiloityVTJ
                               application-id (unit-test-db/init-db-fixture form-fixtures/payment-exemption-test-form
                                                                            (merge
                                                                             application-fixtures/application-without-hakemusmaksu-exemption

--- a/spec/ataru/virkailija/virkailija_routes_spec.clj
+++ b/spec/ataru/virkailija/virkailija_routes_spec.clj
@@ -563,7 +563,7 @@
                              [{:hakukohde "1.2.246.562.20.49028196523" :review-requirement "processing-state" :review-state "processing"}
                               {:hakukohde "1.2.246.562.20.49028196524" :review-requirement "processing-state" :review-state "information-request"}])
             application (application-store/get-application application-id)
-            _ (payment/set-application-fee-not-required-for-eu-citizen (:key application) nil)
+            _ (payment/set-application-fee-not-required-for-eta-citizen (:key application) nil)
             resp         (post-applications-list application-fixtures/applications-list-query)
             status       (:status resp)
             body         (:body resp)
@@ -963,7 +963,7 @@
                                                        application-fixtures/application-without-hakemusmaksu-exemption
                                                        nil)
                     application (get-application-by-id application-id)
-                    _ (payment/set-application-fee-not-required-for-eu-citizen (:key application) nil)
+                    _ (payment/set-application-fee-not-required-for-eta-citizen (:key application) nil)
                     _ (payment/set-application-fee-required (:key application) nil)
                     _ (payment/set-application-fee-paid (:key application) nil)
                     resp (get-application-details (:key application))
@@ -1004,7 +1004,7 @@
 
           (it "should return an application with kk payment data"
               (let [[_ _ _ application _] (init-and-get-kk-fixtures)
-                    _ (payment/set-application-fee-not-required-for-eu-citizen (:key application) nil)
+                    _ (payment/set-application-fee-not-required-for-eta-citizen (:key application) nil)
                     resp (post-valintalaskenta-application-query [(:key application)])
                     status (:status resp)
                     applications (:body resp)]
@@ -1062,7 +1062,7 @@
 
           (it "should return an application with kk payment data"
               (let [[_ _ _ application _] (init-and-get-kk-fixtures)
-                    _ (payment/set-application-fee-not-required-for-eu-citizen (:key application) nil)
+                    _ (payment/set-application-fee-not-required-for-eta-citizen (:key application) nil)
                     resp (post-siirto-application-query [(:key application)])
                     status (:status resp)
                     applications (:body resp)]
@@ -1126,7 +1126,7 @@
 
           (it "should return an application with kk payment data"
               (let [[_ _ _ application haku-oid] (init-and-get-kk-fixtures)
-                    _ (payment/set-application-fee-not-required-for-eu-citizen (:key application) nil)
+                    _ (payment/set-application-fee-not-required-for-eta-citizen (:key application) nil)
                     resp (post-sure-application-query {:hakuOid haku-oid})
                     status (:status resp)
                     applications (get-in resp [:body :applications])]
@@ -1167,7 +1167,7 @@
 
           (it "should return an application with kk payment data"
               (let [[_ _ _ application haku-oid] (init-and-get-kk-fixtures)
-                    _ (payment/set-application-fee-not-required-for-eu-citizen (:key application) nil)
+                    _ (payment/set-application-fee-not-required-for-eta-citizen (:key application) nil)
                     resp (post-vts-application-query {:hakuOid haku-oid})
                     status (:status resp)
                     applications (get-in resp [:body :applications])]

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -1,6 +1,6 @@
 (ns ataru.kk-application-payment.kk-application-payment
   "Logic related to kk application processing payments, AKA hakemusmaksu. The basic spec is that
-   non-exempt non-EU native applicants should be charged an application fee once per semester.
+   non-exempt non-EU/ETA/Swiss native applicants should be charged an application fee once per semester.
    NB! Semester is defined here by the start date of the actual first higher education semester,
    not the application date."
   (:require [ataru.cache.cache-service :as cache]
@@ -15,7 +15,6 @@
             [ataru.person-service.person-service :as person-service]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
             [ataru.util :as util]
-            [clojure.set :as set]
             [clojure.string :as str]
             [taoensso.timbre :as log]
             [ataru.kk-application-payment.utils :as utils]
@@ -46,7 +45,7 @@
 ; Tilalogiikka lyhyesti:
 ;
 ; 1. "not-required": hakemusmaksua ei vaadita. Tämä tila on ainoa, jonka yhteydessä asetetaan myös "reason"-tieto, ja sellainen tulee olla aina seuraavasti:
-;    - "eu-citizen": hakija on Suomen tai EU:n kansalainen - tarkistetaan automaattisesti ONR:sta, toistaiseksi käytössä ainoastaan suomen kansalaisille
+;    - "eu-citizen": hakija on Suomen, EU:n, ETA:n tai Sveitsin kansalainen
 ;    - "exemption-field": hakemukselta löytyy validi hakemusmaksusta vapautuksen syy, esimerkiksi oleskelulupa tai EU-passi
 ; 2. "awaiting": hakemus odottaa vaadittua hakemusmaksua: maksut-palveluun on luotu maksupyyntö hakemukselle ja "maksut-secret" on asetettu
 ; 3. "ok-by-proxy": hakemusmaksu on maksettu toisen saman aloituskauden hakemuksen yhteydessä
@@ -258,26 +257,21 @@
   [haku]
   (:maksullinen-kk-haku? haku))
 
-(defn- is-exempt-for-nationality?
+(defn- is-eta-equivalent-citizen?
   "Citizens of ETA (European Economic Area) members (including EU members) and countries with
    applicable bilateral agreements (currently only Switzerland) are exempt from the application
    payment. They need to be yksilöity with either VTJ or eIDAS for the nationality to count."
   [koodisto-cache person]
   (let [vahvasti-yksiloity?  (or (:yksiloityVTJ person)
                                  (:yksiloityEidas person))
-        eu-area              (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
-                                 (filter #(= "EU" (:value %)))
+        eta-area             (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+                                 (filter #(= "ETA" (:value %)))
                                  (first))
-        efta-area            (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
-                                 (filter #(= "EFTA" (:value %))) ; EFTA = ETA Outside EU + Switzerland
-                                 (first))
-        eu-country-codes     (set (map :value (:within eu-area)))
-        efta-country-codes   (set (map :value (:within efta-area)))
-        exempt-country-codes (set/union eu-country-codes efta-country-codes)]
-    (when (<= (count eu-country-codes) 0)
-      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))
-    (when (<= (count efta-country-codes) 0)
-      (throw (ex-info "Could not fetch country codes for EFTA area" {:person-oid (:oid person)})))
+        swiss-country-code   "756"
+        eta-country-codes    (set (map :value (:within eta-area)))
+        exempt-country-codes (conj eta-country-codes swiss-country-code)]
+    (when (empty? eta-country-codes)
+      (throw (ex-info "Could not fetch country codes for ETA area" {:person-oid (:oid person)})))
     (and vahvasti-yksiloity?
          (some #(contains? exempt-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person)))))
 
@@ -501,12 +495,11 @@
        (new-state-fn (:key application) payment)))))
 
 (defn- update-payments-for-applications
-  [applications-payments exempt-keys is-finnish-citizen? is-eta-citizen? has-existing-payment?]
+  [applications-payments exempt-keys is-eta-citizen? has-existing-payment?]
   (let [map-payments (fn [new-state state-change-fn]
                        (doall
                          (remove nil? (map #(set-payment exempt-keys new-state state-change-fn %) applications-payments))))]
     (cond
-      is-finnish-citizen?   (map-payments (:not-required all-states) set-application-fee-not-required-for-eta-citizen)
       is-eta-citizen?       (map-payments (:not-required all-states) set-application-fee-not-required-for-eta-citizen)
       has-existing-payment? (map-payments (:ok-by-proxy all-states) set-application-fee-ok-by-proxy)
       :else                 (map-payments (:awaiting all-states) set-application-fee-required))))
@@ -545,7 +538,7 @@
                 exempt-keys            (set (map :key (filter (partial exemption-in-application? job-runner)
                                                               applications)))
                 is-finnish-citizen?    (is-finnish-citizen? person)
-                is-eta-citizen?        (is-exempt-for-nationality? koodisto-cache person)
+                is-eta-citizen?        (is-eta-equivalent-citizen? koodisto-cache person)
                 has-existing-payment?  (contains? payment-state-set (:paid all-states))]
             (log/info "Updating application level kk application payment status for person" person-oid "term" term "year" year
                       "is-finnish-citizen?" (boolean is-finnish-citizen?)
@@ -554,7 +547,7 @@
             {:person            person
              :existing-payments applications-payments
              :modified-payments (update-payments-for-applications
-                                  applications-payments exempt-keys is-finnish-citizen? is-eta-citizen? has-existing-payment?)}))))))
+                                  applications-payments exempt-keys (or is-finnish-citizen? is-eta-citizen?) has-existing-payment?)}))))))
 
 (defn get-kk-payment-state
   "Returns higher education application fee related info to single application.

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -15,6 +15,7 @@
             [ataru.person-service.person-service :as person-service]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
             [ataru.util :as util]
+            [clojure.set :as set]
             [clojure.string :as str]
             [taoensso.timbre :as log]
             [ataru.kk-application-payment.utils :as utils]
@@ -208,8 +209,8 @@
                          :required-at    (:required-at previous-state)
                          :approved-at    "now()"})))
 
-(defn set-application-fee-not-required-for-eu-citizen
-  "Sets kk processing fee not required for the application due to person being EU citizen."
+(defn set-application-fee-not-required-for-eta-citizen
+  "Sets kk processing fee not required for the application due to person being EU/ETA/Switzerland citizen."
   [application-key previous-state]
   (set-application-fee-not-required application-key (:eu-citizen all-reasons) previous-state))
 
@@ -257,17 +258,28 @@
   [haku]
   (:maksullinen-kk-haku? haku))
 
-(defn- is-vtj-yksiloity-eu-citizen? [koodisto-cache person]
-  (let [vahvasti-yksiloity? (or (:yksiloityVTJ person)
-                            (:yksiloityEidas person))
-        eu-area             (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+(defn- is-exempt-for-nationality?
+  "Citizens of ETA (European Economic Area) members (including EU members) and countries with
+   applicable bilateral agreements (currently only Switzerland) are exempt from the application
+   payment. They need to be yksilöity with either VTJ or eIDAS for the nationality to count."
+  [koodisto-cache person]
+  (let [vahvasti-yksiloity?  (or (:yksiloityVTJ person)
+                                 (:yksiloityEidas person))
+        eu-area              (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
                                  (filter #(= "EU" (:value %)))
                                  (first))
-        eu-country-codes (set (map :value (:within eu-area)))]
-    (if (> (count eu-country-codes) 0)
-      (and vahvasti-yksiloity?
-           (some #(contains? eu-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person)))
-      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))))
+        efta-area            (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+                                 (filter #(= "EFTA" (:value %))) ; EFTA = ETA Outside EU + Switzerland
+                                 (first))
+        eu-country-codes     (set (map :value (:within eu-area)))
+        efta-country-codes   (set (map :value (:within efta-area)))
+        exempt-country-codes (set/union eu-country-codes efta-country-codes)]
+    (when (<= (count eu-country-codes) 0)
+      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))
+    (when (<= (count efta-country-codes) 0)
+      (throw (ex-info "Could not fetch country codes for EFTA area" {:person-oid (:oid person)})))
+    (and vahvasti-yksiloity?
+         (some #(contains? exempt-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person)))))
 
 (defn- is-finnish-citizen? [person]
   (some #(= "246" (:kansalaisuusKoodi %)) (:kansalaisuus person)))
@@ -489,13 +501,13 @@
        (new-state-fn (:key application) payment)))))
 
 (defn- update-payments-for-applications
-  [applications-payments exempt-keys is-finnish-citizen? is-eu-citizen? has-existing-payment?]
+  [applications-payments exempt-keys is-finnish-citizen? is-eta-citizen? has-existing-payment?]
   (let [map-payments (fn [new-state state-change-fn]
                        (doall
                          (remove nil? (map #(set-payment exempt-keys new-state state-change-fn %) applications-payments))))]
     (cond
-      is-finnish-citizen?   (map-payments (:not-required all-states) set-application-fee-not-required-for-eu-citizen)
-      is-eu-citizen?        (map-payments (:not-required all-states) set-application-fee-not-required-for-eu-citizen)
+      is-finnish-citizen?   (map-payments (:not-required all-states) set-application-fee-not-required-for-eta-citizen)
+      is-eta-citizen?       (map-payments (:not-required all-states) set-application-fee-not-required-for-eta-citizen)
       has-existing-payment? (map-payments (:ok-by-proxy all-states) set-application-fee-ok-by-proxy)
       :else                 (map-payments (:awaiting all-states) set-application-fee-required))))
 
@@ -533,16 +545,16 @@
                 exempt-keys            (set (map :key (filter (partial exemption-in-application? job-runner)
                                                               applications)))
                 is-finnish-citizen?    (is-finnish-citizen? person)
-                is-eu-citizen?         (is-vtj-yksiloity-eu-citizen? koodisto-cache person)
+                is-eta-citizen?        (is-exempt-for-nationality? koodisto-cache person)
                 has-existing-payment?  (contains? payment-state-set (:paid all-states))]
             (log/info "Updating application level kk application payment status for person" person-oid "term" term "year" year
                       "is-finnish-citizen?" (boolean is-finnish-citizen?)
-                      "is-eu-citizen?" (boolean is-eu-citizen?)
+                      "is-eta-citizen?" (boolean is-eta-citizen?)
                       "has-existing-payment?" (boolean has-existing-payment?))
             {:person            person
              :existing-payments applications-payments
              :modified-payments (update-payments-for-applications
-                                  applications-payments exempt-keys is-finnish-citizen? is-eu-citizen? has-existing-payment?)}))))))
+                                  applications-payments exempt-keys is-finnish-citizen? is-eta-citizen? has-existing-payment?)}))))))
 
 (defn get-kk-payment-state
   "Returns higher education application fee related info to single application.

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -14,6 +14,7 @@
             [ataru.person-service.person-service :as person-service]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
             [ataru.util :as util]
+            [clojure.set :as set]
             [clojure.string :as str]
             [taoensso.timbre :as log]
             [ataru.kk-application-payment.utils :as utils]
@@ -206,8 +207,8 @@
                          :required-at    (:required-at previous-state)
                          :approved-at    "now()"})))
 
-(defn set-application-fee-not-required-for-eu-citizen
-  "Sets kk processing fee not required for the application due to person being EU citizen."
+(defn set-application-fee-not-required-for-eta-citizen
+  "Sets kk processing fee not required for the application due to person being EU/ETA/Switzerland citizen."
   [application-key previous-state]
   (set-application-fee-not-required application-key (:eu-citizen all-reasons) previous-state))
 
@@ -255,17 +256,28 @@
   [haku]
   (:maksullinen-kk-haku? haku))
 
-(defn- is-vtj-yksiloity-eu-citizen? [koodisto-cache person]
-  (let [vahvasti-yksiloity? (or (:yksiloityVTJ person)
-                            (:yksiloityEidas person))
-        eu-area             (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+(defn- is-exempt-for-nationality?
+  "Citizens of ETA (European Economic Area) members (including EU members) and countries with
+   applicable bilateral agreements (currently only Switzerland) are exempt from the application
+   payment. They need to be yksilöity with either VTJ or eIDAS for the nationality to count."
+  [koodisto-cache person]
+  (let [vahvasti-yksiloity?  (or (:yksiloityVTJ person)
+                                 (:yksiloityEidas person))
+        eu-area              (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
                                  (filter #(= "EU" (:value %)))
                                  (first))
-        eu-country-codes (set (map :value (:within eu-area)))]
-    (if (> (count eu-country-codes) 0)
-      (and vahvasti-yksiloity?
-           (some #(contains? eu-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person)))
-      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))))
+        efta-area            (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+                                 (filter #(= "EFTA" (:value %))) ; EFTA = ETA Outside EU + Switzerland
+                                 (first))
+        eu-country-codes     (set (map :value (:within eu-area)))
+        efta-country-codes   (set (map :value (:within efta-area)))
+        exempt-country-codes (set/union eu-country-codes efta-country-codes)]
+    (when (<= (count eu-country-codes) 0)
+      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))
+    (when (<= (count efta-country-codes) 0)
+      (throw (ex-info "Could not fetch country codes for EFTA area" {:person-oid (:oid person)})))
+    (and vahvasti-yksiloity?
+         (some #(contains? exempt-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person)))))
 
 (defn- is-finnish-citizen? [person]
   (some #(= "246" (:kansalaisuusKoodi %)) (:kansalaisuus person)))
@@ -487,13 +499,13 @@
        (new-state-fn (:key application) payment)))))
 
 (defn- update-payments-for-applications
-  [applications-payments exempt-keys is-finnish-citizen? is-eu-citizen? has-existing-payment?]
+  [applications-payments exempt-keys is-finnish-citizen? is-eta-citizen? has-existing-payment?]
   (let [map-payments (fn [new-state state-change-fn]
                        (doall
                          (remove nil? (map #(set-payment exempt-keys new-state state-change-fn %) applications-payments))))]
     (cond
-      is-finnish-citizen?   (map-payments (:not-required all-states) set-application-fee-not-required-for-eu-citizen)
-      is-eu-citizen?        (map-payments (:not-required all-states) set-application-fee-not-required-for-eu-citizen)
+      is-finnish-citizen?   (map-payments (:not-required all-states) set-application-fee-not-required-for-eta-citizen)
+      is-eta-citizen?       (map-payments (:not-required all-states) set-application-fee-not-required-for-eta-citizen)
       has-existing-payment? (map-payments (:ok-by-proxy all-states) set-application-fee-ok-by-proxy)
       :else                 (map-payments (:awaiting all-states) set-application-fee-required))))
 
@@ -531,16 +543,16 @@
                 exempt-keys            (set (map :key (filter (partial exemption-in-application? job-runner)
                                                               applications)))
                 is-finnish-citizen?    (is-finnish-citizen? person)
-                is-eu-citizen?         (is-vtj-yksiloity-eu-citizen? koodisto-cache person)
+                is-eta-citizen?        (is-exempt-for-nationality? koodisto-cache person)
                 has-existing-payment?  (contains? payment-state-set (:paid all-states))]
             (log/info "Updating application level kk application payment status for person" person-oid "term" term "year" year
                       "is-finnish-citizen?" (boolean is-finnish-citizen?)
-                      "is-eu-citizen?" (boolean is-eu-citizen?)
+                      "is-eta-citizen?" (boolean is-eta-citizen?)
                       "has-existing-payment?" (boolean has-existing-payment?))
             {:person            person
              :existing-payments applications-payments
              :modified-payments (update-payments-for-applications
-                                  applications-payments exempt-keys is-finnish-citizen? is-eu-citizen? has-existing-payment?)}))))))
+                                  applications-payments exempt-keys is-finnish-citizen? is-eta-citizen? has-existing-payment?)}))))))
 
 (defn get-kk-payment-state
   "Returns higher education application fee related info to single application.

--- a/src/clj/ataru/kk_application_payment/kk_application_payment.clj
+++ b/src/clj/ataru/kk_application_payment/kk_application_payment.clj
@@ -1,6 +1,6 @@
 (ns ataru.kk-application-payment.kk-application-payment
   "Logic related to kk application processing payments, AKA hakemusmaksu. The basic spec is that
-   non-exempt non-EU native applicants should be charged an application fee once per semester.
+   non-exempt non-EU/ETA/Swiss native applicants should be charged an application fee once per semester.
    NB! Semester is defined here by the start date of the actual first higher education semester,
    not the application date."
   (:require [ataru.cache.cache-service :as cache]
@@ -14,7 +14,6 @@
             [ataru.person-service.person-service :as person-service]
             [ataru.tarjonta-service.tarjonta-protocol :as tarjonta]
             [ataru.util :as util]
-            [clojure.set :as set]
             [clojure.string :as str]
             [taoensso.timbre :as log]
             [ataru.kk-application-payment.utils :as utils]
@@ -44,7 +43,7 @@
 ; Tilalogiikka lyhyesti:
 ;
 ; 1. "not-required": hakemusmaksua ei vaadita. Tämä tila on ainoa, jonka yhteydessä asetetaan myös "reason"-tieto, ja sellainen tulee olla aina seuraavasti:
-;    - "eu-citizen": hakija on Suomen tai EU:n kansalainen - tarkistetaan automaattisesti ONR:sta, toistaiseksi käytössä ainoastaan suomen kansalaisille
+;    - "eu-citizen": hakija on Suomen, EU:n, ETA:n tai Sveitsin kansalainen
 ;    - "exemption-field": hakemukselta löytyy validi hakemusmaksusta vapautuksen syy, esimerkiksi oleskelulupa tai EU-passi
 ; 2. "awaiting": hakemus odottaa vaadittua hakemusmaksua: maksut-palveluun on luotu maksupyyntö hakemukselle ja "maksut-secret" on asetettu
 ; 3. "ok-by-proxy": hakemusmaksu on maksettu toisen saman aloituskauden hakemuksen yhteydessä
@@ -256,26 +255,21 @@
   [haku]
   (:maksullinen-kk-haku? haku))
 
-(defn- is-exempt-for-nationality?
+(defn- is-eta-equivalent-citizen?
   "Citizens of ETA (European Economic Area) members (including EU members) and countries with
    applicable bilateral agreements (currently only Switzerland) are exempt from the application
    payment. They need to be yksilöity with either VTJ or eIDAS for the nationality to count."
   [koodisto-cache person]
   (let [vahvasti-yksiloity?  (or (:yksiloityVTJ person)
                                  (:yksiloityEidas person))
-        eu-area              (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
-                                 (filter #(= "EU" (:value %)))
+        eta-area             (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
+                                 (filter #(= "ETA" (:value %)))
                                  (first))
-        efta-area            (->> (koodisto/get-koodisto-options koodisto-cache "valtioryhmat" 1 false)
-                                 (filter #(= "EFTA" (:value %))) ; EFTA = ETA Outside EU + Switzerland
-                                 (first))
-        eu-country-codes     (set (map :value (:within eu-area)))
-        efta-country-codes   (set (map :value (:within efta-area)))
-        exempt-country-codes (set/union eu-country-codes efta-country-codes)]
-    (when (<= (count eu-country-codes) 0)
-      (throw (ex-info "Could not fetch country codes for EU area" {:person-oid (:oid person)})))
-    (when (<= (count efta-country-codes) 0)
-      (throw (ex-info "Could not fetch country codes for EFTA area" {:person-oid (:oid person)})))
+        swiss-country-code   "756"
+        eta-country-codes    (set (map :value (:within eta-area)))
+        exempt-country-codes (conj eta-country-codes swiss-country-code)]
+    (when (empty? eta-country-codes)
+      (throw (ex-info "Could not fetch country codes for ETA area" {:person-oid (:oid person)})))
     (and vahvasti-yksiloity?
          (some #(contains? exempt-country-codes (:kansalaisuusKoodi %)) (:kansalaisuus person)))))
 
@@ -499,12 +493,11 @@
        (new-state-fn (:key application) payment)))))
 
 (defn- update-payments-for-applications
-  [applications-payments exempt-keys is-finnish-citizen? is-eta-citizen? has-existing-payment?]
+  [applications-payments exempt-keys is-eta-citizen? has-existing-payment?]
   (let [map-payments (fn [new-state state-change-fn]
                        (doall
                          (remove nil? (map #(set-payment exempt-keys new-state state-change-fn %) applications-payments))))]
     (cond
-      is-finnish-citizen?   (map-payments (:not-required all-states) set-application-fee-not-required-for-eta-citizen)
       is-eta-citizen?       (map-payments (:not-required all-states) set-application-fee-not-required-for-eta-citizen)
       has-existing-payment? (map-payments (:ok-by-proxy all-states) set-application-fee-ok-by-proxy)
       :else                 (map-payments (:awaiting all-states) set-application-fee-required))))
@@ -543,7 +536,7 @@
                 exempt-keys            (set (map :key (filter (partial exemption-in-application? job-runner)
                                                               applications)))
                 is-finnish-citizen?    (is-finnish-citizen? person)
-                is-eta-citizen?        (is-exempt-for-nationality? koodisto-cache person)
+                is-eta-citizen?        (is-eta-equivalent-citizen? koodisto-cache person)
                 has-existing-payment?  (contains? payment-state-set (:paid all-states))]
             (log/info "Updating application level kk application payment status for person" person-oid "term" term "year" year
                       "is-finnish-citizen?" (boolean is-finnish-citizen?)
@@ -552,7 +545,7 @@
             {:person            person
              :existing-payments applications-payments
              :modified-payments (update-payments-for-applications
-                                  applications-payments exempt-keys is-finnish-citizen? is-eta-citizen? has-existing-payment?)}))))))
+                                  applications-payments exempt-keys (or is-finnish-citizen? is-eta-citizen?) has-existing-payment?)}))))))
 
 (defn get-kk-payment-state
   "Returns higher education application fee related info to single application.

--- a/src/clj/ataru/person_service/person_service.clj
+++ b/src/clj/ataru/person_service/person_service.clj
@@ -158,6 +158,11 @@
                        {:kansalaisuus [{:kansalaisuusKoodi "250"}]
                         :yksiloity true
                         :yksiloityVTJ false})
+      "1.2.3.4.5.756" (merge fake-onr-person  ; Swiss
+                       {:kansalaisuus [{:kansalaisuusKoodi "756"}]
+                        :yksiloity true
+                        :yksiloityVTJ false
+                        :yksiloityEidas true})
       "1.2.3.4.5.752" (merge fake-onr-person  ; Swedish
                              {:kansalaisuus [{:kansalaisuusKoodi "752"}]
                               :yksiloity false

--- a/src/clj/ataru/person_service/person_service.clj
+++ b/src/clj/ataru/person_service/person_service.clj
@@ -163,6 +163,11 @@
                         :yksiloity true
                         :yksiloityVTJ false
                         :yksiloityEidas true})
+      "1.2.3.4.5.555" (merge fake-onr-person  ; Swiss
+                       {:kansalaisuus [{:kansalaisuusKoodi "756"}]
+                        :yksiloity true
+                        :yksiloityVTJ false
+                        :yksiloityEidas false})
       "1.2.3.4.5.752" (merge fake-onr-person  ; Swedish
                              {:kansalaisuus [{:kansalaisuusKoodi "752"}]
                               :yksiloity false


### PR DESCRIPTION
Vapautetaan KK-hakemusmaksusta EU-maiden kansalaisten lisäksi ETA-maiden ja Sveitsin kansalaiset.

ETA-maat ja Sveitsi ovat yhtä kuin EU-maat ja EFTA-maat, joten vertailu tehdään näihin valtioryhmiin. Näin ei tarvitse kovakoodata Sveitsiä.