### PR TITLE
OY-5592: Hakulomake: virheilmoitukset henkilötieto-osiossa ja muissa …

### DIFF
--- a/playwright/tests/hakija-ssn.spec.ts
+++ b/playwright/tests/hakija-ssn.spec.ts
@@ -55,6 +55,21 @@ const expectFieldHidden = async (page: Page, id: string) => {
 const invalidFieldStatus = (page: Page) =>
   page.locator('.application__invalid-field-status-title')
 
+const expectErrorDescribedBy = async (
+  page: Page,
+  fieldTestId: string,
+  errorText: string
+) => {
+  const field = page.getByTestId(fieldTestId)
+
+  await expect(field).toHaveAttribute('aria-invalid', 'true')
+  await expect(field).toHaveAttribute('aria-describedby')
+
+  const describedBy = await field.getAttribute('aria-describedby')
+
+  await expect(page.locator(`#${describedBy}`)).toContainText(errorText)
+}
+
 const withInjectedNationalityOptions = (nodes: FormNode[]): FormNode[] => {
   return nodes.map((node) => {
     const next = { ...node }
@@ -228,6 +243,44 @@ test('Hakijan SSN-lomake näyttää oikeat kentät ja voidaan lähettää ilman 
   await expectFieldHidden(page, 'passport-number')
   await expectFieldHidden(page, 'national-id-number')
   await expect(invalidFieldStatus(page)).toHaveText('Tarkista 10 tietoa')
+
+  await fillField(page, page.getByTestId('ssn-input'), '280782-915')
+  await page.getByTestId('phone-input').click()
+  await expectErrorDescribedBy(
+    page,
+    'ssn-input',
+    'Henkilötunnuksen on oltava muodossa PPKKVVvälimerkkiNNNT'
+  )
+
+  await fillField(page, page.getByTestId('email-input'), 'saku@saku.co')
+  await fillField(page, page.getByTestId('verify-email-input'), 'eri@saku.co')
+  await page.getByTestId('phone-input').click()
+  await expectErrorDescribedBy(
+    page,
+    'verify-email-input',
+    'Sähköpostiosoitteet eivät ole samanlaiset'
+  )
+
+  await fillField(page, page.getByTestId('phone-input'), '898')
+  await page.getByTestId('postal-code-input').click()
+  await expectErrorDescribedBy(
+    page,
+    'phone-input',
+    'Matkapuhelinnumero on virheellinen'
+  )
+
+  await fillField(page, page.getByTestId('postal-code-input'), '9999')
+  await page.getByTestId('phone-input').click()
+  await expectErrorDescribedBy(
+    page,
+    'postal-code-input',
+    'Postinumerossa on oltava viisi numeroa'
+  )
+
+  await fillField(page, page.getByTestId('ssn-input'), '010101A123N')
+  await fillField(page, page.getByTestId('verify-email-input'), 'saku@saku.co')
+  await fillField(page, page.getByTestId('phone-input'), '0123456789')
+  await fillField(page, page.getByTestId('postal-code-input'), '40100')
 
   await fillField(page, getFieldById(page, 'first-name'), 'Etunimi Tokanimi')
   await getFieldById(page, 'first-name').press('Tab')

--- a/playwright/tests/hakukohde-a11y.spec.ts
+++ b/playwright/tests/hakukohde-a11y.spec.ts
@@ -16,6 +16,7 @@ let lomakkeenTunnisteet: { lomakkeenAvain: string; lomakkeenId: number }
 
 const TEST_HAKUKOHDE_OID_1 = '1.2.246.562.20.00000000001'
 const TEST_HAKUKOHDE_OID_2 = '1.2.246.562.20.00000000002'
+const TEST_PRIORISOIVA_HAKUKOHDE_RYHMA_OID = '1.2.246.562.28.00000000001'
 
 const testTarjontaHakukohteet = [
   {
@@ -24,7 +25,7 @@ const testTarjontaHakukohteet = [
     'can-be-applied-to?': true,
     hakuaika: { on: true },
     'opetuskieli-koodi-urit': ['oppilaitoksenopetuskieli_1'],
-    hakukohderyhmat: [],
+    hakukohderyhmat: [TEST_PRIORISOIVA_HAKUKOHDE_RYHMA_OID],
   },
   {
     oid: TEST_HAKUKOHDE_OID_2,
@@ -32,7 +33,7 @@ const testTarjontaHakukohteet = [
     'can-be-applied-to?': true,
     hakuaika: { on: true },
     'opetuskieli-koodi-urit': ['oppilaitoksenopetuskieli_1'],
-    hakukohderyhmat: [],
+    hakukohderyhmat: [TEST_PRIORISOIVA_HAKUKOHDE_RYHMA_OID],
   },
 ]
 
@@ -122,7 +123,15 @@ test.beforeAll(async ({ browser }) => {
         tarjonta: {
           ...(json.tarjonta ?? {}),
           hakukohteet: testTarjontaHakukohteet,
+          'prioritize-hakukohteet': true,
         },
+        'priorisoivat-hakukohderyhmat': [
+          {
+            'haku-oid': '1.2.246.562.29.00000000000000000001',
+            'hakukohderyhma-oid': TEST_PRIORISOIVA_HAKUKOHDE_RYHMA_OID,
+            prioriteetit: [[TEST_HAKUKOHDE_OID_2], [TEST_HAKUKOHDE_OID_1]],
+          },
+        ],
         content: contentWithOptions,
       },
     })
@@ -290,6 +299,64 @@ test('Arrow navigation includes selected hakukohde rows in its sequence', async 
       .locator('.application__search-hit-hakukohde-row--select-button')
       .first()
   ).toBeFocused()
+
+  await ensureSearchClosed()
+})
+
+test('Priorization warning is announced from active priority controls', async () => {
+  await openSearch()
+  await fillSearchAndWaitForResults('Te', 2)
+
+  await page
+    .locator('.application__search-hit-hakukohde-row--select-button')
+    .first()
+    .click()
+
+  const firstSelectedRow = page
+    .locator('.application__selected-hakukohde-row')
+    .filter({ hasText: 'Testikoulutus A' })
+  const secondSelectedRow = page
+    .locator('.application__selected-hakukohde-row')
+    .filter({ hasText: 'Testikoulutus B' })
+
+  const firstWarningId = `hakukohde-priorization-warning-${TEST_HAKUKOHDE_OID_1}`
+  const secondWarningId = `hakukohde-priorization-warning-${TEST_HAKUKOHDE_OID_2}`
+
+  for (const [row, warningId] of [
+    [firstSelectedRow, firstWarningId],
+    [secondSelectedRow, secondWarningId],
+  ] as const) {
+    const warning = row.locator(
+      '.application__selected-hakukohde-row--offending-priorization'
+    )
+
+    await expect(warning).toHaveAttribute('id', warningId)
+    await expect(warning).toHaveAttribute('role', 'alert')
+    await expect(warning).toHaveAttribute('aria-live', 'polite')
+    await expect(warning.locator('.zmdi-alert-circle')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+    await expect(warning).toContainText(
+      'Hakukohteet ovat väärässä ensisijaisuusjärjestyksessä'
+    )
+    await expect(warning).toContainText('Testikoulutus B')
+    await expect(warning).toContainText(
+      'tulee olla korkeammalla prioriteetillä kuin'
+    )
+    await expect(warning).toContainText('Testikoulutus A')
+  }
+
+  await expect(
+    firstSelectedRow.locator(
+      '.application__selected-hakukohde-row--priority-decrease'
+    )
+  ).toHaveAttribute('aria-describedby', firstWarningId)
+  await expect(
+    secondSelectedRow.locator(
+      '.application__selected-hakukohde-row--priority-increase'
+    )
+  ).toHaveAttribute('aria-describedby', secondWarningId)
 
   await ensureSearchClosed()
 })

--- a/playwright/tests/hakukohde-a11y.spec.ts
+++ b/playwright/tests/hakukohde-a11y.spec.ts
@@ -78,6 +78,28 @@ const fillSearchAndWaitForResults = async (
   ).toHaveCount(expectedCount)
 }
 
+const ensureTwoHakukohteetSelected = async () => {
+  const selectedRows = page.locator('.application__selected-hakukohde-row')
+  let selectedRowCount = await selectedRows.count()
+
+  if (selectedRowCount === 0) {
+    await page
+      .locator('.application__search-hit-hakukohde-row--select-button')
+      .first()
+      .click()
+    selectedRowCount = 1
+  }
+
+  if (selectedRowCount === 1) {
+    await page
+      .locator('.application__search-hit-hakukohde-row--select-button')
+      .first()
+      .click()
+  }
+
+  await expect(selectedRows).toHaveCount(2)
+}
+
 test.beforeAll(async ({ browser }) => {
   test.setTimeout(120000)
   page = await browser.newPage()
@@ -307,17 +329,11 @@ test('Priorization warning is announced from active priority controls', async ()
   await openSearch()
   await fillSearchAndWaitForResults('Te', 2)
 
-  await page
-    .locator('.application__search-hit-hakukohde-row--select-button')
-    .first()
-    .click()
+  const selectedRows = page.locator('.application__selected-hakukohde-row')
+  await ensureTwoHakukohteetSelected()
 
-  const firstSelectedRow = page
-    .locator('.application__selected-hakukohde-row')
-    .filter({ hasText: 'Testikoulutus A' })
-  const secondSelectedRow = page
-    .locator('.application__selected-hakukohde-row')
-    .filter({ hasText: 'Testikoulutus B' })
+  const firstSelectedRow = selectedRows.nth(0)
+  const secondSelectedRow = selectedRows.nth(1)
 
   const firstWarningId = `hakukohde-priorization-warning-${TEST_HAKUKOHDE_OID_1}`
   const secondWarningId = `hakukohde-priorization-warning-${TEST_HAKUKOHDE_OID_2}`

--- a/src/cljs/ataru/hakija/application_form_components.cljs
+++ b/src/cljs/ataru/hakija/application_form_components.cljs
@@ -61,11 +61,22 @@
 (defn- trimmed-or-empty-value [value]
   (clojure.string/trim (or value "")))
 
+(defn- validation-error-id
+  [form-field-id]
+  (str form-field-id "-validation-error"))
+
+(defn- validation-error-describedby
+  [form-field-id errors]
+  (when (not-empty (filter some? errors))
+    {:aria-describedby (validation-error-id form-field-id)}))
+
+
 (defn- validation-error
-  [errors]
+  [form-field-id errors]
   (let [languages @(subscribe [:application/default-languages])]
     (when (not-empty (filter #(some? %) errors))
       [:div.application__validation-error-dialog-container
+       {:id (validation-error-id form-field-id)}
        (doall
          (map-indexed (fn [idx error]
                         (with-meta (util/non-blank-val error languages)
@@ -149,13 +160,30 @@
                               :on-paste      (fn [event]
                                                  (.preventDefault event))
                               :data-test-id  "email-input"}
+                              (validation-error-describedby
+                               form-field-id
+                              (some-> answer
+                                      :errors
+                                      first
+                                      :email-main-error))
                              (when @(subscribe [:application/cannot-edit? id])
                                    {:disabled true}))]
-                     [validation-error (some-> answer
-                                               :errors
-                                               first
-                                               :email-main-error)]
-                     (let [id           :verify-email
+                     [validation-error form-field-id
+                      (some-> answer
+                              :errors
+                              first
+                              :email-main-error)]
+                     (let [id              :verify-email
+                           verify-error-id "verify-email"
+                           verify-errors   (concat
+                                             (some-> answer
+                                                     :errors
+                                                     first
+                                                     :email-verify-error)
+                                             (some-> answer
+                                                     :errors
+                                                     first
+                                                     :email-has-applied-error))
                            get-verify-value (fn []
                                               (cond cannot-view?
                                                          "***********"
@@ -171,38 +199,34 @@
                              :for id}
                             [:span text-verify [:span.application__form-field-label.application__form-field-label--required (required-hint field-descriptor lang)]]]
                            [:input.application__form-text-input
-                            {:id           id
-                             :type         "text"
-                             :required     true
-                             :on-blur      (fn [_]
-                                             (swap! local-state assoc
-                                                    :focused-verify? false)
-                                             (email-verify-field-change field-descriptor (:value answer)
-                                                                          (trimmed-or-empty-value (get-verify-value))))
+                            (merge {:id           id
+                                    :type         "text"
+                                    :required     true
+                                    :on-blur      (fn [_]
+                                                    (swap! local-state assoc
+                                                           :focused-verify? false)
+                                                    (email-verify-field-change field-descriptor (:value answer)
+                                                                               (trimmed-or-empty-value (get-verify-value))))
 
-                             :on-paste     (fn [event]
-                                               (.preventDefault event))
-                             :on-change    (event->value (fn [value]
-                                                             (swap! local-state assoc
-                                                                    :focused-verify? true
-                                                                    :value-verify value)
-                                                             (email-verify-field-change field-descriptor (:value answer) (get-verify-value))))
-                             :value        (get-verify-value)
-                             :class        (str size-class
-                                                (if show-error?
-                                                    " application__form-field-error"
-                                                    " application__form-text-input--normal"))
-                             :aria-invalid (not (:valid answer))
-                             :autoComplete autocomplete-off
-                             :data-test-id "verify-email-input"}]
-                           [validation-error (some-> answer
-                                                     :errors
-                                                     first
-                                                     :email-verify-error)]
-                           [validation-error (some-> answer
-                                                     :errors
-                                                     first
-                                                     :email-has-applied-error)]])]))))
+                                    :on-paste     (fn [event]
+                                                    (.preventDefault event))
+                                    :on-change    (event->value (fn [value]
+                                                                  (swap! local-state assoc
+                                                                         :focused-verify? true
+                                                                         :value-verify value)
+                                                                  (email-verify-field-change field-descriptor (:value answer) (get-verify-value))))
+                                    :value        (get-verify-value)
+                                    :class        (str size-class
+                                                       (if show-error?
+                                                         " application__form-field-error"
+                                                         " application__form-text-input--normal"))
+                                    :aria-invalid (not (:valid answer))
+                                    :autoComplete autocomplete-off
+                                    :data-test-id "verify-email-input"}
+                                   (validation-error-describedby
+                                     verify-error-id
+                                     verify-errors))]
+                           [validation-error verify-error-id verify-errors]])]))))
 
 (defn- options-satisfying-condition [field-descriptor answer-value options]
   (filter (option-visibility/visibility-checker field-descriptor answer-value) options))
@@ -304,14 +328,21 @@
                                        (:value @local-state)
                                        :else
                                        value)
-                   :data-test-id data-test-id}
+                  :data-test-id data-test-id}
+                 (validation-error-describedby
+                   form-field-id
+                   (some-> errors ;palautuu map jossa validaattorin id on avain ja varsinainen errorsetti arvot
+                           first ;tiedetään että validaattorin palauttamassa mapissa on vain 1 avain
+                           vals ;mapin arvot listana (jonka koko 1)
+                           first))
                   (when (or disabled? cannot-edit? locked)
                     {:disabled true}))]]
 
-         [validation-error (some-> errors ;palautuu map jossa validaattorin id on avain ja varsinainen errorsetti arvot
-                                   first ;tiedetään että validaattorin palauttamassa mapissa on vain 1 avain
-                                   vals ;mapin arvot listana (jonka koko 1)
-                                   first)] ;kaivettava listan sisältä se varsinainen errors-vector
+         [validation-error form-field-id
+          (some-> errors ;palautuu map jossa validaattorin id on avain ja varsinainen errorsetti arvot
+                  first ;tiedetään että validaattorin palauttamassa mapissa on vain 1 avain
+                  vals ;mapin arvot listana (jonka koko 1)
+                  first)] ;kaivettava listan sisältä se varsinainen errors-vector
          (when (not (or (string/blank? value)
                         show-error?))
            [text-field-followups-container field-descriptor options value idx])]))))
@@ -825,9 +856,10 @@
         validator-name validator-keyword]
     (fn []
       (let [{:keys [errors]} @(subscribe [:application/answer id])]
-        [validation-error (some-> errors
-                                  first
-                                  validator-name)]))))
+        [validation-error (name id)
+         (some-> errors
+                 first
+                 validator-name)]))))
 
 (defn adjacent-text-fields [field-descriptor _]
   (let [cannot-edits? (map #(subscribe [:application/cannot-edit? (keyword (:id %))])

--- a/src/cljs/ataru/hakija/application_hakukohde_component.cljs
+++ b/src/cljs/ataru/hakija/application_hakukohde_component.cljs
@@ -44,7 +44,7 @@
      (translations/get-hakija-translation :remove lang)]))
 
 (defn- selected-hakukohde-increase-priority
-  [hakukohde-oid priority-number disabled?]
+  [hakukohde-oid priority-number disabled? describedby]
   (let [increase-disabled? (or disabled? (= priority-number 1))
         lang               @(subscribe [:application/form-language])]
     [:span.application__selected-hakukohde-row--priority-increase
@@ -54,12 +54,13 @@
         :tab-index  0
         :role       "button"
         :aria-label (translations/get-hakija-translation :increase-priority lang)
+        :aria-describedby describedby
         :on-key-up #(when (a11y/is-enter-or-space? %)
                      (dispatch [:application/change-hakukohde-priority hakukohde-oid -1]))
         :on-click   #(dispatch [:application/change-hakukohde-priority hakukohde-oid -1])})]))
 
 (defn- selected-hakukohde-decrease-priority
-  [hakukohde-oid priority-number disabled?]
+  [hakukohde-oid priority-number disabled? describedby]
   (let [selected-hakukohteet @(subscribe [:application/selected-hakukohteet])
         decrease-disabled?   (or disabled? (= priority-number (count selected-hakukohteet)))
         lang                 @(subscribe [:application/form-language])]
@@ -70,22 +71,28 @@
         :tab-index  0
         :role       "button"
         :aria-label (translations/get-hakija-translation :decrease-priority lang)
+        :aria-describedby describedby
         :on-key-up #(when (a11y/is-enter-or-space? %)
                      (dispatch [:application/change-hakukohde-priority hakukohde-oid 1]))
         :on-click   #(dispatch [:application/change-hakukohde-priority hakukohde-oid 1])})]))
 
 (defn- prioritize-hakukohde-buttons
-  [hakukohde-oid disabled?]
+  [hakukohde-oid disabled? describedby]
   (let [priority-number @(subscribe [:application/hakukohde-priority-number hakukohde-oid])]
     [:div.application__selected-hakukohde-row--priority-changer
-     [selected-hakukohde-increase-priority hakukohde-oid priority-number disabled?]
+     [selected-hakukohde-increase-priority hakukohde-oid priority-number disabled? describedby]
      priority-number
-     [selected-hakukohde-decrease-priority hakukohde-oid priority-number disabled?]]))
+     [selected-hakukohde-decrease-priority hakukohde-oid priority-number disabled? describedby]]))
 
-(defn- offending-priorization [should-be-higher should-be-lower]
-  (let [lang @(subscribe [:application/form-language])]
+(defn- offending-priorization [hakukohde-oid should-be-higher should-be-lower]
+  (let [lang @(subscribe [:application/form-language])
+        warning-id (str "hakukohde-priorization-warning-" hakukohde-oid)]
     [:div.application__selected-hakukohde-row--offending-priorization
-     [:i.zmdi.zmdi-alert-circle]
+     {:id warning-id
+      :role "alert"
+      :aria-live "polite"}
+     [:i.zmdi.zmdi-alert-circle
+      {:aria-hidden "true"}]
      [:div
       [:div.application__selected-hakukohde-row--offending-priorization-heading
        (translations/get-hakija-translation :application-priorization-invalid lang)]
@@ -105,11 +112,18 @@
         rajaavat-hakukohteet               @(subscribe [:application/rajaavat-hakukohteet hakukohde-oid])
         lang                               @(subscribe [:application/form-language])
         virkailija?                        @(subscribe [:application/virkailija?])
-        archived?                          @(subscribe [:application/hakukohde-archived? hakukohde-oid])]
+        archived?                          @(subscribe [:application/hakukohde-archived? hakukohde-oid])
+        priorization-warning-id            (str "hakukohde-priorization-warning-" hakukohde-oid)
+        has-priorization-warning?              (or (seq should-be-higher) 
+                                               (seq should-be-lower))]
     [:div.application__selected-hakukohde-row.animated
      {:class (if deleting? "fadeOut" "fadeIn")}
      (when prioritize-hakukohteet?
-       [prioritize-hakukohde-buttons hakukohde-oid (not hakukohde-editable?)])
+       [prioritize-hakukohde-buttons 
+        hakukohde-oid
+        (not hakukohde-editable?)
+        (when has-priorization-warning?
+          priorization-warning-id)])
      [:div.application__selected-hakukohde-row--content
       [:div.application__hakukohde-header
        (when (and virkailija? archived?)
@@ -134,9 +148,15 @@
                    [:li.application__search-hit-hakukohde-row--limitting-hakukohde
                     @(subscribe [:application/hakukohde-label (:oid hakukohde)])]))]])
       (if (seq should-be-higher)
-        (offending-priorization (first should-be-higher) hakukohde-oid)
+        (offending-priorization 
+         hakukohde-oid
+         (first should-be-higher)
+         hakukohde-oid)
         (when (seq should-be-lower)
-          (offending-priorization hakukohde-oid (first should-be-lower))))]
+          (offending-priorization 
+           hakukohde-oid 
+           hakukohde-oid 
+           (first should-be-lower))))]
      [:div.application__selected-hakukohde-row--buttons
       (cond (and haku-editable? hakukohde-editable?)
             [selected-hakukohde-row-remove hakukohde-oid false]


### PR DESCRIPTION
…hakulomakkeen osissa ruudunlukijoille luettaviksi

- Liitetään tekstikenttien validointivirheet kenttiin aria-describedby-attribuutilla
- Lisätään virhe-elementeille yksilölliset id:t ruudunlukijoita varten
- Kerrotaan hakukohteen valinnan rajoitus Lisää-painikkeen saavutettavassa nimessä
- Liitetään priorisointivaroitus aktiivisiin prioriteettinuoliin aria-describedby-attribuutilla
- Lisätään Playwright-testit validointivirheiden, hakukohderajoituksen ja priorisointivaroituksen saavutettavuudelle